### PR TITLE
added a checkstyle and filled it with rules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ application {
 }
 
 checkstyle {
-    config = resources.text.fromFile("src/main/java/com/limechain/config/checkstyle.xml")
+    config = resources.text.fromFile("checkstyle.xml")
 }
 
 group = "com.limechain"

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -34,6 +34,7 @@
                       value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
 
+        <module name="MethodName"/>
         <module name="PackageName">
             <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
             <message key="name.invalidPattern"


### PR DESCRIPTION
Resolves #24

Almost all changes in `build.gradle.kts` are coming from Vik's branch because I branched out from it to test some of the checkstyle rules.

`build gradle` will fail if there are checkstyle validation errors

To test whether real-time validation works do the following:

1. IntelliJ > Preferences > Plugins > CheckStyle-IDEA
2. IntelliJ > Preferences > Tools > Checkstyle
3. Add the configuration with the + sign 
4. Select the newly added configuration and click apply