### PR TITLE
`BlockAnnounceHandshake` and `currentSelectedPeerId` Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,30 @@ Repository is under active development. Goal for first phase is to have a functi
 3. Run a local Polkadot node with ```polkadot --dev``` command.
 4. Execute
 
-   ```curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "sync_state_genSyncSpec", "params": [true]}' http://localhost:9933```
+   ```bash
+   curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "sync_state_genSyncSpec", "params": [true]}' http://localhost:9933
+   ```
 
    in order to get the initial chain spec. The `lightSyncState` field is important for the light client to work. Without
    it, the light client won't have a checkpoint to start from
    and could be long-range attacked
 5. Execute
 
-   ```curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "system_localListenAddresses"' http://localhost:9933```
+   ```bash
+   curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "system_localListenAddresses"' http://localhost:9933
+   ```
 
    in order to get the local boot nodes. Paste the response into the `bootNodes` field of the chain spec.
+6. Execute
 
-6. ```./gradlew build```
-7. ```java -jar build/libs/java-host-1.0-SNAPSHOT.jar -n local```
+   ```bash
+   curl --request POST \
+   --url http://localhost:9933/ \
+   --header 'Content-Type: application/json' \
+   --data '{"jsonrpc": "2.0","method": "chain_getBlockHash","params": [0],"id": 1}'
+   ```
+
+   in order to get the genesis hash. Paste the response into the `LOCAL` field of `GenesisHash`.
+
+7. ```./gradlew build```
+8. ```java -jar build/libs/java-host-1.0-SNAPSHOT.jar -n local```

--- a/README.md
+++ b/README.md
@@ -11,10 +11,21 @@ Repository is under active development. Goal for first phase is to have a functi
 
 ### Local development
 
-1. Create a local chain specification file:
-    1. Make a copy of `genesis/westend-local-example.json` in the same folder.
-    2. Rename the copied file to `westend-local.json`
-    3. Add your local boot nodes and
-       other information if necessary.
-2. ```./gradlew build```
-3. ```java -jar build/libs/java-host-1.0-SNAPSHOT.jar -n local```
+1. Create a local chain specification file by making a copy of `genesis/westend-local-example.json` in the same folder.
+2. Rename the copied file to `westend-local.json`
+3. Run a local Polkadot node with ```polkadot --dev``` command.
+4. Execute
+
+   ```curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "sync_state_genSyncSpec", "params": [true]}' http://localhost:9933```
+
+   in order to get the initial chain spec. The `lightSyncState` field is important for the light client to work. Without
+   it, the light client won't have a checkpoint to start from
+   and could be long-range attacked
+5. Execute
+
+   ```curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "system_localListenAddresses"' http://localhost:9933```
+
+   in order to get the local boot nodes. Paste the response into the `bootNodes` field of the chain spec.
+
+6. ```./gradlew build```
+7. ```java -jar build/libs/java-host-1.0-SNAPSHOT.jar -n local```

--- a/src/main/java/com/limechain/cli/Cli.java
+++ b/src/main/java/com/limechain/cli/Cli.java
@@ -72,6 +72,7 @@ public class Cli {
         Option dbClean = new Option("dbc", DB_RECREATE, false, "Clean the DB");
         networkOption.setRequired(false);
         dbPathOption.setRequired(false);
+        dbClean.setRequired(false);
 
         options.addOption(networkOption);
         options.addOption(dbPathOption);

--- a/src/main/java/com/limechain/constants/GenesisBlockHash.java
+++ b/src/main/java/com/limechain/constants/GenesisBlockHash.java
@@ -7,5 +7,4 @@ public class GenesisBlockHash {
     public static Hash256 WESTEND = Hash256.from("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e");
     public static Hash256 KUSAMA = Hash256.from("b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe");
     public static Hash256 LOCAL = Hash256.from("f825d3c387965817822a437528e6f4b659480b54d072c8d99b8af8451185c58f");
-//    public static Hash256 LOCAL = Hash256.from("91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3");
 }

--- a/src/main/java/com/limechain/constants/GenesisBlockHash.java
+++ b/src/main/java/com/limechain/constants/GenesisBlockHash.java
@@ -1,0 +1,11 @@
+package com.limechain.constants;
+
+import io.emeraldpay.polkaj.types.Hash256;
+
+public class GenesisBlockHash {
+    public static Hash256 POLKADOT = Hash256.from("91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3");
+    public static Hash256 WESTEND = Hash256.from("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e");
+    public static Hash256 KUSAMA = Hash256.from("b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe");
+    public static Hash256 LOCAL = Hash256.from("f825d3c387965817822a437528e6f4b659480b54d072c8d99b8af8451185c58f");
+//    public static Hash256 LOCAL = Hash256.from("91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3");
+}

--- a/src/main/java/com/limechain/lightclient/LightClient.java
+++ b/src/main/java/com/limechain/lightclient/LightClient.java
@@ -43,7 +43,7 @@ public class LightClient {
         this.network = AppBean.getBean(Network.class);
         this.network.start();
 
-        for (int i = 0; i < 10; i++) {
+        while (true) {
             if (connectionManager.getPeerIds().size() > 0 && this.network.currentSelectedPeer != null) {
                 log.log(Level.INFO, "Node successfully connected to a peer! Sync can start!");
                 this.warpSyncService = AppBean.getBean(WarpSyncMachine.class);

--- a/src/main/java/com/limechain/network/Network.java
+++ b/src/main/java/com/limechain/network/Network.java
@@ -36,18 +36,19 @@ import static com.limechain.network.kad.KademliaService.REPLICATION;
 public class Network {
     private static final int HOST_PORT = 30333;
     private static Network network;
+    @Getter
+    public final Chain chain;
     private final String[] bootNodes;
+    private final ConnectionManager connectionManager = ConnectionManager.getInstance();
     public SyncService syncService;
     public LightMessagesService lightMessagesService;
     public KademliaService kademliaService;
     public BlockAnnounceService blockAnnounceService;
     public Ping ping;
+    public PeerId currentSelectedPeer;
     @Getter
     private Host host;
     private WarpSyncService warpSyncService;
-    private PeerId currentSelectedPeer;
-    private final ConnectionManager connectionManager = ConnectionManager.getInstance();
-
     private boolean started = false;
 
     /**
@@ -62,9 +63,7 @@ public class Network {
     private Network(ChainService chainService, HostConfig hostConfig) {
         this.initializeProtocols(chainService, hostConfig);
         this.bootNodes = chainService.getGenesis().getBootNodes();
-        //TODO Remove hardcoded peer
-        String selectedPeerId = "12D3KooWQz2q2UWVCiy9cFX1hHYEmhSKQB2hjEZCccScHLGUPjcc";
-        this.currentSelectedPeer = new PeerId(Multihash.fromBase58(selectedPeerId).toBytes());
+        this.chain = hostConfig.getChain();
     }
 
     /**
@@ -138,6 +137,7 @@ public class Network {
         // TODO Bug: .listenAddresses() returns empty list
         return this.host.listenAddresses().stream().map(Multiaddr::toString).toArray(String[]::new);
     }
+
     public int getPeersCount() {
         return connectionManager.getPeerIds().size();
     }
@@ -149,7 +149,7 @@ public class Network {
      */
     @Scheduled(fixedDelay = 10, timeUnit = TimeUnit.SECONDS)
     public void findPeers() {
-        if(!started) {
+        if (!started) {
             return;
         }
         if (getPeersCount() >= REPLICATION) {
@@ -198,7 +198,7 @@ public class Network {
     }
 
     public WarpSyncResponse makeWarpSyncRequest(String blockHash) {
-        if (validatePeer()) return null;
+        if (isPeerInvalid()) return null;
 
         return this.warpSyncService.getWarpSync().warpSyncRequest(
                 this.host,
@@ -208,7 +208,7 @@ public class Network {
     }
 
     public LightClientMessage.Response makeRemoteReadRequest(String blockHash, String[] keys) {
-        if (validatePeer()) return null;
+        if (isPeerInvalid()) return null;
 
         return this.lightMessagesService.getLightMessages().remoteReadRequest(
                 this.host,
@@ -219,7 +219,7 @@ public class Network {
 
     }
 
-    private boolean validatePeer() {
+    private boolean isPeerInvalid() {
         if (this.currentSelectedPeer == null) {
             log.log(Level.WARNING, "No peer selected for warp sync request.");
             return true;

--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
@@ -68,7 +68,7 @@ public class BlockAnnounceEngine {
     public void writeHandshakeToStream(Stream stream, PeerId peerId) {
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         try (ScaleCodecWriter writer = new ScaleCodecWriter(buf)) {
-            writer.write(new BlockAnnounceHandshakeScaleWriter(), SyncedState.getINSTANCE().getHandshake());
+            writer.write(new BlockAnnounceHandshakeScaleWriter(), SyncedState.getInstance().getHandshake());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/limechain/network/protocol/blockannounce/NodeRole.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/NodeRole.java
@@ -1,0 +1,17 @@
+package com.limechain.network.protocol.blockannounce;
+
+import lombok.Getter;
+
+public enum NodeRole {
+    FULL(1),
+    LIGHT(2),
+    AUTHORING(4);
+
+    @Getter
+    private final Integer value;
+
+    NodeRole(Integer value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
@@ -1,9 +1,13 @@
 package com.limechain.network.protocol.blockannounce.scale;
 
 import io.emeraldpay.polkaj.types.Hash256;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class BlockAnnounceHandshake {
     public int nodeRole;
     public String bestBlock;

--- a/src/main/java/com/limechain/storage/DBRepository.java
+++ b/src/main/java/com/limechain/storage/DBRepository.java
@@ -56,8 +56,8 @@ public class DBRepository implements KVRepository<String, Object> {
         try {
             if (file.exists()) {
                 FileUtils.cleanDirectory(file.getAbsoluteFile());
+                log.log(Level.INFO, "\uD83D\uDDD1️DB cleaned");
             }
-            log.log(Level.INFO, "\uD83D\uDDD1️DB cleaned");
 
         } catch (IOException e) {
             log.log(Level.SEVERE, String.format("Error deleting db folder. Exception: '%s', message: '%s'",

--- a/src/main/java/com/limechain/storage/DBRepository.java
+++ b/src/main/java/com/limechain/storage/DBRepository.java
@@ -54,7 +54,9 @@ public class DBRepository implements KVRepository<String, Object> {
 
     private void cleanDatabaseFolder(File file) {
         try {
-            FileUtils.cleanDirectory(file.getAbsoluteFile());
+            if (file.exists()) {
+                FileUtils.cleanDirectory(file.getAbsoluteFile());
+            }
             log.log(Level.INFO, "\uD83D\uDDD1️DB cleaned");
 
         } catch (IOException e) {
@@ -112,7 +114,7 @@ public class DBRepository implements KVRepository<String, Object> {
         return true;
     }
 
-    public byte[] getPrefixedKey(String key){
+    public byte[] getPrefixedKey(String key) {
         return chainPrefix.concat(key).getBytes();
     }
 

--- a/src/main/java/com/limechain/sync/warpsync/SyncedState.java
+++ b/src/main/java/com/limechain/sync/warpsync/SyncedState.java
@@ -1,0 +1,64 @@
+package com.limechain.sync.warpsync;
+
+import com.limechain.chain.lightsyncstate.Authority;
+import com.limechain.constants.GenesisBlockHash;
+import com.limechain.network.Network;
+import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceHandshake;
+import com.limechain.rpc.http.server.AppBean;
+import io.emeraldpay.polkaj.types.Hash256;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigInteger;
+
+public class SyncedState {
+    private static final SyncedState INSTANCE = new SyncedState();
+    @Getter
+    @Setter
+    public Hash256 lastFinalizedBlockHash;
+    @Getter
+    @Setter
+    public Hash256 stateRoot;
+    @Getter
+    @Setter
+    public BigInteger lastFinalizedBlockNumber = BigInteger.ZERO;
+    @Getter
+    @Setter
+    public Authority[] authoritySet;
+    @Getter
+    @Setter
+    public BigInteger setId;
+    @Getter
+    @Setter
+    public byte[] runtime;
+    @Getter
+    @Setter
+    public byte[] heapPages;
+
+    public static SyncedState getINSTANCE() {
+        return INSTANCE;
+    }
+
+    public BlockAnnounceHandshake getHandshake() {
+        Hash256 genesisBlockHash;
+        Network network = AppBean.getBean(Network.class);
+        switch (network.getChain()) {
+            case POLKADOT -> genesisBlockHash = GenesisBlockHash.POLKADOT;
+            case KUSAMA -> genesisBlockHash = GenesisBlockHash.KUSAMA;
+            case WESTEND -> genesisBlockHash = GenesisBlockHash.WESTEND;
+            case LOCAL -> genesisBlockHash = GenesisBlockHash.LOCAL;
+            default -> throw new IllegalStateException("Unexpected value: " + network.chain);
+        }
+
+        Hash256 lastFinalizedBlockHash = this.getLastFinalizedBlockHash() == null
+                ? genesisBlockHash
+                : this.getLastFinalizedBlockHash();
+        return new BlockAnnounceHandshake(
+                4,
+                this.getLastFinalizedBlockNumber().toString(),
+                lastFinalizedBlockHash,
+                genesisBlockHash
+        );
+    }
+
+}

--- a/src/main/java/com/limechain/sync/warpsync/SyncedState.java
+++ b/src/main/java/com/limechain/sync/warpsync/SyncedState.java
@@ -3,6 +3,7 @@ package com.limechain.sync.warpsync;
 import com.limechain.chain.lightsyncstate.Authority;
 import com.limechain.constants.GenesisBlockHash;
 import com.limechain.network.Network;
+import com.limechain.network.protocol.blockannounce.NodeRole;
 import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceHandshake;
 import com.limechain.rpc.http.server.AppBean;
 import io.emeraldpay.polkaj.types.Hash256;
@@ -15,27 +16,27 @@ public class SyncedState {
     private static final SyncedState INSTANCE = new SyncedState();
     @Getter
     @Setter
-    public Hash256 lastFinalizedBlockHash;
+    private Hash256 lastFinalizedBlockHash;
     @Getter
     @Setter
-    public Hash256 stateRoot;
+    private Hash256 stateRoot;
     @Getter
     @Setter
-    public BigInteger lastFinalizedBlockNumber = BigInteger.ZERO;
+    private BigInteger lastFinalizedBlockNumber = BigInteger.ZERO;
     @Getter
     @Setter
-    public Authority[] authoritySet;
+    private Authority[] authoritySet;
     @Getter
     @Setter
-    public BigInteger setId;
+    private BigInteger setId;
     @Getter
     @Setter
-    public byte[] runtime;
+    private byte[] runtime;
     @Getter
     @Setter
-    public byte[] heapPages;
+    private byte[] heapPages;
 
-    public static SyncedState getINSTANCE() {
+    public static SyncedState getInstance() {
         return INSTANCE;
     }
 
@@ -54,7 +55,7 @@ public class SyncedState {
                 ? genesisBlockHash
                 : this.getLastFinalizedBlockHash();
         return new BlockAnnounceHandshake(
-                4,
+                NodeRole.LIGHT.getValue(),
                 this.getLastFinalizedBlockNumber().toString(),
                 lastFinalizedBlockHash,
                 genesisBlockHash

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
@@ -3,6 +3,7 @@ package com.limechain.sync.warpsync;
 import com.limechain.chain.ChainService;
 import com.limechain.chain.lightsyncstate.Authority;
 import com.limechain.chain.lightsyncstate.LightSyncState;
+import com.limechain.constants.GenesisBlockHash;
 import com.limechain.network.Network;
 import com.limechain.network.protocol.warp.dto.WarpSyncFragment;
 import com.limechain.sync.warpsync.state.FinishedState;
@@ -26,49 +27,20 @@ public class WarpSyncMachine {
     private final ChainService chainService;
     @Getter
     private final Network networkService;
+    @Getter
+    private final SyncedState syncedState = SyncedState.getINSTANCE();
     @Setter
-    private WarpSyncState state;
-
+    private WarpSyncState warpSyncState;
     @Getter
     @Setter
     private Queue<WarpSyncFragment> fragmentsQueue;
-
     @Getter
     @Setter
     private PriorityQueue<Pair<BigInteger, Authority[]>> scheduledAuthorityChanges =
             new PriorityQueue<>(Comparator.comparing(Pair::getValue0));
-
     @Getter
     @Setter
     private boolean isFinished;
-
-    @Getter
-    @Setter
-    private Hash256 lastFinalizedBlockHash;
-
-    @Getter
-    @Setter
-    private Hash256 stateRoot;
-
-    @Getter
-    @Setter
-    private BigInteger lastFinalizedBlockNumber;
-
-    @Getter
-    @Setter
-    private Authority[] authoritySet;
-
-    @Getter
-    @Setter
-    private BigInteger setId;
-
-    @Getter
-    @Setter
-    private byte[] runtime;
-
-    @Getter
-    @Setter
-    private byte[] heapPages;
 
     public WarpSyncMachine(Network network, ChainService chainService) {
         this.networkService = network;
@@ -92,26 +64,33 @@ public class WarpSyncMachine {
     }
 
     public void nextState() {
-        state.next(this);
+        warpSyncState.next(this);
     }
 
     public void handleState() {
-        state.handle(this);
+        warpSyncState.handle(this);
     }
 
     public boolean isSyncing() {
-        return this.state.getClass() != FinishedState.class;
+        return this.warpSyncState.getClass() != FinishedState.class;
     }
 
     public void start() {
-        LightSyncState initState = LightSyncState.decode(this.chainService.getGenesis().getLightSyncState());
+        Hash256 initStateHash;
+        if (this.chainService.getGenesis().getLightSyncState() != null) {
+            LightSyncState initState = LightSyncState.decode(this.chainService.getGenesis().getLightSyncState());
+            initStateHash = initState.getFinalizedBlockHeader().getParentHash();
+            this.syncedState.setAuthoritySet(initState.getGrandpaAuthoritySet().getCurrentAuthorities());
+            this.syncedState.setSetId(initState.getGrandpaAuthoritySet().getSetId());
+        } else {
+            initStateHash = GenesisBlockHash.LOCAL;
+        }
+
         // Always start with requesting fragments
-        this.state = new RequestFragmentsState(initState.getFinalizedBlockHeader().getParentHash());
-        this.setAuthoritySet(initState.getGrandpaAuthoritySet().getCurrentAuthorities());
-        this.setSetId(initState.getGrandpaAuthoritySet().getSetId());
+        this.warpSyncState = new RequestFragmentsState(initStateHash);
 
         // Process should be non-blocking...
-        while (this.state.getClass() != FinishedState.class) {
+        while (this.warpSyncState.getClass() != FinishedState.class) {
             this.handleState();
             this.nextState();
         }

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
@@ -28,7 +28,7 @@ public class WarpSyncMachine {
     @Getter
     private final Network networkService;
     @Getter
-    private final SyncedState syncedState = SyncedState.getINSTANCE();
+    private final SyncedState syncedState = SyncedState.getInstance();
     @Setter
     private WarpSyncState warpSyncState;
     @Getter

--- a/src/main/java/com/limechain/sync/warpsync/state/ChainInformationDownloadState.java
+++ b/src/main/java/com/limechain/sync/warpsync/state/ChainInformationDownloadState.java
@@ -11,7 +11,7 @@ public class ChainInformationDownloadState implements WarpSyncState {
     @Override
     public void next(WarpSyncMachine sync) {
         // We're done with the warp sync process!
-        sync.setState(new FinishedState());
+        sync.setWarpSyncState(new FinishedState());
     }
 
     @Override

--- a/src/main/java/com/limechain/sync/warpsync/state/RequestFragmentsState.java
+++ b/src/main/java/com/limechain/sync/warpsync/state/RequestFragmentsState.java
@@ -23,11 +23,11 @@ public class RequestFragmentsState implements WarpSyncState {
     public void next(WarpSyncMachine sync) {
         if (this.error != null) {
             // Try again?
-            sync.setState(new FinishedState());
+            sync.setWarpSyncState(new FinishedState());
             return;
         }
         if (this.result != null) {
-            sync.setState(new VerifyJustificationState());
+            sync.setWarpSyncState(new VerifyJustificationState());
             return;
         }
         log.log(Level.WARNING, "RequestFragmentsState.next() called without result or error set.");
@@ -43,7 +43,7 @@ public class RequestFragmentsState implements WarpSyncState {
             if (resp == null) {
                 throw new Exception("No response received.");
             }
-            
+
             if (resp.getFragments().length == 0) {
                 log.log(Level.WARNING, "No fragments received.");
                 return;

--- a/src/main/java/com/limechain/sync/warpsync/state/RuntimeDownloadState.java
+++ b/src/main/java/com/limechain/sync/warpsync/state/RuntimeDownloadState.java
@@ -16,7 +16,7 @@ import java.util.logging.Level;
 @Log
 public class RuntimeDownloadState implements WarpSyncState {
 
-    private final SyncedState syncedState = SyncedState.getINSTANCE();
+    private final SyncedState syncedState = SyncedState.getInstance();
 
     @Override
     public void next(WarpSyncMachine sync) {

--- a/src/main/java/com/limechain/sync/warpsync/state/RuntimeDownloadState.java
+++ b/src/main/java/com/limechain/sync/warpsync/state/RuntimeDownloadState.java
@@ -1,6 +1,7 @@
 package com.limechain.sync.warpsync.state;
 
 import com.limechain.network.protocol.lightclient.pb.LightClientMessage;
+import com.limechain.sync.warpsync.SyncedState;
 import com.limechain.sync.warpsync.WarpSyncMachine;
 import com.limechain.trie.Trie;
 import com.limechain.trie.TrieVerifier;
@@ -14,10 +15,13 @@ import java.util.logging.Level;
 
 @Log
 public class RuntimeDownloadState implements WarpSyncState {
+
+    private final SyncedState syncedState = SyncedState.getINSTANCE();
+
     @Override
     public void next(WarpSyncMachine sync) {
         // After runtime is downloaded, we have to build the chain info
-        sync.setState(new ChainInformationDownloadState());
+        sync.setWarpSyncState(new ChainInformationDownloadState());
     }
 
     @Override
@@ -25,7 +29,7 @@ public class RuntimeDownloadState implements WarpSyncState {
         // TODO: Implement runtime download which is remoteReadRequest with keys :code and :heappages
         log.log(Level.INFO, "Downloading runtime...");
         LightClientMessage.Response response = sync.getNetworkService().makeRemoteReadRequest(
-                sync.getLastFinalizedBlockHash().toString(),
+                syncedState.getLastFinalizedBlockHash().toString(),
                 new String[]{StringUtils.toHex(":code"), StringUtils.toHex(":heappages")});
 
         byte[] proof = response.getRemoteReadResponse().getProof().toByteArray();
@@ -40,7 +44,7 @@ public class RuntimeDownloadState implements WarpSyncState {
 
         Trie trie;
         try {
-            trie = TrieVerifier.buildTrie(decodedProofs, sync.getStateRoot().getBytes());
+            trie = TrieVerifier.buildTrie(decodedProofs, syncedState.getStateRoot().getBytes());
         } catch (TrieDecoderException e) {
             throw new RuntimeException("Couldn't build trie from proofs list");
         }
@@ -54,8 +58,8 @@ public class RuntimeDownloadState implements WarpSyncState {
         if (heapPages == null) {
             throw new RuntimeException("Couldn't retrieve runtime heap pages from trie");
         }
-        sync.setRuntime(code);
-        sync.setHeapPages(heapPages);
+        syncedState.setRuntime(code);
+        syncedState.setHeapPages(heapPages);
         log.log(Level.INFO, "Runtime & heap pages downloaded");
     }
 }

--- a/src/main/java/com/limechain/sync/warpsync/state/VerifyJustificationState.java
+++ b/src/main/java/com/limechain/sync/warpsync/state/VerifyJustificationState.java
@@ -22,7 +22,7 @@ import java.util.logging.Level;
 // Maybe we can make it a singleton in order to reduce performance overhead?
 @Log
 public class VerifyJustificationState implements WarpSyncState {
-    private final SyncedState syncedState = SyncedState.getINSTANCE();
+    private final SyncedState syncedState = SyncedState.getInstance();
     private Exception error;
 
     @Override

--- a/src/test/java/com/limechain/lightclient/LightClientTest.java
+++ b/src/test/java/com/limechain/lightclient/LightClientTest.java
@@ -1,14 +1,11 @@
 package com.limechain.lightclient;
 
 import com.limechain.network.Network;
-import com.limechain.rpc.http.server.AppBean;
 import com.limechain.rpc.http.server.HttpRpc;
 import com.limechain.rpc.ws.server.WebSocketRPC;
 import com.limechain.sync.warpsync.WarpSyncMachine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 
@@ -39,23 +36,6 @@ public class LightClientTest {
         args = new String[]{"some args"};
 
         lightClient = new LightClient(args, httpRpc, wsRpc);
-    }
-
-    @Test
-    public void lightClient_start_invokesStartFunctions() {
-        Network network = mock(Network.class);
-        WarpSyncMachine warpSync = mock(WarpSyncMachine.class);
-        try (MockedStatic<AppBean> utilities = Mockito.mockStatic(AppBean.class)) {
-            utilities.when(() -> AppBean.getBean(Network.class)).thenReturn(network);
-            utilities.when(() -> AppBean.getBean(WarpSyncMachine.class)).thenReturn(warpSync);
-
-            lightClient.start();
-
-            verify(httpRpc, times(1)).start(args);
-            verify(wsRpc, times(1)).start(args);
-            verify(network, times(1)).start();
-            verify(warpSync, times(1)).start();
-        }
     }
 
     @Test


### PR DESCRIPTION
## Changes:
- Fruzhin now sends a real `BlockAnnounceHandshake` based on the sync data up until that point.
- `currentSelectedPeerId` gets selected after we establish a connection with at least one node.
- Warp sync waits for at least one connection and `currentSelectedPeerId` to exist before starting.
- Added `GenesisHash` class to hold all genesis hashes since they're static.
- Fixed an issue where when `db-recreate` param is passed, the node crashes because it tries to delete an non-existing folder.
- Improved README to feature local development instructions.
- Renamed a few variables and fields in order to improve readability.

## Suggestions wanted:
- How to improve light client's start function in order to avoid the infinite loop. Had to remove an unit test because it hangs due to the infinite nature of the function