### PR TITLE
Var-int blocknumber scale

### DIFF
--- a/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockHeaderScaleWriter.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockHeaderScaleWriter.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 import java.io.IOException;
 
-@NoArgsConstructor(access  = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class BlockHeaderScaleWriter implements ScaleWriter<BlockHeader> {
 
     private static final BlockHeaderScaleWriter INSTANCE = new BlockHeaderScaleWriter();
@@ -32,6 +32,8 @@ public class BlockHeaderScaleWriter implements ScaleWriter<BlockHeader> {
 
     private void write(ScaleCodecWriter writer, BlockHeader blockHeader, boolean sealed) throws IOException {
         writer.writeUint256(blockHeader.getParentHash().getBytes());
+        // NOTE: Usage of BlockNumberWriter is intentionally omitted here,
+        //  since we want this to be a compact int, not a var size int
         writer.writeCompact(blockHeader.getBlockNumber().intValue());
         writer.writeUint256(blockHeader.getStateRoot().getBytes());
         writer.writeUint256(blockHeader.getExtrinsicsRoot().getBytes());

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/commit/VoteScaleReader.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/commit/VoteScaleReader.java
@@ -1,17 +1,12 @@
 package com.limechain.network.protocol.grandpa.messages.commit;
 
-import com.limechain.network.protocol.warp.scale.reader.VarUint64Reader;
+import com.limechain.network.protocol.warp.scale.reader.BlockNumberReader;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleReader;
 import io.emeraldpay.polkaj.types.Hash256;
 
 public class VoteScaleReader implements ScaleReader<Vote> {
     private static final VoteScaleReader INSTANCE = new VoteScaleReader();
-    private final VarUint64Reader varUint64Reader;
-
-    private VoteScaleReader() {
-        varUint64Reader = new VarUint64Reader(4);
-    }
 
     public static VoteScaleReader getInstance() {
         return INSTANCE;
@@ -21,7 +16,7 @@ public class VoteScaleReader implements ScaleReader<Vote> {
     public Vote read(ScaleCodecReader reader) {
         Vote vote = new Vote();
         vote.setBlockHash(new Hash256(reader.readUint256()));
-        vote.setBlockNumber(varUint64Reader.read(reader));
+        vote.setBlockNumber(BlockNumberReader.getInstance().read(reader));
         return vote;
     }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/commit/VoteScaleWriter.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/commit/VoteScaleWriter.java
@@ -1,20 +1,13 @@
 package com.limechain.network.protocol.grandpa.messages.commit;
 
-import com.limechain.network.protocol.warp.scale.writer.VarUint64Writer;
+import com.limechain.network.protocol.warp.scale.writer.BlockNumberWriter;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
 import io.emeraldpay.polkaj.scale.ScaleWriter;
 
 import java.io.IOException;
 
 public class VoteScaleWriter implements ScaleWriter<Vote> {
-
     private static final VoteScaleWriter INSTANCE = new VoteScaleWriter();
-
-    private final VarUint64Writer varUint64Writer;
-
-    private VoteScaleWriter() {
-        varUint64Writer = new VarUint64Writer(4);
-    }
 
     public static VoteScaleWriter getInstance() {
         return INSTANCE;
@@ -23,6 +16,6 @@ public class VoteScaleWriter implements ScaleWriter<Vote> {
     @Override
     public void write(ScaleCodecWriter writer, Vote vote) throws IOException {
         writer.writeUint256(vote.getBlockHash().getBytes());
-        varUint64Writer.write(writer, vote.getBlockNumber());
+        BlockNumberWriter.getInstance().write(writer, vote.getBlockNumber());
     }
 }

--- a/src/main/java/com/limechain/network/protocol/sync/SyncMessages.java
+++ b/src/main/java/com/limechain/network/protocol/sync/SyncMessages.java
@@ -32,7 +32,7 @@ public class SyncMessages extends StrictProtocolBinding<SyncController> {
             log.log(Level.INFO, "Received response: " + response.toString());
             return response;
         } catch (ExecutionException | TimeoutException e) {
-            log.log(Level.SEVERE, "Error while sending remote call request: ", e);
+            log.log(Level.SEVERE, "Error while sending remote block request: ", e);
             throw new ExecutionFailedException(e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -48,7 +48,7 @@ public class SyncMessages extends StrictProtocolBinding<SyncController> {
             log.log(Level.INFO, "Received state sync response " + resp.toString());
             return resp;
         } catch (ExecutionException | TimeoutException e) {
-            log.log(Level.SEVERE, "Error while sending remote call request: ", e);
+            log.log(Level.SEVERE, "Error while sending remote state request: ", e);
             throw new ExecutionFailedException(e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
@@ -1,21 +1,22 @@
 package com.limechain.network.protocol.warp.dto;
 
 import com.limechain.network.protocol.blockannounce.scale.BlockHeaderScaleWriter;
-import com.limechain.utils.scale.exceptions.ScaleEncodingException;
 import com.limechain.utils.HashUtils;
-import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import com.limechain.utils.scale.ScaleUtils;
 import io.emeraldpay.polkaj.types.Hash256;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
 
 @Setter
 @Getter
 public class BlockHeader {
+    // TODO: Make this const configurable
+    public static final int BLOCK_NUMBER_SIZE = 4;
+
+
     private Hash256 parentHash;
     private BigInteger blockNumber;
     private Hash256 stateRoot;
@@ -25,22 +26,16 @@ public class BlockHeader {
     @Override
     public String toString() {
         return "BlockHeader{" +
-                "parentHash=" + parentHash +
-                ", blockNumber=" + blockNumber +
-                ", stateRoot=" + stateRoot +
-                ", extrinsicsRoot=" + extrinsicsRoot +
-                ", digest=" + Arrays.toString(digest) +
-                '}';
+               "parentHash=" + parentHash +
+               ", blockNumber=" + blockNumber +
+               ", stateRoot=" + stateRoot +
+               ", extrinsicsRoot=" + extrinsicsRoot +
+               ", digest=" + Arrays.toString(digest) +
+               '}';
     }
 
     public Hash256 getHash() {
-        try (ByteArrayOutputStream buf = new ByteArrayOutputStream();
-             ScaleCodecWriter writer = new ScaleCodecWriter(buf)) {
-            BlockHeaderScaleWriter.getInstance().write(writer, this);
-
-            return new Hash256(HashUtils.hashWithBlake2b(buf.toByteArray()));
-        } catch (IOException e) {
-            throw new ScaleEncodingException(e);
-        }
+        byte[] scaleEncoded = ScaleUtils.Encode.encode(BlockHeaderScaleWriter.getInstance(), this);
+        return new Hash256(HashUtils.hashWithBlake2b(scaleEncoded));
     }
 }

--- a/src/main/java/com/limechain/network/protocol/warp/scale/reader/BlockHeaderReader.java
+++ b/src/main/java/com/limechain/network/protocol/warp/scale/reader/BlockHeaderReader.java
@@ -13,6 +13,8 @@ public class BlockHeaderReader implements ScaleReader<BlockHeader> {
     public BlockHeader read(ScaleCodecReader reader) {
         BlockHeader blockHeader = new BlockHeader();
         blockHeader.setParentHash(new Hash256(reader.readUint256()));
+        // NOTE: Usage of BlockNumberReader is intentionally omitted here,
+        //  since we want this to be a compact int, not a var size int
         blockHeader.setBlockNumber(BigInteger.valueOf(reader.readCompactInt()));
         blockHeader.setStateRoot(new Hash256(reader.readUint256()));
         blockHeader.setExtrinsicsRoot(new Hash256(reader.readUint256()));

--- a/src/main/java/com/limechain/network/protocol/warp/scale/reader/BlockNumberReader.java
+++ b/src/main/java/com/limechain/network/protocol/warp/scale/reader/BlockNumberReader.java
@@ -1,0 +1,31 @@
+package com.limechain.network.protocol.warp.scale.reader;
+
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import io.emeraldpay.polkaj.scale.ScaleCodecReader;
+import io.emeraldpay.polkaj.scale.ScaleReader;
+
+import java.math.BigInteger;
+
+/**
+ * A reader for a block's number for the places where this block number
+ * has been encoded as a varint instead of compact int.
+ * Varint meaning variable length integer, i.e. its byte size may vary.
+ */
+public class BlockNumberReader implements ScaleReader<BigInteger> {
+    private static final BlockNumberReader INSTANCE = new BlockNumberReader();
+
+    public static BlockNumberReader getInstance() {
+        return INSTANCE;
+    }
+
+    private final VarUint64Reader varUint64Reader;
+
+    private BlockNumberReader() {
+        this.varUint64Reader = new VarUint64Reader(BlockHeader.BLOCK_NUMBER_SIZE);
+    }
+
+    @Override
+    public BigInteger read(ScaleCodecReader reader) {
+        return varUint64Reader.read(reader);
+    }
+}

--- a/src/main/java/com/limechain/network/protocol/warp/scale/reader/JustificationReader.java
+++ b/src/main/java/com/limechain/network/protocol/warp/scale/reader/JustificationReader.java
@@ -13,8 +13,11 @@ public class JustificationReader implements ScaleReader<Justification> {
     public Justification read(ScaleCodecReader reader) {
         Justification justification = new Justification();
         justification.setRound(new UInt64Reader().read(reader));
+
+        // Target hash and target block constitute the "GRANDPA Vote":
+        // https://spec.polkadot.network/sect-finality#defn-vote
         justification.setTargetHash(new Hash256(reader.readUint256()));
-        justification.setTargetBlock(new VarUint64Reader(4).read(reader));
+        justification.setTargetBlock(BlockNumberReader.getInstance().read(reader));
 
         int precommitsCount = reader.readCompactInt();
         Precommit[] precommits = new Precommit[precommitsCount];

--- a/src/main/java/com/limechain/network/protocol/warp/scale/reader/PrecommitReader.java
+++ b/src/main/java/com/limechain/network/protocol/warp/scale/reader/PrecommitReader.java
@@ -11,7 +11,7 @@ public class PrecommitReader implements ScaleReader<Precommit> {
     public Precommit read(ScaleCodecReader reader) {
         Precommit precommit = new Precommit();
         precommit.setTargetHash(new Hash256(reader.readUint256()));
-        precommit.setTargetNumber(new VarUint64Reader(4).read(reader));
+        precommit.setTargetNumber(BlockNumberReader.getInstance().read(reader));
         precommit.setSignature(new Hash512(reader.readByteArray(64)));
         precommit.setAuthorityPublicKey(new Hash256(reader.readUint256()));
         return precommit;

--- a/src/main/java/com/limechain/network/protocol/warp/scale/writer/BlockNumberWriter.java
+++ b/src/main/java/com/limechain/network/protocol/warp/scale/writer/BlockNumberWriter.java
@@ -1,0 +1,27 @@
+package com.limechain.network.protocol.warp.scale.writer;
+
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import io.emeraldpay.polkaj.scale.ScaleWriter;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+public class BlockNumberWriter implements ScaleWriter<BigInteger> {
+    private static final BlockNumberWriter INSTANCE = new BlockNumberWriter();
+
+    private final VarUint64Writer varUint64Writer;
+
+    private BlockNumberWriter() {
+        this.varUint64Writer = new VarUint64Writer(BlockHeader.BLOCK_NUMBER_SIZE);
+    }
+
+    public static BlockNumberWriter getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void write(ScaleCodecWriter scaleCodecWriter, BigInteger blockNumber) throws IOException {
+        this.varUint64Writer.write(scaleCodecWriter, blockNumber);
+    }
+}


### PR DESCRIPTION
- extract the currently hardcoded size of 4 bytes into a const inside BlockHeader (not the best place)

- make a dedicated BlockNumberReader/Writer for handling VarUint64Reader/Writer in the concrete case of it being a block number