### PR TITLE
chore(deps): bump prometheus-metrics-exporter-httpserver and remove jackson, improve block execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,9 +39,6 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
     testImplementation("org.mockito:mockito-core:5.1.1")
 
-    // Jackson
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
-
     // CLI
     implementation("commons-cli:commons-cli:1.6.0")
 
@@ -62,7 +59,7 @@ dependencies {
     // Prometheus
     implementation("io.prometheus:prometheus-metrics-core:1.2.1")
     implementation("io.prometheus:prometheus-metrics-instrumentation-jvm:1.2.1")
-    implementation("io.prometheus:prometheus-metrics-exporter-httpserver:1.0.0")
+    implementation("io.prometheus:prometheus-metrics-exporter-httpserver:1.2.1")
 
 }
 


### PR DESCRIPTION
# Description

*Please include a summary of the changes and the related issue. Please also include relevant motivation and context,
including:*

- What does this PR do?
Update and remove dependencies.
Improve block execution logic.
- Why are these changes needed?
To get rid of dependabot alert for unused dependencies and keep up-to-date a missed one from dependabot.
Block execution seemed too slow.
- How were these changes implemented and what do they affect?

## Checklist:
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.