### PR TITLE
Extract some reused SCALE en/decoding logic into `utils`

### DIFF
--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
@@ -8,7 +8,7 @@ import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceMessage;
 import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceMessageScaleReader;
 import com.limechain.network.protocol.warp.dto.Block;
 import com.limechain.network.protocol.warp.dto.BlockBody;
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.storage.block.BlockState;
 import com.limechain.sync.warpsync.SyncedState;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -13,7 +13,7 @@ import com.limechain.network.protocol.grandpa.messages.neighbour.NeighbourMessag
 import com.limechain.network.protocol.grandpa.messages.neighbour.NeighbourMessageScaleWriter;
 import com.limechain.network.protocol.grandpa.messages.vote.VoteMessage;
 import com.limechain.network.protocol.grandpa.messages.vote.VoteMessageScaleReader;
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.sync.warpsync.SyncedState;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;

--- a/src/main/java/com/limechain/network/protocol/transactions/TransactionsEngine.java
+++ b/src/main/java/com/limechain/network/protocol/transactions/TransactionsEngine.java
@@ -3,7 +3,7 @@ package com.limechain.network.protocol.transactions;
 import com.limechain.network.ConnectionManager;
 import com.limechain.network.protocol.transactions.scale.TransactionsReader;
 import com.limechain.network.protocol.transactions.scale.TransactionsWriter;
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.sync.warpsync.SyncedState;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;

--- a/src/main/java/com/limechain/network/protocol/warp/WarpSyncProtocol.java
+++ b/src/main/java/com/limechain/network/protocol/warp/WarpSyncProtocol.java
@@ -5,7 +5,7 @@ import com.limechain.network.encoding.Leb128LengthFrameEncoder;
 import com.limechain.network.protocol.warp.dto.WarpSyncRequest;
 import com.limechain.network.protocol.warp.dto.WarpSyncResponse;
 import com.limechain.network.protocol.warp.encoding.WarpSyncResponseDecoder;
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.network.protocol.warp.scale.writer.WarpSyncRequestWriter;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
 import io.libp2p.core.Stream;

--- a/src/main/java/com/limechain/network/protocol/warp/dto/BlockBody.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/BlockBody.java
@@ -1,6 +1,6 @@
 package com.limechain.network.protocol.warp.dto;
 
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.network.protocol.warp.scale.reader.BlockBodyReader;
 import com.limechain.network.protocol.warp.scale.writer.BlockBodyWriter;
 import com.limechain.utils.HashUtils;

--- a/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
@@ -1,7 +1,7 @@
 package com.limechain.network.protocol.warp.dto;
 
 import com.limechain.network.protocol.blockannounce.scale.BlockHeaderScaleWriter;
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.utils.HashUtils;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
 import io.emeraldpay.polkaj.types.Hash256;

--- a/src/main/java/com/limechain/network/protocol/warp/dto/Extrinsics.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/Extrinsics.java
@@ -1,6 +1,6 @@
 package com.limechain.network.protocol.warp.dto;
 
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.utils.HashUtils;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
 import lombok.Data;

--- a/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
+++ b/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
@@ -1,6 +1,6 @@
 package com.limechain.runtime.hostapi;
 
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.rpc.server.AppBean;
 import com.limechain.runtime.hostapi.dto.Key;
 import com.limechain.runtime.hostapi.dto.RuntimePointerSize;

--- a/src/main/java/com/limechain/runtime/hostapi/StorageHostFunctions.java
+++ b/src/main/java/com/limechain/runtime/hostapi/StorageHostFunctions.java
@@ -1,6 +1,6 @@
 package com.limechain.runtime.hostapi;
 
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.runtime.hostapi.dto.RuntimePointerSize;
 import com.limechain.storage.DBConstants;
 import com.limechain.storage.DeleteByPrefixResult;

--- a/src/main/java/com/limechain/storage/DeleteByPrefixResult.java
+++ b/src/main/java/com/limechain/storage/DeleteByPrefixResult.java
@@ -1,6 +1,6 @@
 package com.limechain.storage;
 
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/com/limechain/storage/block/BlockStateHelper.java
+++ b/src/main/java/com/limechain/storage/block/BlockStateHelper.java
@@ -2,7 +2,7 @@ package com.limechain.storage.block;
 
 import com.limechain.network.protocol.blockannounce.scale.BlockHeaderScaleWriter;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
-import com.limechain.network.protocol.warp.exception.ScaleEncodingException;
+import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.network.protocol.warp.scale.reader.BlockHeaderReader;
 import com.limechain.storage.DBConstants;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;

--- a/src/main/java/com/limechain/utils/scale/ScaleUtils.java
+++ b/src/main/java/com/limechain/utils/scale/ScaleUtils.java
@@ -1,0 +1,71 @@
+package com.limechain.utils.scale;
+
+import com.limechain.utils.scale.writers.PairWriter;
+import io.emeraldpay.polkaj.scale.ScaleCodecReader;
+import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import io.emeraldpay.polkaj.scale.ScaleReader;
+import io.emeraldpay.polkaj.scale.reader.ListReader;
+import io.emeraldpay.polkaj.scale.writer.ListWriter;
+import kotlin.Pair;
+import lombok.experimental.UtilityClass;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+// TODO: This class is currently just a helper utility class,
+//  planned to grow into a unified scale encode/decode util class with whatever methods are useful
+//  WIP
+// Currently trying out different approaches to spare some of the boilerplate around SCALE en/decoding
+@UtilityClass
+public class ScaleUtils {
+
+    @UtilityClass
+    public class Decode {
+        public <T> T decode(byte[] encodedData, ScaleReader<T> reader) {
+            try {
+                return new ScaleCodecReader(encodedData).read(reader);
+            } catch (RuntimeException e) {
+                throw new RuntimeException("Error while SCALE decoding.", e); // TODO: is this a code smell?
+            }
+        }
+
+        public <T> List<T> decodeList(byte[] encodedData, ScaleReader<T> listItemReader) {
+            return decode(encodedData, new ListReader<>(listItemReader));
+        }
+    }
+
+    @UtilityClass
+    public class Encode {
+        public <K, V> byte[] encode(
+            List<Pair<K, V>> pairs,
+            Function<K, byte[]> fstSerializer,
+            Function<V, byte[]> sndSerializer
+        ) throws IOException {
+            return encode(
+                pairs.stream()
+                    .map(p -> new Pair<>(fstSerializer.apply(p.getFirst()), sndSerializer.apply(p.getSecond())))
+                    .toList());
+        }
+
+        public byte[] encode(List<Pair<byte[], byte[]>> pairs) throws IOException {
+            try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                 ScaleCodecWriter writer = new ScaleCodecWriter(buffer)) {
+                new ListWriter<>(new PairWriter<>(ScaleCodecWriter::writeAsList, ScaleCodecWriter::writeAsList))
+                    .write(writer, pairs);
+                return buffer.toByteArray();
+            }
+        }
+
+        public byte[] encode(byte[][] values) throws IOException {
+            try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                 ScaleCodecWriter writer = new ScaleCodecWriter(buffer)) {
+                new ListWriter<>(ScaleCodecWriter::writeAsList)
+                    .write(writer, Arrays.asList(values));
+                return buffer.toByteArray();
+            }
+        }
+    }
+}

--- a/src/main/java/com/limechain/utils/scale/ScaleUtils.java
+++ b/src/main/java/com/limechain/utils/scale/ScaleUtils.java
@@ -1,5 +1,6 @@
 package com.limechain.utils.scale;
 
+import com.limechain.utils.scale.exceptions.ScaleDecodingException;
 import com.limechain.utils.scale.writers.PairWriter;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
@@ -15,7 +16,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
-// TODO: This class is currently just a helper utility class,
+// TODO:
+//  This is currently a helper utility class
 //  planned to grow into a unified scale encode/decode util class with whatever methods are useful
 //  WIP
 // Currently trying out different approaches to spare some of the boilerplate around SCALE en/decoding
@@ -28,7 +30,7 @@ public class ScaleUtils {
             try {
                 return new ScaleCodecReader(encodedData).read(reader);
             } catch (RuntimeException e) {
-                throw new RuntimeException("Error while SCALE decoding.", e); // TODO: is this a code smell?
+                throw new ScaleDecodingException("Error while SCALE decoding.", e);
             }
         }
 

--- a/src/main/java/com/limechain/utils/scale/exceptions/ScaleDecodingException.java
+++ b/src/main/java/com/limechain/utils/scale/exceptions/ScaleDecodingException.java
@@ -1,0 +1,15 @@
+package com.limechain.utils.scale.exceptions;
+
+public class ScaleDecodingException extends RuntimeException {
+    public ScaleDecodingException(Throwable cause) {
+        super(cause);
+    }
+
+    public ScaleDecodingException(String message) {
+        super(message);
+    }
+
+    public ScaleDecodingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/limechain/utils/scale/exceptions/ScaleEncodingException.java
+++ b/src/main/java/com/limechain/utils/scale/exceptions/ScaleEncodingException.java
@@ -1,4 +1,4 @@
-package com.limechain.network.protocol.warp.exception;
+package com.limechain.utils.scale.exceptions;
 
 public class ScaleEncodingException extends RuntimeException{
     public ScaleEncodingException(Throwable cause) {

--- a/src/main/java/com/limechain/utils/scale/readers/PairReader.java
+++ b/src/main/java/com/limechain/utils/scale/readers/PairReader.java
@@ -1,0 +1,19 @@
+package com.limechain.utils.scale.readers;
+
+import io.emeraldpay.polkaj.scale.ScaleCodecReader;
+import io.emeraldpay.polkaj.scale.ScaleReader;
+import kotlin.Pair;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class PairReader<K, V> implements ScaleReader<Pair<K, V>> {
+    protected ScaleReader<K> firstReader;
+    protected ScaleReader<V> secondReader;
+
+    @Override
+    public Pair<K, V> read(ScaleCodecReader scaleCodecReader) {
+        K first = scaleCodecReader.read(firstReader);
+        V second = scaleCodecReader.read(secondReader);
+        return new Pair<>(first, second);
+    }
+}

--- a/src/main/java/com/limechain/utils/scale/writers/PairWriter.java
+++ b/src/main/java/com/limechain/utils/scale/writers/PairWriter.java
@@ -1,0 +1,20 @@
+package com.limechain.utils.scale.writers;
+
+import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import io.emeraldpay.polkaj.scale.ScaleWriter;
+import kotlin.Pair;
+import lombok.AllArgsConstructor;
+
+import java.io.IOException;
+
+@AllArgsConstructor
+public class PairWriter<K, V> implements ScaleWriter<Pair<K, V>> {
+    protected ScaleWriter<K> firstWriter;
+    protected ScaleWriter<V> secondWriter;
+
+    @Override
+    public void write(ScaleCodecWriter scaleCodecWriter, Pair<K, V> pair) throws IOException {
+        scaleCodecWriter.write(firstWriter, pair.getFirst());
+        scaleCodecWriter.write(secondWriter, pair.getSecond());
+    }
+}


### PR DESCRIPTION
A beginning of a vision to extract away all the SCALE encoding/decoding logic into `utils`.