### PR TITLE
Unify all unsigned integers to be of type BigInteger

### DIFF
--- a/src/main/java/com/limechain/network/ConnectionManager.java
+++ b/src/main/java/com/limechain/network/ConnectionManager.java
@@ -48,7 +48,7 @@ public class ConnectionManager {
     }
 
     private void updateBestBlock(PeerInfo peerInfo, BlockHeader blockHeader) {
-        peerInfo.setBestBlock(blockHeader.getBlockNumber().toString());
+        peerInfo.setBestBlock(blockHeader.getBlockNumber());
         peerInfo.setBestBlockHash(new Hash256(blockHeader.getHash()));
     }
 

--- a/src/main/java/com/limechain/network/PeerInfo.java
+++ b/src/main/java/com/limechain/network/PeerInfo.java
@@ -5,11 +5,13 @@ import io.emeraldpay.polkaj.types.Hash256;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigInteger;
+
 @Data
 @NoArgsConstructor
 public class PeerInfo {
     private int nodeRole;
-    private String bestBlock;
+    private BigInteger bestBlock;
     private Hash256 bestBlockHash;
     private Hash256 genesisBlockHash;
     private int latestBlock;

--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounce.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounce.java
@@ -1,7 +1,6 @@
 package com.limechain.network.protocol.blockannounce;
 
 import com.limechain.network.StrictProtocolBinding;
-import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceHandshake;
 import io.libp2p.core.AddressBook;
 import io.libp2p.core.Host;
 import io.libp2p.core.PeerId;
@@ -15,9 +14,9 @@ public class BlockAnnounce extends StrictProtocolBinding<BlockAnnounceController
         super(protocolId, protocol);
     }
 
-    public void sendHandshake(Host us, AddressBook addrs, PeerId peer, BlockAnnounceHandshake handshake) {
+    public void sendHandshake(Host us, AddressBook addrs, PeerId peer) {
         BlockAnnounceController controller = dialPeer(us, peer, addrs);
-        controller.sendHandshake(handshake);
+        controller.sendHandshake();
         log.log(Level.INFO, "Sent block announce handshake");
     }
 }

--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceController.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceController.java
@@ -1,7 +1,5 @@
 package com.limechain.network.protocol.blockannounce;
 
-import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceHandshake;
-
 public interface BlockAnnounceController {
-    void sendHandshake(BlockAnnounceHandshake req);
+    void sendHandshake();
 }

--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceProtocol.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceProtocol.java
@@ -2,7 +2,6 @@ package com.limechain.network.protocol.blockannounce;
 
 import com.limechain.network.encoding.Leb128LengthFrameDecoder;
 import com.limechain.network.encoding.Leb128LengthFrameEncoder;
-import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceHandshake;
 import io.libp2p.core.Stream;
 import io.libp2p.protocol.ProtocolHandler;
 import io.libp2p.protocol.ProtocolMessageHandler;
@@ -77,7 +76,7 @@ public class BlockAnnounceProtocol extends ProtocolHandler<BlockAnnounceControll
         }
 
         @Override
-        public void sendHandshake(BlockAnnounceHandshake req) {
+        public void sendHandshake() {
             engine.writeHandshakeToStream(stream, stream.remotePeerId());
         }
     }

--- a/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
@@ -15,4 +15,14 @@ public class BlockAnnounceHandshake {
     private BigInteger bestBlock;
     private Hash256 bestBlockHash;
     private Hash256 genesisBlockHash;
+
+    @Override
+    public String toString() {
+        return "BlockAnnounceHandShake{" +
+                "nodeRole=" + nodeRole +
+                ", bestBlock='" + bestBlock + '\'' +
+                ", bestBlockHash=" + bestBlockHash +
+                ", genesisBlockHash=" + genesisBlockHash +
+                '}';
+    }
 }

--- a/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
@@ -2,16 +2,14 @@ package com.limechain.network.protocol.blockannounce.scale;
 
 import io.emeraldpay.polkaj.types.Hash256;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.math.BigInteger;
 
-@Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Data
 public class BlockAnnounceHandshake {
     private int nodeRole;
     private BigInteger bestBlock;

--- a/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
@@ -15,14 +15,4 @@ public class BlockAnnounceHandshake {
     private BigInteger bestBlock;
     private Hash256 bestBlockHash;
     private Hash256 genesisBlockHash;
-
-    @Override
-    public String toString() {
-        return "BlockAnnounceHandShake{" +
-                "nodeRole=" + nodeRole +
-                ", bestBlock='" + bestBlock + '\'' +
-                ", bestBlockHash=" + bestBlockHash +
-                ", genesisBlockHash=" + genesisBlockHash +
-                '}';
-    }
 }

--- a/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshake.java
@@ -4,15 +4,19 @@ import io.emeraldpay.polkaj.types.Hash256;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigInteger;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class BlockAnnounceHandshake {
-    public int nodeRole;
-    public String bestBlock;
-    public Hash256 bestBlockHash;
-    public Hash256 genesisBlockHash;
+    private int nodeRole;
+    private BigInteger bestBlock;
+    private Hash256 bestBlockHash;
+    private Hash256 genesisBlockHash;
 
     @Override
     public String toString() {

--- a/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshakeScaleReader.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshakeScaleReader.java
@@ -4,14 +4,16 @@ import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleReader;
 import io.emeraldpay.polkaj.types.Hash256;
 
+import java.math.BigInteger;
+
 public class BlockAnnounceHandshakeScaleReader implements ScaleReader<BlockAnnounceHandshake> {
     @Override
     public BlockAnnounceHandshake read(ScaleCodecReader reader) {
         BlockAnnounceHandshake handshake = new BlockAnnounceHandshake();
-        handshake.nodeRole = reader.readByte();
-        handshake.bestBlock = Long.toString(reader.readUint32());
-        handshake.bestBlockHash = new Hash256(reader.readUint256());
-        handshake.genesisBlockHash = new Hash256(reader.readUint256());
+        handshake.setNodeRole(reader.readByte());
+        handshake.setBestBlock(BigInteger.valueOf(reader.readUint32()));
+        handshake.setBestBlockHash(new Hash256(reader.readUint256()));
+        handshake.setGenesisBlockHash(new Hash256(reader.readUint256()));
         return handshake;
     }
 }

--- a/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshakeScaleWriter.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshakeScaleWriter.java
@@ -8,9 +8,9 @@ import java.io.IOException;
 public class BlockAnnounceHandshakeScaleWriter implements ScaleWriter<BlockAnnounceHandshake> {
     @Override
     public void write(ScaleCodecWriter writer, BlockAnnounceHandshake handshake) throws IOException {
-        writer.writeByte(handshake.nodeRole);
-        writer.writeUint32(Long.parseLong(handshake.bestBlock));
-        writer.writeUint256(handshake.bestBlockHash.getBytes());
-        writer.writeUint256(handshake.genesisBlockHash.getBytes());
+        writer.writeByte(handshake.getNodeRole());
+        writer.writeUint32(handshake.getBestBlock().longValue());
+        writer.writeUint256(handshake.getBestBlockHash().getBytes());
+        writer.writeUint256(handshake.getGenesisBlockHash().getBytes());
     }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -102,7 +102,7 @@ public class GrandpaEngine {
 
     public void writeHandshakeToStream(Stream stream, PeerId peerId) {
         byte[] handshake = new byte[] {
-                (byte) syncedState.getHandshake().nodeRole
+                (byte) syncedState.getHandshake().getNodeRole()
         };
 
         log.log(Level.INFO, "Sending grandpa handshake to " + peerId);

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessage.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessage.java
@@ -13,5 +13,5 @@ public class NeighbourMessage {
     private int version;
     private BigInteger round;
     private BigInteger setId;
-    private long lastFinalizedBlock;
+    private BigInteger lastFinalizedBlock;
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessageScaleReader.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessageScaleReader.java
@@ -5,6 +5,8 @@ import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleReader;
 import io.emeraldpay.polkaj.scale.reader.UInt64Reader;
 
+import java.math.BigInteger;
+
 public class NeighbourMessageScaleReader implements ScaleReader<NeighbourMessage> {
     @Override
     public NeighbourMessage read(ScaleCodecReader reader) {
@@ -17,7 +19,7 @@ public class NeighbourMessageScaleReader implements ScaleReader<NeighbourMessage
         neighbourMessage.setVersion(reader.readByte());
         neighbourMessage.setRound(new UInt64Reader().read(reader));
         neighbourMessage.setSetId(new UInt64Reader().read(reader));
-        neighbourMessage.setLastFinalizedBlock(reader.readUint32());
+        neighbourMessage.setLastFinalizedBlock(BigInteger.valueOf(reader.readUint32()));
         return neighbourMessage;
     }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessageScaleWriter.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessageScaleWriter.java
@@ -15,6 +15,6 @@ public class NeighbourMessageScaleWriter implements ScaleWriter<NeighbourMessage
         writer.writeByte(neighbourMessage.getVersion());
         new UInt64Writer().write(writer, neighbourMessage.getRound());
         new UInt64Writer().write(writer, neighbourMessage.getSetId());
-        writer.writeUint32(neighbourMessage.getLastFinalizedBlock());
+        writer.writeUint32(neighbourMessage.getLastFinalizedBlock().longValue());
     }
 }

--- a/src/main/java/com/limechain/sync/warpsync/SyncedState.java
+++ b/src/main/java/com/limechain/sync/warpsync/SyncedState.java
@@ -85,7 +85,7 @@ public class SyncedState {
                 : this.getLastFinalizedBlockHash();
         return new BlockAnnounceHandshake(
                 NodeRole.LIGHT.getValue(),
-                this.getLastFinalizedBlockNumber().toString(),
+                this.getLastFinalizedBlockNumber(),
                 lastFinalizedBlockHash,
                 genesisBlockHash
         );
@@ -96,7 +96,7 @@ public class SyncedState {
                 NEIGHBOUR_MESSAGE_VERSION,
                 this.latestRound,
                 this.setId,
-                this.lastFinalizedBlockNumber.longValue()
+                this.lastFinalizedBlockNumber
         );
     }
 

--- a/src/main/java/com/limechain/sync/warpsync/scale/RuntimeVersionReader.java
+++ b/src/main/java/com/limechain/sync/warpsync/scale/RuntimeVersionReader.java
@@ -19,10 +19,10 @@ public class RuntimeVersionReader implements ScaleReader<RuntimeVersion> {
         // Probably only reads a 0 byte since the runtime apis have been moved to a different custom sections
         int apiVersionsSize = reader.readCompactInt();
         byte[][] apiVersions = new byte[apiVersionsSize][];
-        long[] apiVersionsNumbers = new long[apiVersionsSize];
+        BigInteger[] apiVersionsNumbers = new BigInteger[apiVersionsSize];
         for (int i = 0; i < apiVersionsSize; i++) {
             apiVersions[i] = reader.readByteArray(8);
-            apiVersionsNumbers[i] = reader.readUint32();
+            apiVersionsNumbers[i] = BigInteger.valueOf(reader.readUint32());
         }
 
         runtimeVersion.setTransactionVersion(BigInteger.valueOf(reader.readUint32()));

--- a/src/test/java/com/limechain/network/ConnectionManagerTest.java
+++ b/src/test/java/com/limechain/network/ConnectionManagerTest.java
@@ -68,7 +68,7 @@ class ConnectionManagerTest {
 
         connectionManager.updatePeer(peerId, message);
 
-        verify(peerInfo).setBestBlock("10");
+        verify(peerInfo).setBestBlock(BigInteger.TEN);
         verify(peerInfo).setBestBlockHash(new Hash256(hash));
     }
 

--- a/src/test/java/com/limechain/network/protocol/blockannounce/BlockAnnounceTest.java
+++ b/src/test/java/com/limechain/network/protocol/blockannounce/BlockAnnounceTest.java
@@ -12,13 +12,14 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.peergos.HostBuilder;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Random;
 
-public class BlockAnnounceTest {
+class BlockAnnounceTest {
     @Disabled("This is an integration test")
     @Test
-    public void receivesNotifications() {
+    void receivesNotifications() {
         Host senderNode = null;
         try {
             HostBuilder hostBuilder1 =
@@ -46,11 +47,11 @@ public class BlockAnnounceTest {
             kademliaService.connectBootNodes(receivers);
 
             var handshake = new BlockAnnounceHandshake() {{
-                nodeRole = 4;
-                bestBlockHash = Hash256.from("0x7b22fc4469863c9671686c189a3238708033d364a77ba8d83e78777e7563f346");
-                bestBlock = "0";
-                genesisBlockHash = Hash256.from(
-                        "0x7b22fc4469863c9671686c189a3238708033d364a77ba8d83e78777e7563f346");
+                setNodeRole(4);
+                setBestBlockHash(Hash256.from("0x7b22fc4469863c9671686c189a3238708033d364a77ba8d83e78777e7563f346"));
+                setBestBlock(BigInteger.ZERO);
+                setGenesisBlockHash(Hash256.from(
+                        "0x7b22fc4469863c9671686c189a3238708033d364a77ba8d83e78777e7563f346"));
             }};
 
             Multiaddr[] addr = senderNode.getAddressBook().get(peerId)

--- a/src/test/java/com/limechain/network/protocol/blockannounce/BlockAnnounceTest.java
+++ b/src/test/java/com/limechain/network/protocol/blockannounce/BlockAnnounceTest.java
@@ -63,7 +63,7 @@ class BlockAnnounceTest {
             if (addr.length == 0)
                 throw new IllegalStateException("No addresses known for peer " + peerId);
 
-            blockAnnounce.sendHandshake(senderNode, senderNode.getAddressBook(), peerId, handshake);
+            blockAnnounce.sendHandshake(senderNode, senderNode.getAddressBook(), peerId);
 
             Thread.sleep(60000);
         } catch (

--- a/src/test/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshakeScaleReaderTest.java
+++ b/src/test/java/com/limechain/network/protocol/blockannounce/scale/BlockAnnounceHandshakeScaleReaderTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,7 +27,7 @@ class BlockAnnounceHandshakeScaleReaderTest {
         BlockAnnounceHandshake decoded = reader.read(new BlockAnnounceHandshakeScaleReader());
 
         assertEquals(4, decoded.getNodeRole());
-        assertEquals("77", decoded.getBestBlock());
+        assertEquals(BigInteger.valueOf(77), decoded.getBestBlock());
         assertEquals("0x0100000000000000000000000000000000000000000000000000000000000000",
                 decoded.getBestBlockHash().toString());
         assertEquals("0x0200000000000000000000000000000000000000000000000000000000000000",
@@ -34,18 +35,18 @@ class BlockAnnounceHandshakeScaleReaderTest {
     }
 
     @Test
-    public void EncodeAnnouncementHandshakeTest() {
+    void EncodeAnnouncementHandshakeTest() {
         //CHECKSTYLE.OFF
         byte[] expected = ByteString.fromHex("044d00000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000").toByteArray();
         //CHECKSTYLE.ON
 
         BlockAnnounceHandshake dataToEncode = new BlockAnnounceHandshake();
-        dataToEncode.nodeRole = 4;
-        dataToEncode.bestBlock = "77";
-        dataToEncode.bestBlockHash = Hash256.from(
-                "0x0100000000000000000000000000000000000000000000000000000000000000");
-        dataToEncode.genesisBlockHash = Hash256.from(
-                "0x0200000000000000000000000000000000000000000000000000000000000000");
+        dataToEncode.setNodeRole(4);
+        dataToEncode.setBestBlock(BigInteger.valueOf(77));
+        dataToEncode.setBestBlockHash(Hash256.from(
+                "0x0100000000000000000000000000000000000000000000000000000000000000"));
+        dataToEncode.setGenesisBlockHash(Hash256.from(
+                "0x0200000000000000000000000000000000000000000000000000000000000000"));
 
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         try (ScaleCodecWriter writer = new ScaleCodecWriter(buf)) {


### PR DESCRIPTION
* change long values to BigInteger for uint32 readers

* change BlockAnnounceHandshake fields to private and user proper getters and setters

Closes #85 