### PR TITLE
Refactor nibbles

### DIFF
--- a/src/main/java/com/limechain/client/FullNode.java
+++ b/src/main/java/com/limechain/client/FullNode.java
@@ -151,7 +151,7 @@ public class FullNode implements HostNode {
 
             // First, build the trie structure
             for (Map.Entry<String, String> entry : mainStorage.entrySet()) {
-                Nibbles key = new Nibbles(new BytesToNibbles(entry.getKey().getBytes()));
+                Nibbles key = Nibbles.of(new BytesToNibbles(entry.getKey().getBytes()));
                 byte[] value = entry.getValue().getBytes();
 
                 switch (trieStructure.node(key)) {
@@ -219,7 +219,7 @@ public class FullNode implements HostNode {
                     }
                 }
 
-                DecodedNode<Nibbles, List<Byte>> decoded = new DecodedNode<>(
+                DecodedNode<List<Byte>> decoded = new DecodedNode<>(
                         // TODO:
                         //  All of this ugly boilerplate for a simple List<Optional<byte[]>> to List<Byte>[] conversion...
                         //  figure out a better representation

--- a/src/main/java/com/limechain/trie/structure/TrieStructure.java
+++ b/src/main/java/com/limechain/trie/structure/TrieStructure.java
@@ -261,7 +261,7 @@ public class TrieStructure<T> {
             // NOTE:
             //  For now, the remainingKey argument of `ClosestAncestor` is not used, so if this becomes an efficiency issue
             //  We could omit storing it. Also, this is the only reason we're reassigning the iterator.
-            var remainingKey = new Nibbles(keyIter);
+            var remainingKey = Nibbles.of(keyIter);
             closestAncestor = new ExistingNodeInnerResult.NotFound.ClosestAncestor(currentIndex, remainingKey);
             keyIter = remainingKey.iterator();
 

--- a/src/main/java/com/limechain/trie/structure/decoded/node/DecodedNode.java
+++ b/src/main/java/com/limechain/trie/structure/decoded/node/DecodedNode.java
@@ -6,7 +6,7 @@ import com.limechain.trie.structure.decoded.node.exceptions.NodeEncodingExceptio
 import com.limechain.trie.structure.nibble.BytesToNibbles;
 import com.limechain.trie.structure.nibble.Nibble;
 import com.limechain.trie.structure.nibble.Nibbles;
-import com.limechain.trie.structure.nibble.NibblesToBytes;
+import com.limechain.trie.structure.nibble.NibblesUtils;
 import com.limechain.utils.scale.ScaleUtils;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import lombok.AllArgsConstructor;
@@ -118,7 +118,7 @@ public class DecodedNode<C extends Collection<Byte>> {
     }
 
     private List<Byte> encodePartialKey() {
-        return NibblesToBytes.paddingPrepend(this.partialKey);
+        return NibblesUtils.toBytesPrepending(this.partialKey);
     }
 
     // TODO: Optimize, a lot of unnecessary copying is going on.

--- a/src/main/java/com/limechain/trie/structure/decoded/node/DecodedNode.java
+++ b/src/main/java/com/limechain/trie/structure/decoded/node/DecodedNode.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -25,13 +26,13 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 // NOTE:
-//  Those `extends` restrictions on the generic types are only used for `.size()` methods
+//  This `extends` restriction on the generic type is only used for `.size()` methods
 //  These needn't be restrictions on the node itself, but rather only for the `encode` method
 //  Which could alternatively be implemented as a generic static methods only for nodes obeying these constraints
 //  But we don't need that much overcomplicating now.
 @Getter
 @AllArgsConstructor
-public class DecodedNode<I extends Collection<Nibble>, C extends Collection<Byte>> {
+public class DecodedNode<C extends Collection<Byte>> {
     public final static int CHILDREN_COUNT = 16;
 
     private static final int HASHED_STORAGE_VALUE_LENGTH = 32;
@@ -39,7 +40,7 @@ public class DecodedNode<I extends Collection<Nibble>, C extends Collection<Byte
 
     private List<C> children;
 
-    private I partialKey;
+    private Nibbles partialKey;
 
     @Nullable
     private StorageValue storageValue;
@@ -117,7 +118,7 @@ public class DecodedNode<I extends Collection<Nibble>, C extends Collection<Byte
     }
 
     private List<Byte> encodePartialKey() {
-        return new NibblesToBytes(new Nibbles(this.partialKey)).paddingPrepend();
+        return NibblesToBytes.paddingPrepend(this.partialKey);
     }
 
     // TODO: Optimize, a lot of unnecessary copying is going on.
@@ -231,7 +232,7 @@ public class DecodedNode<I extends Collection<Nibble>, C extends Collection<Byte
      * @throws NodeDecodingException    If the encoded array is null, empty, or invalid.
      * @throws IllegalArgumentException If 'encoded' is null.
      */
-    public static DecodedNode<Nibbles, List<Byte>> decode(byte[] encoded) {
+    public static DecodedNode<List<Byte>> decode(byte[] encoded) {
         ScaleCodecReader reader = new ScaleCodecReader(encoded);
         if (encoded == null || encoded.length == 0) {
             throw new NodeDecodingException("Invalid node value: it's empty");
@@ -295,13 +296,20 @@ public class DecodedNode<I extends Collection<Nibble>, C extends Collection<Byte
         byte[] storageValue = decodeStorageValue(reader, storageValueHashed);
 
         List<List<Byte>> children = decodeChildren(reader, childrenBitmap);
-        Nibbles partialKey = new Nibbles(new BytesToNibbles(partialKeyLEBytes));
+
+        Iterator<Nibble> pkNibbles = new BytesToNibbles(partialKeyLEBytes).iterator();
+
+        // This is for situations where the partial key contains a `0` prefix that exists for
+        // alignment but doesn't actually represent a nibble. So we skip it.
         if (pkLen % 2 == 1) {
-            // This is for situations where the partial key contains a `0` prefix that exists for
-            // alignment but doesn't actually represent a nibble.
-            partialKey.remove(0);
+            pkNibbles.next();
         }
-        return new DecodedNode<>(children, partialKey, new StorageValue(storageValue, storageValueHashed));
+
+        return new DecodedNode<>(
+            children,
+            Nibbles.of(pkNibbles),
+            new StorageValue(storageValue, Objects.requireNonNull(storageValueHashed))
+        );
     }
 
     /**

--- a/src/main/java/com/limechain/trie/structure/nibble/BytesToNibbles.java
+++ b/src/main/java/com/limechain/trie/structure/nibble/BytesToNibbles.java
@@ -11,10 +11,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
-// TODO:
-//  Maybe extract into an interface with a single implementor?
-//  Since NibblesToBytes would have different implementations depending on how we pad the nibbles
-//  But the semantics of `BytesToNibbles` is only one possible: split the bytes in the middle and iterate :D
 public class BytesToNibbles implements Iterable<Nibble> {
 
     private final List<Byte> bytes;
@@ -36,10 +32,6 @@ public class BytesToNibbles implements Iterable<Nibble> {
     private static class InnerIterator implements Iterator<Nibble> {
         private final Iterator<Byte> byteIterator;
 
-        //NOTE:
-        // This would've been an `Optional<Nibble>`, but we're in Java world...
-        // See: https://stackoverflow.com/a/26328555 for the reason why we'd get the warning
-        //      "'Optional<Nibble>' used as type for field 'remainingNibble'"
         @Nullable
         private Nibble remainingNibble = null;
 

--- a/src/main/java/com/limechain/trie/structure/nibble/Nibbles.java
+++ b/src/main/java/com/limechain/trie/structure/nibble/Nibbles.java
@@ -1,86 +1,78 @@
 package com.limechain.trie.structure.nibble;
 
 import org.apache.commons.collections4.IteratorUtils;
-import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Objects;
 import java.util.RandomAccess;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
-
-// TODO:
-//  Should this implement List or just Iterable... or maybe extend List<Nibble>?
-//  This current version contains a huge amount of boilerplate,
-//  but it's what I've reached as a most convenient option to use outside.
-//  Basically a List<Nibble> with additional methods.
-
-// TODO:
-//  As a List<Nibble> implementor, Nibbles is currently mutable, which I severely dislike,
-//  since this mandates the developer to think about where to copy and where passing by reference is sufficient.
+import java.util.stream.StreamSupport;
 
 /**
- * Convenience wrapper for any 'sequence of Nibble'-like structure
+ * Convenience wrapper for any 'sequence of Nibble'-like structure.
+ * It's immutable and its public static factory methods eagerly copy passed data (nibbles) to obtain ownership.
  */
-public class Nibbles implements List<Nibble>, RandomAccess, Comparable<List<Nibble>> {
-    public static final Nibbles EMPTY = new Nibbles(new byte[]{});
+public class Nibbles implements Iterable<Nibble>, RandomAccess, Comparable<Iterable<Nibble>> {
+    /**
+     * A sequence of zero nibbles, i.e. empty
+     */
+    public static final Nibbles EMPTY = new Nibbles(List.of());
 
     /**
-     * Don't mutate! :D
+     * A sequence of all nibbles in order, from 0 to F
      */
-    public static final Nibbles ALL = new Nibbles(Nibble.all());
-
-    public static Stream<Nibble> all() {
-        return ALL.stream();
-    }
+    public static final Nibbles ALL = Nibble.all().collect(NibblesCollector.toNibbles());
 
     private final List<Nibble> nibbles;
 
-    // TODO: Maybe convert all those overloaded constructors to static generational methods
-    public Nibbles(Nibble nibble) {
-        this(List.of(nibble));
+    public static Nibbles of(Nibble nibble) {
+        return Nibbles.of(List.of(nibble));
     }
 
-    public Nibbles(Nibble[] nibbles) {
-        this(Arrays.asList(nibbles));
+    public static Nibbles of(Nibble[] nibbles) {
+        return Nibbles.of(Arrays.asList(nibbles));
     }
 
-    public Nibbles(byte[] nibbles) {
-        this(Arrays.stream(ArrayUtils.toObject(nibbles)).map(Nibble::fromByte).toList());
+    public static Nibbles of(Collection<Nibble> nibbles) {
+        return new Nibbles(new ArrayList<>(nibbles));
     }
 
-    public Nibbles(Iterable<Nibble> nibbles) {
-        this(nibbles.iterator());
+    public static Nibbles of(Stream<Nibble> nibbles) {
+        return Nibbles.of(nibbles.iterator());
     }
 
-    public Nibbles(Stream<Nibble> nibbles) {
-        this(nibbles.iterator());
+    public static Nibbles of(Iterable<Nibble> nibbles) {
+        return Nibbles.of(nibbles.iterator());
     }
 
-    public static Nibbles of(int... nibbles) {
-        return new Nibbles(Arrays.stream(nibbles).mapToObj(Nibble::fromInt));
+    public static Nibbles of(Iterator<Nibble> nibbles) {
+        return new Nibbles(IteratorUtils.toList(nibbles));
     }
 
-    public Nibbles(Iterator<Nibble> nibbles) {
-        // TODO:
-        //  Reconsider the internal representation
-        //  LinkedList seems appropriate since we'll mostly iterate from left to right...
-        //  but for now we're sticking with ArrayList (returned from IteratorUtils.toList)
-
-        // TODO:
-        //  Reconsider whether this class should eagerly copy outer data to gain ownership
-        //  or simply trust the caller for `read-only` invariance of the given references...
-        //  For now, we simply copy references. Could lead to problems if a Nibble is mutated outside...
-        this.nibbles = IteratorUtils.toList(nibbles);
+    Nibbles(List<Nibble> nibbles) {
+        this.nibbles = nibbles;
     }
 
+    /**
+     * @return Nibbles constructed from a string of hexadecimal characters (nibbles).
+     * The capitalization of the characters doesn't matter.
+     */
+    public static Nibbles fromHexString(String hex) {
+        return hex.chars()
+            .mapToObj(c -> Nibble.fromAsciiHexDigit((char) c))
+            .collect(NibblesCollector.toNibbles());
+    }
+
+    /**
+     * Whether this nibbles starts with the given prefix.
+     */
     public boolean startsWith(Nibbles prefix) {
         final int thisSize = this.size();
         final int prefixSize = prefix.size();
@@ -92,12 +84,6 @@ public class Nibbles implements List<Nibble>, RandomAccess, Comparable<List<Nibb
         return prefix.nibbles.equals(this.nibbles.subList(0, prefixSize));
     }
 
-    @NotNull
-    @Override
-    public Iterator<Nibble> iterator() {
-        return nibbles.iterator();
-    }
-
     /**
      * @return the lower hexadecimal string representation of this Nibbles
      */
@@ -105,30 +91,129 @@ public class Nibbles implements List<Nibble>, RandomAccess, Comparable<List<Nibb
         return toLowerHexString(this.nibbles);
     }
 
-    // TODO:
-    //  This methods exists simply because to Java, not any `List<Nibble>` is the same as `Nibbles`
-    //  Although that's exactly what I want :D
-    private static String toLowerHexString(List<Nibble> nibbles) {
-        return nibbles.stream()
-                .map(Nibble::asLowerHexDigit)
-                .collect(
-                        Collector.of(
-                                StringBuilder::new,
-                                StringBuilder::append,
-                                StringBuilder::append,
-                                StringBuilder::toString
-                        )
-                );
+    private static String toLowerHexString(Iterable<Nibble> nibbles) {
+        return StreamSupport.stream(nibbles.spliterator(), false)
+            .map(Nibble::asLowerHexDigit)
+            .collect(
+                Collector.of(
+                    StringBuilder::new,
+                    StringBuilder::append,
+                    StringBuilder::append,
+                    StringBuilder::toString
+                )
+            );
+    }
+
+    /**
+     * Adds a new nibble to the nibbles.
+     * @param nibble the new nibble to add
+     * @return the new Nibbles after insertion
+     * @implNote will create a new modified copy of the nibbles, does not mutate the instance invoked on
+     */
+    public Nibbles add(Nibble nibble) {
+        List<Nibble> newNibbles = new ArrayList<>(this.nibbles);
+        newNibbles.add(nibble);
+        return new Nibbles(newNibbles);
+    }
+
+    /**
+     * Adds a new nibble to the nibbles at the given position.
+     * @param nibble the new nibble to add
+     * @return the new Nibbles after insertion
+     * @implNote will create a new modified copy of the nibbles, does not mutate the instance invoked on
+     */
+    public Nibbles add(int index, Nibble nibble) {
+        List<Nibble> newNibbles = new ArrayList<>(this.nibbles);
+        newNibbles.add(index, nibble);
+        return new Nibbles(newNibbles);
+    }
+
+    /**
+     * Returns the element at the specified position in this list.
+     *
+     * @param index index of the element to return
+     * @return the element at the specified position in this list
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *         ({@code index < 0 || index >= size()})
+     */
+    public Nibble get(int index) {
+        return nibbles.get(index);
+    }
+
+    // NOTE:
+    //  Since Nibbles is immutable, we don't actually need to explicitly copy
+    //  This method could go away, passing by reference could suffice, although going back to mutability
+    //  if later decided would become rather difficult.
+    public Nibbles copy() {
+        return Nibbles.of(this.nibbles);
+    }
+
+    /**
+     * Drops a number of nibbles from the beginning
+     * @param n the number of nibbles to skip
+     * @return a new Nibbles without the first n leading nibbles
+     * @throws IndexOutOfBoundsException if
+     *         ({@code n < 0 || n > size})
+     */
+    public Nibbles drop(int n) {
+        // NOTE: We might want to not throw, but return an empty Nibbles instead if (n < 0 || n > size).
+        return new Nibbles(this.nibbles.subList(n, this.nibbles.size()));
+    }
+
+    /**
+     * Takes only the first n nibbles from the beginning.
+     * @param n the number of nibbles to take
+     * @return a new Nibbles limited to only the first n leading nibbles
+     * @throws IndexOutOfBoundsException if
+     *         ({@code n < 0 || n > size})
+     */
+    public Nibbles take(int n) {
+        // NOTE: We might want to not throw, but return the same Nibbles instead if (n > size).
+        return new Nibbles(this.nibbles.subList(0, n));
+    }
+
+    /**
+     * Returns the number of elements in this Nibbles. If it contains
+     * more than {@code Integer.MAX_VALUE} elements, returns
+     * {@code Integer.MAX_VALUE}.
+     *
+     * @return the number of elements in this Nibbles
+     */
+    public int size() {
+        return nibbles.size();
+    }
+
+    /**
+     * @return true if this Nibbles contains no elements
+     */
+    public boolean isEmpty() {
+        return nibbles.isEmpty();
+    }
+
+    /**
+     * @return an unmodifiable view of the underlying list of nibbles
+     */
+    public List<Nibble> asUnmodifiableList() {
+        return Collections.unmodifiableList(this.nibbles);
+    }
+
+    public Stream<Nibble> stream() {
+        return nibbles.stream();
+    }
+
+    @NotNull
+    public Iterator<Nibble> iterator() {
+        return nibbles.iterator();
+    }
+
+    @Override
+    public int compareTo(@NotNull Iterable<Nibble> o) {
+        return this.toLowerHexString().compareTo(toLowerHexString(o));
     }
 
     @Override
     public String toString() {
         return this.toLowerHexString();
-    }
-
-    @Override
-    public Stream<Nibble> stream() {
-        return nibbles.stream();
     }
 
     @Override
@@ -139,144 +224,8 @@ public class Nibbles implements List<Nibble>, RandomAccess, Comparable<List<Nibb
         return this.nibbles.equals(nibbles1.nibbles);
     }
 
-
     @Override
     public int hashCode() {
         return Objects.hash(this.nibbles);
-    }
-
-    @NotNull
-    @Override
-    public Object[] toArray() {
-        return nibbles.toArray();
-    }
-
-    @NotNull
-    @Override
-    public <T> T[] toArray(@NotNull T[] a) {
-        return nibbles.toArray(a);
-    }
-
-    @Override
-    public boolean add(Nibble nibble) {
-        return nibbles.add(nibble);
-    }
-
-    @Override
-    public boolean remove(Object o) {
-        return nibbles.remove(o);
-    }
-
-    @Override
-    public boolean containsAll(@NotNull Collection<?> c) {
-        return new HashSet<>(nibbles).containsAll(c);
-    }
-
-    @Override
-    public boolean addAll(@NotNull Collection<? extends Nibble> c) {
-        return nibbles.addAll(c);
-    }
-
-    @Override
-    public boolean addAll(int index, @NotNull Collection<? extends Nibble> c) {
-        return nibbles.addAll(c);
-    }
-
-    @Override
-    public boolean removeAll(@NotNull Collection<?> c) {
-        return nibbles.removeAll(c);
-    }
-
-    @Override
-    public boolean retainAll(@NotNull Collection<?> c) {
-        return nibbles.retainAll(c);
-    }
-
-    @Override
-    public void clear() {
-        nibbles.clear();
-    }
-
-    @Override
-    public Nibble get(int index) {
-        return nibbles.get(index);
-    }
-
-    @Override
-    public Nibble set(int index, Nibble element) {
-        return nibbles.get(index);
-    }
-
-    @Override
-    public void add(int index, Nibble element) {
-        nibbles.add(index, element);
-    }
-
-    @Override
-    public Nibble remove(int index) {
-        return nibbles.remove(index);
-    }
-
-    @Override
-    public int indexOf(Object o) {
-        return nibbles.indexOf(o);
-    }
-
-    @Override
-    public int lastIndexOf(Object o) {
-        return nibbles.lastIndexOf(o);
-    }
-
-    @NotNull
-    @Override
-    public ListIterator<Nibble> listIterator() {
-        return nibbles.listIterator();
-    }
-
-    @NotNull
-    @Override
-    public ListIterator<Nibble> listIterator(int index) {
-        return nibbles.listIterator();
-    }
-
-    @NotNull
-    @Override
-    public List<Nibble> subList(int fromIndex, int toIndex) {
-        return nibbles.subList(fromIndex, toIndex);
-    }
-
-    public Nibbles copy() {
-        return new Nibbles(this.nibbles);
-    }
-
-    @Override
-    public int size() {
-        return nibbles.size();
-    }
-
-    public boolean isEmpty() {
-        return nibbles.isEmpty();
-    }
-
-    @Override
-    public boolean contains(Object o) {
-        return nibbles.contains(o);
-    }
-
-    public List<Nibble> asUnmodifiableList() {
-        return Collections.unmodifiableList(this.nibbles);
-    }
-
-    @Override
-    public int compareTo(@NotNull List<Nibble> o) {
-        return this.toLowerHexString().compareTo(toLowerHexString(o));
-    }
-
-    /**
-     * @return Nibbles constructed from a string of hexadecimal characters (nibbles).
-     * The capitalization of the characters doesn't matter.
-     */
-    public static Nibbles fromHexString(String hex) {
-        return new Nibbles(hex.chars().mapToObj(c -> (char) c).map(Nibble::fromAsciiHexDigit));
     }
 }

--- a/src/main/java/com/limechain/trie/structure/nibble/Nibbles.java
+++ b/src/main/java/com/limechain/trie/structure/nibble/Nibbles.java
@@ -11,9 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.RandomAccess;
-import java.util.stream.Collector;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * Convenience wrapper for any 'sequence of Nibble'-like structure.
@@ -88,20 +86,7 @@ public class Nibbles implements Iterable<Nibble>, RandomAccess, Comparable<Itera
      * @return the lower hexadecimal string representation of this Nibbles
      */
     public String toLowerHexString() {
-        return toLowerHexString(this.nibbles);
-    }
-
-    private static String toLowerHexString(Iterable<Nibble> nibbles) {
-        return StreamSupport.stream(nibbles.spliterator(), false)
-            .map(Nibble::asLowerHexDigit)
-            .collect(
-                Collector.of(
-                    StringBuilder::new,
-                    StringBuilder::append,
-                    StringBuilder::append,
-                    StringBuilder::toString
-                )
-            );
+        return NibblesUtils.toLowerHexString(this.nibbles);
     }
 
     /**
@@ -215,7 +200,8 @@ public class Nibbles implements Iterable<Nibble>, RandomAccess, Comparable<Itera
 
     @Override
     public int compareTo(@NotNull Iterable<Nibble> o) {
-        return this.toLowerHexString().compareTo(toLowerHexString(o));
+        // NOTE: Could be made more efficient by avoiding the string serialization, if it ever becomes an issue.
+        return this.toLowerHexString().compareTo(NibblesUtils.toLowerHexString(o));
     }
 
     @Override

--- a/src/main/java/com/limechain/trie/structure/nibble/Nibbles.java
+++ b/src/main/java/com/limechain/trie/structure/nibble/Nibbles.java
@@ -156,7 +156,6 @@ public class Nibbles implements Iterable<Nibble>, RandomAccess, Comparable<Itera
      *         ({@code n < 0 || n > size})
      */
     public Nibbles drop(int n) {
-        // NOTE: We might want to not throw, but return an empty Nibbles instead if (n < 0 || n > size).
         return new Nibbles(this.nibbles.subList(n, this.nibbles.size()));
     }
 
@@ -168,7 +167,6 @@ public class Nibbles implements Iterable<Nibble>, RandomAccess, Comparable<Itera
      *         ({@code n < 0 || n > size})
      */
     public Nibbles take(int n) {
-        // NOTE: We might want to not throw, but return the same Nibbles instead if (n > size).
         return new Nibbles(this.nibbles.subList(0, n));
     }
 

--- a/src/main/java/com/limechain/trie/structure/nibble/Nibbles.java
+++ b/src/main/java/com/limechain/trie/structure/nibble/Nibbles.java
@@ -141,11 +141,17 @@ public class Nibbles implements Iterable<Nibble>, RandomAccess, Comparable<Itera
     }
 
     // NOTE:
-    //  Since Nibbles is immutable, we don't actually need to explicitly copy
-    //  This method could go away, passing by reference could suffice, although going back to mutability
-    //  if later decided would become rather difficult.
+    //  Since Nibbles is immutable, we don't actually need to explicitly copy. Passing by reference suffices.
+    //  This method would've been removed during refactoring to immutability, but we've left it out as a clear marker
+    //  of where ownership changes occur, so that if one day efficiency becomes a problem and we want to refactor again
+    //  in favor of mutability, we won't have to deduce our way back the hard way.
+    /**
+     * Since {@link Nibbles} is immutable, returns {@code this}.
+     * Exists only as a marker for copying in order to trace ownership more explicitly.
+     * @return this
+     */
     public Nibbles copy() {
-        return Nibbles.of(this.nibbles);
+        return this;
     }
 
     /**
@@ -195,6 +201,9 @@ public class Nibbles implements Iterable<Nibble>, RandomAccess, Comparable<Itera
         return Collections.unmodifiableList(this.nibbles);
     }
 
+    /**
+     * @return a stream of the contained nibbles
+     */
     public Stream<Nibble> stream() {
         return nibbles.stream();
     }

--- a/src/main/java/com/limechain/trie/structure/nibble/NibblesCollector.java
+++ b/src/main/java/com/limechain/trie/structure/nibble/NibblesCollector.java
@@ -34,7 +34,6 @@ public class NibblesCollector implements Collector<Nibble, List<Nibble>, Nibbles
 
     @Override
     public Function<List<Nibble>, Nibbles> finisher() {
-        // TODO: Avoid this unnecessary copying by introducing "lightweight by-reference only" constructors to Nibbles
         return Nibbles::new;
     }
 

--- a/src/main/java/com/limechain/trie/structure/nibble/NibblesToBytes.java
+++ b/src/main/java/com/limechain/trie/structure/nibble/NibblesToBytes.java
@@ -3,21 +3,45 @@ package com.limechain.trie.structure.nibble;
 import java.util.ArrayList;
 import java.util.List;
 
-// TODO: This could potentially be made similar to BytesToNibbles, consider whether a simple iterator strategy would be better.
 public class NibblesToBytes {
-    private final Nibbles nibbles;
-
     /**
-     * Doesn't clone the given `Nibbles`. Only serves as an iterable to provide a way to look at the existing nibbles in a new way.
+     * Turns a collection of nibbles into an iterator of bytes.
+     * If the number of nibbles is odd, adds a `0` nibble at the beginning.
      */
-    public NibblesToBytes(Nibbles nibbles) {
-        this.nibbles = nibbles;
+    public static List<Byte> paddingPrepend(final Nibbles nibbles) {
+        Nibbles prependedNibbles;
+
+        if (nibbles.size() % 2 == 1) {
+            // NOTE: Inefficient copying, could be bettered
+            prependedNibbles = nibbles.add(0, Nibble.ZERO);
+        } else {
+            prependedNibbles = nibbles;
+        }
+
+        return convert(prependedNibbles);
     }
 
     /**
-     * Actually constructs the new list; the Nibble references have been read from and the new Bytes have been constructed.
+     * Turns a collection of nibbles into an iterator of bytes.
+     * If the number of nibbles is odd, adds a `0` nibble at the end.
      */
-    private List<Byte> convert(List<Nibble> nibbles) {
+    public static List<Byte> paddingAppend(final Nibbles nibbles) {
+        Nibbles prependedNibbles;
+        if (nibbles.size() % 2 == 1) {
+            // NOTE: Inefficient copying, could be bettered
+            prependedNibbles = nibbles.add(Nibble.ZERO);
+        } else {
+            prependedNibbles = nibbles;
+        }
+
+        return convert(prependedNibbles);
+    }
+
+    /**
+     * Actually constructs the new list;
+     * the Nibble references have been read from and the new Bytes have been constructed.
+     */
+    private static List<Byte> convert(Nibbles nibbles) {
         assert nibbles.size() % 2 == 0 : "Only an even number of nibbles can be converted to bytes.";
 
         int halfLen = nibbles.size() / 2;
@@ -32,39 +56,5 @@ public class NibblesToBytes {
         }
 
         return result;
-    }
-
-    /**
-     * Turns an iterator of nibbles into an iterator of bytes.
-     * If the number of nibbles is odd, adds a `0` nibble at the beginning.
-     */
-    public List<Byte> paddingPrepend() {
-        Nibbles prependedNibbles;
-        if (this.nibbles.size() % 2 == 1) {
-            // TODO: Inefficient copying, figure out a better way
-            prependedNibbles = new Nibbles(this.nibbles);
-            prependedNibbles.add(0, Nibble.ZERO);
-        } else {
-            prependedNibbles = this.nibbles;
-        }
-
-        return convert(prependedNibbles);
-    }
-
-    /**
-     * Turns an iterator of nibbles into an iterator of bytes.
-     * If the number of nibbles is odd, adds a `0` nibble at the end.
-     */
-    public List<Byte> paddingAppend() {
-        Nibbles prependedNibbles;
-        if (this.nibbles.size() % 2 == 1) {
-            // TODO: Inefficient copying, figure out a better way
-            prependedNibbles = new Nibbles(this.nibbles);
-            prependedNibbles.add(Nibble.ZERO);
-        } else {
-            prependedNibbles = this.nibbles;
-        }
-
-        return convert(prependedNibbles);
     }
 }

--- a/src/main/java/com/limechain/trie/structure/nibble/NibblesUtils.java
+++ b/src/main/java/com/limechain/trie/structure/nibble/NibblesUtils.java
@@ -2,13 +2,16 @@ package com.limechain.trie.structure.nibble;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.StreamSupport;
 
-public class NibblesToBytes {
+public class NibblesUtils {
     /**
-     * Turns a collection of nibbles into an iterator of bytes.
+     * Joins a collection of nibbles into a list of bytes by
+     * joining each two consecutive nibbles into a single byte.
      * If the number of nibbles is odd, adds a `0` nibble at the beginning.
      */
-    public static List<Byte> paddingPrepend(final Nibbles nibbles) {
+    public static List<Byte> toBytesPrepending(final Nibbles nibbles) {
         Nibbles prependedNibbles;
 
         if (nibbles.size() % 2 == 1) {
@@ -18,14 +21,15 @@ public class NibblesToBytes {
             prependedNibbles = nibbles;
         }
 
-        return convert(prependedNibbles);
+        return toBytes(prependedNibbles);
     }
 
     /**
-     * Turns a collection of nibbles into an iterator of bytes.
+     * Joins a collection of nibbles into a list of bytes by
+     * joining each two consecutive nibbles into a single byte.
      * If the number of nibbles is odd, adds a `0` nibble at the end.
      */
-    public static List<Byte> paddingAppend(final Nibbles nibbles) {
+    public static List<Byte> toBytesAppending(final Nibbles nibbles) {
         Nibbles prependedNibbles;
         if (nibbles.size() % 2 == 1) {
             // NOTE: Inefficient copying, could be bettered
@@ -34,14 +38,14 @@ public class NibblesToBytes {
             prependedNibbles = nibbles;
         }
 
-        return convert(prependedNibbles);
+        return toBytes(prependedNibbles);
     }
 
     /**
      * Actually constructs the new list;
      * the Nibble references have been read from and the new Bytes have been constructed.
      */
-    private static List<Byte> convert(Nibbles nibbles) {
+    private static List<Byte> toBytes(Nibbles nibbles) {
         assert nibbles.size() % 2 == 0 : "Only an even number of nibbles can be converted to bytes.";
 
         int halfLen = nibbles.size() / 2;
@@ -56,5 +60,18 @@ public class NibblesToBytes {
         }
 
         return result;
+    }
+
+    static String toLowerHexString(Iterable<Nibble> nibbles) {
+        return StreamSupport.stream(nibbles.spliterator(), false)
+            .map(Nibble::asLowerHexDigit)
+            .collect(
+                Collector.of(
+                    StringBuilder::new,
+                    StringBuilder::append,
+                    StringBuilder::append,
+                    StringBuilder::toString
+                )
+            );
     }
 }

--- a/src/main/java/com/limechain/trie/structure/nibble/NibblesUtils.java
+++ b/src/main/java/com/limechain/trie/structure/nibble/NibblesUtils.java
@@ -1,17 +1,20 @@
 package com.limechain.trie.structure.nibble;
 
+import lombok.experimental.UtilityClass;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collector;
 import java.util.stream.StreamSupport;
 
+@UtilityClass
 public class NibblesUtils {
     /**
      * Joins a collection of nibbles into a list of bytes by
      * joining each two consecutive nibbles into a single byte.
      * If the number of nibbles is odd, adds a `0` nibble at the beginning.
      */
-    public static List<Byte> toBytesPrepending(final Nibbles nibbles) {
+    public List<Byte> toBytesPrepending(final Nibbles nibbles) {
         Nibbles prependedNibbles;
 
         if (nibbles.size() % 2 == 1) {
@@ -29,7 +32,7 @@ public class NibblesUtils {
      * joining each two consecutive nibbles into a single byte.
      * If the number of nibbles is odd, adds a `0` nibble at the end.
      */
-    public static List<Byte> toBytesAppending(final Nibbles nibbles) {
+    public List<Byte> toBytesAppending(final Nibbles nibbles) {
         Nibbles prependedNibbles;
         if (nibbles.size() % 2 == 1) {
             // NOTE: Inefficient copying, could be bettered
@@ -45,7 +48,7 @@ public class NibblesUtils {
      * Actually constructs the new list;
      * the Nibble references have been read from and the new Bytes have been constructed.
      */
-    private static List<Byte> toBytes(Nibbles nibbles) {
+    private List<Byte> toBytes(Nibbles nibbles) {
         assert nibbles.size() % 2 == 0 : "Only an even number of nibbles can be converted to bytes.";
 
         int halfLen = nibbles.size() / 2;
@@ -62,7 +65,7 @@ public class NibblesUtils {
         return result;
     }
 
-    static String toLowerHexString(Iterable<Nibble> nibbles) {
+    String toLowerHexString(Iterable<Nibble> nibbles) {
         return StreamSupport.stream(nibbles.spliterator(), false)
             .map(Nibble::asLowerHexDigit)
             .collect(

--- a/src/test/java/com/limechain/trie/structure/TrieStructureDotSerializer.java
+++ b/src/test/java/com/limechain/trie/structure/TrieStructureDotSerializer.java
@@ -52,7 +52,7 @@ class TrieStructureDotSerializer<T> {
 
     private static final String CHILDREN_INDICES;
     static {
-        String childrenIndices = Nibbles.all().map(childIndex -> String.format("<%1$s>%1$s", childIndex)).collect(
+        String childrenIndices = Nibble.all().map(childIndex -> String.format("<%1$s>%1$s", childIndex)).collect(
             Collectors.joining(" | "));
         CHILDREN_INDICES = String.format("{%s}", childrenIndices);
     }

--- a/src/test/java/com/limechain/trie/structure/TrieStructureTest.java
+++ b/src/test/java/com/limechain/trie/structure/TrieStructureTest.java
@@ -8,13 +8,9 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Queue;
-import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +39,7 @@ class TrieStructureTest {
         assertTrue(trie1.structurallyEquals(trie2),
             "Empty tries must be structurally equal.");
 
-        final Nibbles key = new Nibbles(new BytesToNibbles("foo".getBytes()));
+        final Nibbles key = Nibbles.of(new BytesToNibbles("foo".getBytes()));
         trie1
             .node(key)
             .asVacant()
@@ -91,7 +87,7 @@ class TrieStructureTest {
             Stream.of(1, 3, 5)
                 .map(Nibble::fromInt)
                 // NOTE: Intentionally lists of only one nibble, since those are the expected partial keys
-                .map(Nibbles::new)
+                .map(Nibbles::of)
                 .toList();
 
         int i = 0;
@@ -120,7 +116,7 @@ class TrieStructureTest {
             var trie = new TrieStructure<>();
 
             for (var key : keys) {
-                var k = new Nibbles(key.stream().map(Nibble::fromInt));
+                var k = key.stream().map(Nibble::fromInt).collect(NibblesCollector.toNibbles());
                 var handle = trie.node(k);
 
                 handle
@@ -160,7 +156,7 @@ class TrieStructureTest {
                 .insert(null);
         }
 
-        assertFalse(trie.node(Nibbles.of(1, 2, 3)).asNodeHandle().hasStorageValue());
+        assertFalse(trie.node(Nibbles.fromHexString("123")).asNodeHandle().hasStorageValue());
     }
 
     // NOTE: This is illegally beautiful :D

--- a/src/test/java/com/limechain/trie/structure/decoded/node/DecodedNodeTest.java
+++ b/src/test/java/com/limechain/trie/structure/decoded/node/DecodedNodeTest.java
@@ -1,7 +1,6 @@
 package com.limechain.trie.structure.decoded.node;
 
 import com.limechain.trie.structure.decoded.node.exceptions.NodeEncodingException;
-import com.limechain.trie.structure.nibble.Nibble;
 import com.limechain.trie.structure.nibble.Nibbles;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
@@ -43,7 +42,7 @@ class DecodedNodeTest {
         StorageValue expectedStorageValue = new StorageValue(new byte[]{}, false);
         Nibbles expectedPartialKey = Nibbles.fromHexString("63");
 
-        DecodedNode<Nibbles, List<Byte>> decoded = DecodedNode.decode(expectedEncoded);
+        DecodedNode<List<Byte>> decoded = DecodedNode.decode(expectedEncoded);
         assertNotNull(decoded);
 
         assertEquals(boxedExpectedEncoded, decoded.encode());
@@ -62,9 +61,9 @@ class DecodedNodeTest {
     @Test
     void emptyNodeEncodesSuccessfully() {
         var decodedNode = new DecodedNode<>(
-                List.of(),
-                List.of(),
-                null
+            List.of(),
+            Nibbles.EMPTY,
+            null
         );
         assertDoesNotThrow(decodedNode::encode);
     }
@@ -73,7 +72,7 @@ class DecodedNodeTest {
     void nodeOnlyWithPartialKeyThrowsException() {
         var decodedNode = new DecodedNode<>(
                 List.of(),
-                List.of(Nibble.fromInt(2)),
+                Nibbles.fromHexString("2"),
                 null
         );
         assertThrows(NodeEncodingException.class, decodedNode::encode);


### PR DESCRIPTION
refactor(nibbles)!: 

* make Nibbles immutable
* turn constructors into public factory methods for Nibbles that copy data on construction to gain ownership, instead leaving the constructor package protected in order to still make us of internal list's mutability when modifying the Nibbles.
* `Nibbles implements Iterable<Nibble>` instead of Collection or List
* remove generic partial key type argument from `DecodedNode` since in Java's eyes `Nibbles` is no more a collection, thus we can't access its `size()` method generically. Instead, we simply specify that generic type to Nibbles
* make `NibblesToBytes` a static utility class