### PR TITLE
Increase GRANDPA traffic limit and synchronize update state

### DIFF
--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -30,6 +30,11 @@ public class GrandpaEngine {
         boolean connectedToPeer = connectionManager.isGrandpaConnected(peerId);
         GrandpaMessageType messageType = getGrandpaMessageType(msg);
 
+        if (messageType == null) {
+            log.log(Level.WARNING, String.format("Unknown grandpa message type \"%d\" from Peer %s", msg[0], peerId));
+            return;
+        }
+
         if (!connectedToPeer && messageType != GrandpaMessageType.HANDSHAKE) {
             log.log(Level.WARNING, "No handshake for grandpa message from Peer " + peerId);
             return;
@@ -42,8 +47,6 @@ public class GrandpaEngine {
             case NEIGHBOUR -> handleNeighbourMessage(msg, peerId);
             case CATCH_UP_REQUEST -> log.log(Level.INFO, "Catch up request received from Peer " + peerId);
             case CATCH_UP_RESPONSE -> log.log(Level.INFO, "Catch up response received from Peer " + peerId);
-            default -> log.log(Level.WARNING,
-                    String.format("Unknown grandpa message type \"%d\" from Peer %s", msg[0], peerId));
         }
     }
 
@@ -87,7 +90,7 @@ public class GrandpaEngine {
         ScaleCodecReader reader = new ScaleCodecReader(msg);
         CommitMessage commitMessage = reader.read(new CommitMessageScaleReader());
         if (isBlockAlreadyReached(commitMessage.getVote().getBlockNumber())) {
-            log.log(Level.INFO, String.format("Received commit message for already reached block %d from peer %s",
+            log.log(Level.INFO, String.format("Received commit message for finalized block %d from peer %s",
                             commitMessage.getVote().getBlockNumber(), peerId));
             return;
         }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -90,7 +90,7 @@ public class GrandpaEngine {
         ScaleCodecReader reader = new ScaleCodecReader(msg);
         CommitMessage commitMessage = reader.read(new CommitMessageScaleReader());
         if (isBlockAlreadyReached(commitMessage.getVote().getBlockNumber())) {
-            log.log(Level.INFO, String.format("Received commit message for finalized block %d from peer %s",
+            log.log(Level.FINE, String.format("Received commit message for finalized block %d from peer %s",
                             commitMessage.getVote().getBlockNumber(), peerId));
             return;
         }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaProtocol.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaProtocol.java
@@ -11,10 +11,11 @@ import lombok.extern.java.Log;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 @Log
 public class GrandpaProtocol extends ProtocolHandler<GrandpaController> {
-    public static final int TRAFFIC_LIMIT = 1024 * 1024;
+    private static final long TRAFFIC_LIMIT = Long.MAX_VALUE;
     private final GrandpaEngine engine;
 
     public GrandpaProtocol() {

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaProtocol.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaProtocol.java
@@ -63,6 +63,23 @@ public class GrandpaProtocol extends ProtocolHandler<GrandpaController> {
         }
 
         @Override
+        public void onClosed(Stream stream) {
+            log.log(Level.INFO, "Grandpa stream closed for peer " + stream.remotePeerId());
+            ProtocolMessageHandler.super.onClosed(stream);
+        }
+
+        @Override
+        public void onException(Throwable cause) {
+            if (cause != null) {
+                log.log(Level.WARNING, "Grandpa Exception: " + cause.getMessage());
+                cause.printStackTrace();
+            } else {
+                log.log(Level.WARNING, "Grandpa Exception with unknown cause");
+            }
+            ProtocolMessageHandler.super.onException(cause);
+        }
+
+        @Override
         public void sendHandshake() {
             engine.writeHandshakeToStream(stream, stream.remotePeerId());
         }

--- a/src/main/java/com/limechain/sync/warpsync/SyncedState.java
+++ b/src/main/java/com/limechain/sync/warpsync/SyncedState.java
@@ -112,7 +112,10 @@ public class SyncedState {
         }
     }
 
-    private void updateState(CommitMessage commitMessage) {
+    private synchronized void updateState(CommitMessage commitMessage) {
+        if (commitMessage.getVote().getBlockNumber().compareTo(lastFinalizedBlockNumber) < 1) {
+            return;
+        }
         latestRound = commitMessage.getRoundNumber();
         lastFinalizedBlockHash = commitMessage.getVote().getBlockHash();
         lastFinalizedBlockNumber = commitMessage.getVote().getBlockNumber();


### PR DESCRIPTION
Increase GRANDPA traffic limit to Long.MAX_VALUE, make updateState, used when receiving commit messages, synchronized and handle receiveMessage NPE.