### PR TITLE
Enable System RPC method family to be handled by WS

### DIFF
--- a/src/main/java/com/limechain/rpc/server/SimpleInputBuffer.java
+++ b/src/main/java/com/limechain/rpc/server/SimpleInputBuffer.java
@@ -1,0 +1,36 @@
+package com.limechain.rpc.server;
+
+import lombok.extern.java.Log;
+import org.apache.coyote.InputBuffer;
+import org.apache.tomcat.util.net.ApplicationBufferHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.logging.Level;
+
+@Log
+class SimpleInputBuffer implements InputBuffer {
+    private final InputStream messageStream;
+
+    public SimpleInputBuffer(InputStream messageStream) {
+        this.messageStream = messageStream;
+    }
+
+    @Override
+    public int doRead(ApplicationBufferHandler handler) throws IOException {
+        var size = messageStream.readAllBytes();
+        handler.setByteBuffer(ByteBuffer.wrap(size));
+        return size.length;
+    }
+
+    @Override
+    public int available() {
+        try {
+            return messageStream.available();
+        } catch (IOException e) {
+            log.log(Level.SEVERE, "Error while checking available bytes", e);
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
As per Polkadot requirements, RPC functions can be handled by either WS or HTTP. Jsonrpc4j works only with HTTP requests so WS didn't work. In order to fix that, WS request payload has to be "disguised" as a HTTP request. Not the cleanest solution, in the future it can be improved with extensions to jsonrpc4j