### PR TITLE
feat(dot/sync): Load Trie from database, fix some host APIs

### DIFF
--- a/src/main/java/com/limechain/network/protocol/sync/SyncProtocol.java
+++ b/src/main/java/com/limechain/network/protocol/sync/SyncProtocol.java
@@ -20,7 +20,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 
 public class SyncProtocol extends ProtocolHandler<SyncController> {
     public static final int MAX_REQUEST_SIZE = 1024 * 512;
-    public static final int MAX_RESPONSE_SIZE = 10 * 1024 * 1024;
+    public static final int MAX_RESPONSE_SIZE = 16 * 1024 * 1024; //16mb
 
     public SyncProtocol() {
         super(MAX_REQUEST_SIZE, MAX_RESPONSE_SIZE);

--- a/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
+++ b/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
@@ -600,7 +600,7 @@ public class CryptoHostFunctions {
      * @return a pointer-size to the SCALE encoded Result. On success it contains the 64-byte recovered public key or
      * an error type on failure.
      */
-    public int secp256k1EcdsaRecoverV1(int signature, int message) {
+    public long secp256k1EcdsaRecoverV1(int signature, int message) {
         log.log(Level.FINEST, "secp256k1EcdsaRecoverV1");
 
         byte[] ecdsaPublicKey = internalSecp256k1RecoverKey(signature, message, false);
@@ -616,21 +616,22 @@ public class CryptoHostFunctions {
      * @return a pointer-size (Definition 201) to the SCALE encoded Result value. On success it contains the 33-byte
      * recovered public key in compressed form on success or an error type on failure.
      */
-    public int secp256k1EcdsaRecoverCompressedV1(int signature, int message) {
+    public long secp256k1EcdsaRecoverCompressedV1(int signature, int message) {
         log.log(Level.FINEST, "secp256k1EcdsaRecoverCompressedV1");
 
         byte[] rawBytes = internalSecp256k1RecoverKey(signature, message, true);
-        return secp2561kScaleKeyResult(rawBytes);
+        long result = secp2561kScaleKeyResult(rawBytes);
+        return result;
     }
 
-    private int secp2561kScaleKeyResult(byte[] rawBytes) {
+    private long secp2561kScaleKeyResult(byte[] rawBytes) {
         ResultWriter resultWriter = new ResultWriter();
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
              ScaleCodecWriter scaleCodecWriter = new ScaleCodecWriter(baos)) {
 
             resultWriter.writeResult(scaleCodecWriter, true);
             resultWriter.write(scaleCodecWriter, rawBytes);
-            return runtime.writeDataToMemory(baos.toByteArray()).pointer();
+            return runtime.writeDataToMemory(baos.toByteArray()).pointerSize();
         } catch (IOException e) {
             throw new ScaleEncodingException(SCALE_ENCODING_SIGNED_MESSAGE_ERROR);
         }

--- a/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
+++ b/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
@@ -620,8 +620,7 @@ public class CryptoHostFunctions {
         log.log(Level.FINEST, "secp256k1EcdsaRecoverCompressedV1");
 
         byte[] rawBytes = internalSecp256k1RecoverKey(signature, message, true);
-        long result = secp2561kScaleKeyResult(rawBytes);
-        return result;
+        return secp2561kScaleKeyResult(rawBytes);
     }
 
     private long secp2561kScaleKeyResult(byte[] rawBytes) {

--- a/src/main/java/com/limechain/storage/DBRepository.java
+++ b/src/main/java/com/limechain/storage/DBRepository.java
@@ -104,7 +104,7 @@ public class DBRepository implements KVRepository<String, Object> {
                     e.getMessage())
             );
         }
-        log.info(String.format("finding key '%s' returns '%s'", Nibbles.fromBytes(key.getBytes()), value));
+        log.fine(String.format("finding key '%s' returns '%s'", Nibbles.fromBytes(key.getBytes()), value));
         return Optional.ofNullable(value);
     }
 
@@ -118,7 +118,7 @@ public class DBRepository implements KVRepository<String, Object> {
 
     @Override
     public synchronized boolean delete(String key) {
-        log.log(Level.INFO, String.format("deleting key '%s'", key));
+        log.log(Level.FINE, String.format("deleting key '%s'", key));
         try {
             db.delete(getPrefixedKey(key));
         } catch (RocksDBException e) {
@@ -131,7 +131,7 @@ public class DBRepository implements KVRepository<String, Object> {
 
     @Override
     public synchronized DeleteByPrefixResult deleteByPrefix(String prefix, Long limit) {
-        log.log(Level.INFO, String.format("deleting %s keys with prefix '%s'", limit == null ? "all" : limit, prefix));
+        log.log(Level.FINE, String.format("deleting %s keys with prefix '%s'", limit == null ? "all" : limit, prefix));
         List<byte[]> keysToDelete = findByPrefix(prefix, limit);
 
         keysToDelete.forEach(key -> {

--- a/src/main/java/com/limechain/storage/block/tree/BlockTree.java
+++ b/src/main/java/com/limechain/storage/block/tree/BlockTree.java
@@ -1,11 +1,11 @@
 package com.limechain.storage.block.tree;
 
-import com.limechain.network.protocol.warp.dto.BlockHeader;
-import com.limechain.runtime.Runtime;
 import com.limechain.exception.storage.BlockAlreadyExistsException;
 import com.limechain.exception.storage.BlockNodeNotFoundException;
 import com.limechain.exception.storage.BlockStorageGenericException;
 import com.limechain.exception.storage.LowerThanRootException;
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import com.limechain.runtime.Runtime;
 import com.limechain.storage.block.map.HashToRuntime;
 import io.emeraldpay.polkaj.types.Hash256;
 import lombok.Getter;
@@ -199,9 +199,7 @@ public class BlockTree {
             throw new IllegalArgumentException("Start is greater than end");
         }
 
-        // blocksInRange is the difference between the end number to start number
-        // but the difference don't include the start item that is why we add 1
-        int blocksInRange = (int) (endNode.getNumber() - startNode.getNumber() + 1);
+        int blocksInRange = (int) (endNode.getNumber() - startNode.getNumber());
         List<Hash256> hashes = new ArrayList<>(blocksInRange);
 
         BlockNode tempNode = endNode;

--- a/src/main/java/com/limechain/storage/trie/TrieStorage.java
+++ b/src/main/java/com/limechain/storage/trie/TrieStorage.java
@@ -507,6 +507,7 @@ public class TrieStorage {
         List<byte[]> childrenMerkleValues = trieNode.childrenMerkleValues();
 
         TrieNodeData storageValue = new TrieNodeData(
+                trieNode.isBranch(),
                 trieNode.partialKeyNibbles(),
                 childrenMerkleValues,
                 trieNode.isReferenceValue() ? null : trieNode.storageValue(),
@@ -556,9 +557,12 @@ public class TrieStorage {
         // utilising our knowledge of which node has a storage value anywhere in our algorithm, which is a grand
         // coincidence.
 
-        trie.insertNode(currentPath,
-                new NodeData(currentNodeData.getValue() == null ? currentNodeData.getTrieRootRef() :
-        currentNodeData.getValue(), merkleValue));
+        if (currentNodeData.isBranchNode()) {
+            trie.insertBranch(currentPath, new NodeData(null, merkleValue));
+        } else {
+            byte[] value = currentNodeData.getValue() == null ? currentNodeData.getTrieRootRef() : currentNodeData.getValue();
+            trie.insertNode(currentPath, new NodeData(value, merkleValue));
+        }
 
         // Recursively load children and construct the trie
         List<byte[]> childrenMerkleValues = currentNodeData.getChildrenMerkleValues();

--- a/src/main/java/com/limechain/storage/trie/TrieStorage.java
+++ b/src/main/java/com/limechain/storage/trie/TrieStorage.java
@@ -549,6 +549,13 @@ public class TrieStorage {
      */
     private void loadSubTrie(TrieStructure<NodeData> trie, TrieNodeData currentNodeData, byte[] merkleValue,
                              Nibbles currentPath) {
+        // TODO Known issue:
+        // We're inserting all nodes from the DB as key-value-pairs, thus marking a lot of
+        // structural branch nodes (i.e. branch nodes with no storage value) as actually having a storage value.
+        // Miraculously though, we're still able to calculate proper state root hashes since we're not actually
+        // utilising our knowledge of which node has a storage value anywhere in our algorithm, which is a grand
+        // coincidence.
+
         trie.insertNode(currentPath,
                 new NodeData(currentNodeData.getValue() == null ? currentNodeData.getTrieRootRef() :
         currentNodeData.getValue(), merkleValue));

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -126,8 +126,7 @@ public class FullSyncMachine {
             // Protobuf decode the block header
             var encodedHeader = blockData.getHeader().toByteArray();
             BlockHeader blockHeader = ScaleUtils.Decode.decode(encodedHeader, new BlockHeaderReader());
-            BigInteger blockNumber = blockHeader.getBlockNumber();
-            log.info("Block number to be executed is " + blockNumber);
+            log.info("Block number to be executed is " + blockHeader.getBlockNumber());
             byte[] encodedUnsealedHeader =
                     ScaleUtils.Encode.encode(BlockHeaderScaleWriter.getInstance()::writeUnsealed, blockHeader);
 

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -1,6 +1,7 @@
 package com.limechain.sync.fullsync;
 
 import com.google.protobuf.ByteString;
+import com.limechain.constants.GenesisBlockHash;
 import com.limechain.exception.sync.BlockExecutionException;
 import com.limechain.network.Network;
 import com.limechain.network.protocol.blockannounce.scale.BlockHeaderScaleWriter;
@@ -11,6 +12,7 @@ import com.limechain.network.protocol.warp.dto.BlockBody;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.network.protocol.warp.dto.Extrinsics;
 import com.limechain.network.protocol.warp.scale.reader.BlockHeaderReader;
+import com.limechain.rpc.server.AppBean;
 import com.limechain.runtime.Runtime;
 import com.limechain.runtime.RuntimeBuilder;
 import com.limechain.runtime.version.StateVersion;
@@ -30,6 +32,7 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * FullSyncMachine is responsible for executing full synchronization of blocks.

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -174,10 +174,15 @@ public class FullSyncMachine {
      * @return True if the block is good to execute, false otherwise.
      */
     private static boolean isBlockGoodToExecute(byte[] checkInherentsOutput) {
-        var data =
-                ScaleUtils.Decode.decode(ArrayUtils.subarray(checkInherentsOutput, 2, checkInherentsOutput.length),
-                        new ListReader<>(new PairReader<>(scr -> new String(scr.readByteArray(8)),
-                                scr -> new String(scr.readByteArray()))));
+        var data = ScaleUtils.Decode.decode(
+                ArrayUtils.subarray(checkInherentsOutput, 2, checkInherentsOutput.length),
+                new ListReader<>(
+                        new PairReader<>(
+                                scr -> new String(scr.readByteArray(8)),
+                                scr -> new String(scr.readByteArray())
+                        )
+                )
+        );
 
         boolean goodToExecute;
 
@@ -185,8 +190,7 @@ public class FullSyncMachine {
             goodToExecute = false;
         } else if (data.size() == 1) {
             //If the inherent is babeslot or auraslot, then it's an expected issue and we can proceed
-            goodToExecute =
-                    data.get(0).getValue0().equals("babeslot") || data.get(0).getValue0().equals("auraslot");
+            goodToExecute = data.get(0).getValue0().equals("babeslot") || data.get(0).getValue0().equals("auraslot");
         } else {
             goodToExecute = true;
         }

--- a/src/main/java/com/limechain/trie/AccessorHolder.java
+++ b/src/main/java/com/limechain/trie/AccessorHolder.java
@@ -1,8 +1,5 @@
 package com.limechain.trie;
 
-import com.limechain.constants.GenesisBlockHash;
-import com.limechain.rpc.server.AppBean;
-import io.emeraldpay.polkaj.types.Hash256;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -24,17 +21,6 @@ public class AccessorHolder {
             instance = new AccessorHolder();
         }
         return instance;
-    }
-
-    /**
-     * Sets the current BlockTrieAccessor instance to the trie structure of the genesis block.
-     *
-     * @return The BlockTrieAccessor instance representing the genesis block trie.
-     */
-    public BlockTrieAccessor setToGenesis() {
-        Hash256 genesisHash = AppBean.getBean(GenesisBlockHash.class).getGenesisHash();
-        this.blockTrieAccessor = new BlockTrieAccessor(genesisHash);
-        return this.blockTrieAccessor;
     }
 
     /**

--- a/src/main/java/com/limechain/trie/BlockTrieAccessor.java
+++ b/src/main/java/com/limechain/trie/BlockTrieAccessor.java
@@ -9,12 +9,17 @@ import io.emeraldpay.polkaj.types.Hash256;
  */
 public class BlockTrieAccessor extends TrieAccessor {
 
-    public BlockTrieAccessor(Hash256 blockHash) {
-        super(blockHash.getBytes());
+    /**
+     * Constructs a new BlockTrieAccessor using a {@link Hash256} object representing the state root hash.
+     *
+     * @param stateRootHash the state root hash of the block whose trie is to be accessed
+     */
+    public BlockTrieAccessor(Hash256 stateRootHash) {
+        super(stateRootHash.getBytes());
 
         BlockState blockState = BlockState.getInstance();
-        if (blockState.isInitialized() && blockState.hasHeader(blockHash)) {
-            super.lastRoot = blockState.getHeader(blockHash).getStateRoot().getBytes();
+        if (blockState.isInitialized() && blockState.hasHeader(stateRootHash)) {
+            super.lastRoot = blockState.getHeader(stateRootHash).getStateRoot().getBytes();
         }
     }
 

--- a/src/main/java/com/limechain/trie/BlockTrieAccessor.java
+++ b/src/main/java/com/limechain/trie/BlockTrieAccessor.java
@@ -10,7 +10,7 @@ import io.emeraldpay.polkaj.types.Hash256;
 public class BlockTrieAccessor extends TrieAccessor {
 
     public BlockTrieAccessor(Hash256 blockHash) {
-        super(null);
+        super(blockHash.getBytes());
 
         BlockState blockState = BlockState.getInstance();
         if (blockState.isInitialized() && blockState.hasHeader(blockHash)) {

--- a/src/main/java/com/limechain/trie/BlockTrieAccessor.java
+++ b/src/main/java/com/limechain/trie/BlockTrieAccessor.java
@@ -10,21 +10,18 @@ import io.emeraldpay.polkaj.types.Hash256;
 public class BlockTrieAccessor extends TrieAccessor {
 
     /**
-     * Constructs a new BlockTrieAccessor using a {@link Hash256} object representing the state root hash.
+     * Constructs a new BlockTrieAccessor using a {@link Hash256} block hash.
      *
-     * @param stateRootHash the state root hash of the block whose trie is to be accessed
+     * @param blockHash the block hash of the block whose trie is to be accessed
      */
-    public BlockTrieAccessor(Hash256 stateRootHash) {
-        super(stateRootHash.getBytes());
-
-        BlockState blockState = BlockState.getInstance();
-        if (blockState.isInitialized() && blockState.hasHeader(stateRootHash)) {
-            super.lastRoot = blockState.getHeader(stateRootHash).getStateRoot().getBytes();
-        }
+    public BlockTrieAccessor(Hash256 blockHash) {
+        super(BlockState.getInstance().isInitialized() ?
+                BlockState.getInstance().getHeader(blockHash).getStateRoot().getBytes() :
+                null);
     }
 
-    public BlockTrieAccessor(byte[] lastRoot) {
-        super(lastRoot);
+    public BlockTrieAccessor(byte[] stateRoot) {
+        super(stateRoot);
     }
 
 }

--- a/src/main/java/com/limechain/trie/TrieAccessor.java
+++ b/src/main/java/com/limechain/trie/TrieAccessor.java
@@ -94,7 +94,7 @@ public class TrieAccessor implements KVRepository<Nibbles, byte[]> {
      */
     @Override
     public boolean delete(Nibbles key) {
-        return initialTrie.deleteNodeAt(key);
+        return initialTrie.deleteStorageNodeAt(key);
     }
 
     @Override
@@ -130,8 +130,14 @@ public class TrieAccessor implements KVRepository<Nibbles, byte[]> {
             return new DeleteByPrefixResult(deleted.get(), false);
         }
 
-        initialTrie.deleteNodeAt(nodeHandle.getFullKey());
-        return new DeleteByPrefixResult(deleted.incrementAndGet(), true);
+        if (nodeHandle.hasStorageValue()) {
+            initialTrie.deleteStorageNodeAt(nodeHandle.getFullKey());
+            deleted.incrementAndGet();
+        }else{
+            initialTrie.deleteInternalNodeAt(nodeHandle.getFullKey());
+        }
+
+        return new DeleteByPrefixResult(deleted.get(), true);
     }
 
     public void persistUpdates() {

--- a/src/main/java/com/limechain/trie/TrieAccessor.java
+++ b/src/main/java/com/limechain/trie/TrieAccessor.java
@@ -1,7 +1,5 @@
 package com.limechain.trie;
 
-import com.limechain.constants.GenesisBlockHash;
-import com.limechain.rpc.server.AppBean;
 import com.limechain.runtime.version.StateVersion;
 import com.limechain.storage.DeleteByPrefixResult;
 import com.limechain.storage.KVRepository;
@@ -36,7 +34,7 @@ public class TrieAccessor implements KVRepository<Nibbles, byte[]> {
         this.lastRoot = trieRoot;
         this.loadedChildTries = new HashMap<>();
         this.trieStorage = TrieStorage.getInstance();
-        this.initialTrie = AppBean.getBean(GenesisBlockHash.class).getInitialSyncTrie();
+        this.initialTrie = trieStorage.loadTrieStructure(trieRoot);
     }
 
     /**

--- a/src/main/java/com/limechain/trie/TrieAccessor.java
+++ b/src/main/java/com/limechain/trie/TrieAccessor.java
@@ -151,10 +151,6 @@ public class TrieAccessor implements KVRepository<Nibbles, byte[]> {
     @Override
     public Optional<Nibbles> getNextKey(Nibbles key) {
         NodeHandle<NodeData> rootHandle = initialTrie.getRootNode().orElse(null);
-        if (rootHandle == null) {
-            return Optional.empty();
-        }
-
         return findNextKey(rootHandle, key, Nibbles.EMPTY);
     }
 

--- a/src/main/java/com/limechain/trie/structure/BranchNodeHandle.java
+++ b/src/main/java/com/limechain/trie/structure/BranchNodeHandle.java
@@ -43,7 +43,4 @@ public final class BranchNodeHandle<T> extends NodeHandle<T> {
         return new StorageNodeHandle<>(this.trieStructure, this.rawNodeIndex);
     }
 
-    public boolean clearStorageValue() {
-        return trieStructure.clearNodeValue(rawNodeIndex);
-    }
 }

--- a/src/main/java/com/limechain/trie/structure/StorageNodeHandle.java
+++ b/src/main/java/com/limechain/trie/structure/StorageNodeHandle.java
@@ -5,12 +5,27 @@ package com.limechain.trie.structure;
  * i.e. might be a branch node, might be a leaf node, doesn't matter.
  */
 public final class StorageNodeHandle<T> extends NodeHandle<T> {
+    boolean consumed;
     StorageNodeHandle(TrieStructure<T> trieStructure, int nodeIndex) {
         super(trieStructure, nodeIndex);
+        consumed = false;
     }
 
     @Override
     public boolean hasStorageValue() {
         return true;
+    }
+
+    public BranchNodeHandle<T> convertToBranchNode() {
+        if (this.consumed) {
+            throw new IllegalStateException(
+                    "Storage node has already been converted to a branch node, so this handle is invalid.");
+        }
+
+        TrieNode<T> node = this.trieStructure.getNodeAtIndexInner(this.rawNodeIndex);
+        node.hasStorageValue = false;
+
+        return new BranchNodeHandle<>(this.trieStructure, this.rawNodeIndex);
+
     }
 }

--- a/src/main/java/com/limechain/trie/structure/TrieStructure.java
+++ b/src/main/java/com/limechain/trie/structure/TrieStructure.java
@@ -52,8 +52,8 @@ public class TrieStructure<T> {
 
     /**
      * @return the number of nodes in the trie structure, both
-     *         branch (purely structural, with no storage value) and
-     *         storage nodes (leafs or branches).
+     * branch (purely structural, with no storage value) and
+     * storage nodes (leafs or branches).
      */
     public int size() {
         return this.nodes.size();
@@ -69,6 +69,7 @@ public class TrieStructure<T> {
 
     /**
      * Queries the trie at the given key.
+     *
      * @param key to look up at
      * @return the {@link Entry} at the given key
      */
@@ -76,7 +77,7 @@ public class TrieStructure<T> {
     public Entry<T> node(Nibbles key) {
         return switch (this.existingNodeInner(key)) {
             case ExistingNodeInnerResult.Found found ->
-                NodeHandle.<T>getConstructor(found.hasStorageValue()).apply(this, found.nodeIndex());
+                    NodeHandle.<T>getConstructor(found.hasStorageValue()).apply(this, found.nodeIndex());
             case ExistingNodeInnerResult.NotFound notFound -> {
                 Integer closestAncestorIndex = null;
 
@@ -92,7 +93,7 @@ public class TrieStructure<T> {
     /**
      * Insert a node at the given key.
      *
-     * @param key partial key in nibbles
+     * @param key      partial key in nibbles
      * @param nodeData data to insert
      * @implSpec if a storage value is already present for the given key, it will be overwritten
      */
@@ -113,7 +114,7 @@ public class TrieStructure<T> {
 
     /**
      * @return an iterator of all {@link TrieNode}s in no specific order,
-     *         indexed by their respective {@link TrieNodeIndex}es.
+     * indexed by their respective {@link TrieNodeIndex}es.
      */
     public Iterator<TrieNodeIndex> iteratorUnordered() {
         return this.streamUnordered().iterator();
@@ -121,6 +122,7 @@ public class TrieStructure<T> {
 
     /**
      * Convenience alternative for {@link TrieStructure#iteratorUnordered()}
+     *
      * @return the trie structure, represented as an iterable of {@link TrieNodeIndex}es in no specific order.
      * @see TrieStructure#iteratorUnordered()
      */
@@ -130,17 +132,17 @@ public class TrieStructure<T> {
 
     /**
      * @return a stream of all {@link TrieNode}s in no specific order,
-     *           indexed by their respective {@link TrieNodeIndex}es.
+     * indexed by their respective {@link TrieNodeIndex}es.
      */
     public Stream<TrieNodeIndex> streamUnordered() {
         return StreamSupport.stream(this.nodes.spliterator(), false)
-            .map(Pair::getValue0)
-            .map(TrieNodeIndex::new);
+                .map(Pair::getValue0)
+                .map(TrieNodeIndex::new);
     }
 
     /**
      * @return an iterator of all {@link TrieNode}s in lexicographic order,
-     *         indexed by their respective {@link TrieNodeIndex}es.
+     * indexed by their respective {@link TrieNodeIndex}es.
      */
     public Iterator<TrieNodeIndex> iteratorOrdered() {
         return this.streamOrdered().iterator();
@@ -148,6 +150,7 @@ public class TrieStructure<T> {
 
     /**
      * Convenience alternative for {@link TrieStructure#iteratorOrdered()}
+     *
      * @return the trie structure, represented as an iterable of {@link TrieNodeIndex}es in lexicographic order.
      * @see TrieStructure#iteratorOrdered()
      */
@@ -157,64 +160,64 @@ public class TrieStructure<T> {
 
     /**
      * @return a stream of all {@link TrieNode}s in lexicographic order,
-     *           indexed by their respective {@link TrieNodeIndex}es.
+     * indexed by their respective {@link TrieNodeIndex}es.
      */
     public Stream<TrieNodeIndex> streamOrdered() {
         return this
-            .allNodesInLexicographicOrder()
-            .map(TrieNodeIndex::new);
+                .allNodesInLexicographicOrder()
+                .map(TrieNodeIndex::new);
     }
 
     /**
      * @return a stream of all {@link TrieNode}s in lexicographic order,
-     *         indexed by their respective integer indices.
+     * indexed by their respective integer indices.
      */
     Stream<Integer> allNodesInLexicographicOrder() {
         return Stream.iterate(
-            this.rootIndex,
-            Objects::nonNull,
-            nodeIndex -> {
-                TrieNode<T> node = this.getNodeAtIndexInner(nodeIndex);
-                // Search for first direct child (as lexicographically next)
-                {
-                    Optional<Integer> firstChild = node.firstChild();
+                this.rootIndex,
+                Objects::nonNull,
+                nodeIndex -> {
+                    TrieNode<T> node = this.getNodeAtIndexInner(nodeIndex);
+                    // Search for first direct child (as lexicographically next)
+                    {
+                        Optional<Integer> firstChild = node.firstChild();
 
-                    if (firstChild.isPresent()) {
-                        return firstChild.get();
-                    }
-                }
-
-                // If no children, then search for direct siblings
-                {
-                    Integer nextSibling = this.nextSibling(nodeIndex);
-                    if (nextSibling != null) {
-                        return nextSibling;
-                    }
-                }
-
-                // If no direct siblings either, then go up the tree and repeat for parent
-                TrieNode.Parent parent = node.parent;
-                while (parent != null) {
-                    int idx = parent.parentNodeIndex();
-                    Integer nextSibling = this.nextSibling(idx);
-
-                    if (nextSibling != null) {
-                        return nextSibling;
+                        if (firstChild.isPresent()) {
+                            return firstChild.get();
+                        }
                     }
 
-                    parent = this.getNodeAtIndexInner(idx).parent;
-                }
+                    // If no children, then search for direct siblings
+                    {
+                        Integer nextSibling = this.nextSibling(nodeIndex);
+                        if (nextSibling != null) {
+                            return nextSibling;
+                        }
+                    }
 
-                // At the end, no nodes should be left.
-                return null;
-            }
+                    // If no direct siblings either, then go up the tree and repeat for parent
+                    TrieNode.Parent parent = node.parent;
+                    while (parent != null) {
+                        int idx = parent.parentNodeIndex();
+                        Integer nextSibling = this.nextSibling(idx);
+
+                        if (nextSibling != null) {
+                            return nextSibling;
+                        }
+
+                        parent = this.getNodeAtIndexInner(idx).parent;
+                    }
+
+                    // At the end, no nodes should be left.
+                    return null;
+                }
         );
     }
 
     /**
      * @param nodeIndex index of a node
      * @return the index of the next sibling of the node,
-     *         null if it's the last (lexicographically speaking) child if its parent, thus no next sibling exists.
+     * null if it's the last (lexicographically speaking) child if its parent, thus no next sibling exists.
      */
     private @Nullable Integer nextSibling(int nodeIndex) {
         var parentIndexPair = this.getNodeAtIndexInner(nodeIndex).parent;
@@ -245,8 +248,8 @@ public class TrieStructure<T> {
         return switch (this.existingNodeInner(key)) {
             case ExistingNodeInnerResult.Found found -> Optional.of(
                     NodeHandle
-                        .<T>getConstructor(found.hasStorageValue())
-                        .apply(this, found.nodeIndex())
+                            .<T>getConstructor(found.hasStorageValue())
+                            .apply(this, found.nodeIndex())
             );
             case ExistingNodeInnerResult.NotFound ignored -> Optional.empty();
         };
@@ -362,6 +365,7 @@ public class TrieStructure<T> {
 
     /**
      * Returns the user data of the node by its index.
+     *
      * @param nodeIndex the index of the existing node
      * @return the user data of the node with the index provided
      */
@@ -372,6 +376,7 @@ public class TrieStructure<T> {
 
     /**
      * Returns a handle for the node at the given index.
+     *
      * @param nodeIndex the index of the existing node
      * @return a node handle for the node
      */
@@ -403,20 +408,20 @@ public class TrieStructure<T> {
         nodePath.add(targetNodeIndex); // add target to the end
 
         Stream<Nibble> nibblesStream = nodePath
-            .stream()
-            .flatMap(n -> {
-                TrieNode<T> node = this.getNodeAtIndexInner(n);
+                .stream()
+                .flatMap(n -> {
+                    TrieNode<T> node = this.getNodeAtIndexInner(n);
 
-                Stream<Nibble> childIndex = Stream.ofNullable(
-                    node.parent == null
-                        ? null
-                        : node.parent.childIndexWithinParent()
-                );
+                    Stream<Nibble> childIndex = Stream.ofNullable(
+                            node.parent == null
+                                    ? null
+                                    : node.parent.childIndexWithinParent()
+                    );
 
-                Nibbles partialKey = node.partialKey.copy();
+                    Nibbles partialKey = node.partialKey.copy();
 
-                return Stream.concat(childIndex, partialKey.stream());
-            });
+                    return Stream.concat(childIndex, partialKey.stream());
+                });
 
         return nibblesStream.collect(NibblesCollector.toNibbles());
     }
@@ -424,7 +429,7 @@ public class TrieStructure<T> {
     /**
      * @param targetNodeIndex index of the target node
      * @return the indices to traverse to reach {@code target} from root, not including {@code target} itself.
-     *         So if {@code target} is root, returns an empty deque.
+     * So if {@code target} is root, returns an empty deque.
      * @throws NullPointerException if targetNodeIndex is not a valid index
      */
     Deque<Integer> nodePath(int targetNodeIndex) {
@@ -445,9 +450,9 @@ public class TrieStructure<T> {
      * Everything is compared for equality except for the {@link TrieNode#userData}s.
      *
      * @implNote This method first compares the sizes of the two trie structures,
-     *           and if they don't match, it early returns false.
-     *           Otherwise, it performs the expensive operation of traversing both tries
-     *           in order to identify a potential mismatch.
+     * and if they don't match, it early returns false.
+     * Otherwise, it performs the expensive operation of traversing both tries
+     * in order to identify a potential mismatch.
      */
     public <U> boolean structurallyEquals(TrieStructure<U> other) {
         if (this.nodes.size() != other.nodes.size()) {
@@ -479,9 +484,9 @@ public class TrieStructure<T> {
 
                 boolean bothParentsNull = thisNodeParent == null || otherNodeParent == null;
                 boolean bothParentsNotNullAndSameChildIndices =
-                    thisNodeParent != null
-                    && otherNodeParent != null
-                    && thisNodeParent.childIndexWithinParent().equals(otherNodeParent.childIndexWithinParent());
+                        thisNodeParent != null
+                        && otherNodeParent != null
+                        && thisNodeParent.childIndexWithinParent().equals(otherNodeParent.childIndexWithinParent());
 
                 if (!(bothParentsNull || bothParentsNotNullAndSameChildIndices)) {
                     return false;
@@ -499,6 +504,37 @@ public class TrieStructure<T> {
             case ExistingNodeInnerResult.NotFound ignored -> false;
             case ExistingNodeInnerResult.Found found -> clearNodeValue(found.nodeIndex);
         };
+    }
+
+    public int clearNodeValueRecursive(TrieNodeIndex nodeIndex, Long limit) {
+        return clearNodeValueRecursive(nodeIndex.getValue(), limit);
+    }
+
+    public int clearNodeValueRecursive(int nodeIndex, Long limit) {
+        int deleted = 0;
+        TrieNode<T> trieNode = getNodeAtIndexInner(nodeIndex);
+
+        TrieNode.Parent parent = trieNode.parent;
+        if (parent == null) {
+            nodes.remove(nodeIndex);
+            deleted++;
+            return deleted;
+        }
+        TrieNode<T> parentNode = getNodeAtIndexInner(parent.parentNodeIndex());
+
+        for (Integer childrenIndex : trieNode.childrenIndices) {
+            if (limit != null && deleted >= limit) {
+                return deleted;
+            }
+            if (childrenIndex != null) {
+                deleted += clearNodeValueRecursive(childrenIndex, limit);
+            }
+        }
+
+        parentNode.childrenIndices[parent.childIndexWithinParent().asInt()] = null;
+        nodes.remove(nodeIndex);
+
+        return deleted;
     }
 
     public boolean clearNodeValue(TrieNodeIndex nodeIndex) {

--- a/src/main/java/com/limechain/trie/structure/TrieStructure.java
+++ b/src/main/java/com/limechain/trie/structure/TrieStructure.java
@@ -503,7 +503,7 @@ public class TrieStructure<T> {
     public boolean deleteNodeAt(Nibbles key) {
         return switch (existingNodeInner(key)) {
             case ExistingNodeInnerResult.NotFound ignored -> false;
-            case ExistingNodeInnerResult.Found found -> clearNodeValue(found.nodeIndex);
+            case ExistingNodeInnerResult.Found found -> deleteNodeAt(found.nodeIndex);
         };
     }
 
@@ -535,7 +535,7 @@ public class TrieStructure<T> {
         nodes.remove(nodeIndex);
     }
 
-    private boolean clearNodeValue(int nodeIndex) {
+    private boolean deleteNodeAt(int nodeIndex) {
         TrieNode<T> trieNode = getNodeAtIndexInner(nodeIndex);
 
         TrieNode.Parent parent = trieNode.parent;

--- a/src/main/java/com/limechain/trie/structure/TrieStructure.java
+++ b/src/main/java/com/limechain/trie/structure/TrieStructure.java
@@ -94,6 +94,9 @@ public class TrieStructure<T> {
     /**
      * Insert a branch node at the given key.
      *
+     * Warning: This method is only to be used when loading a Trie from the database.
+     * If you need to use this method for other purposes, you are probably doing something wrong.
+     *
      * @param key      partial key in nibbles
      * @param nodeData data to insert
      * @implSpec if a storage value is already present for the given key, it will be overwritten
@@ -528,7 +531,7 @@ public class TrieStructure<T> {
     public boolean deleteStorageNodeAt(Nibbles key) {
         return switch (node(key)){
             case StorageNodeHandle<T> storageNodeHandle -> {
-                deleteStorageNodeAt(storageNodeHandle.rawNodeIndex);
+                deleteNodeAt(storageNodeHandle.rawNodeIndex);
                 yield true;
             }
             case BranchNodeHandle<T> branchNodeHandle -> false;
@@ -539,7 +542,7 @@ public class TrieStructure<T> {
     public boolean deleteInternalNodeAt(Nibbles key) {
         Entry<T> entry = node(key);
         if(!(entry instanceof Vacant<T>)){
-            deleteStorageNodeAt(entry.asNodeHandle().rawNodeIndex);
+            deleteNodeAt(entry.asNodeHandle().rawNodeIndex);
             return true;
         }
         return false;
@@ -579,7 +582,7 @@ public class TrieStructure<T> {
         }
     }
 
-    private void deleteStorageNodeAt(int nodeIndex) {
+    private void deleteNodeAt(int nodeIndex) {
         TrieNode<T> trieNode = getNodeAtIndexInner(nodeIndex);
 
         TrieNode.Parent parent = trieNode.parent;

--- a/src/main/java/com/limechain/trie/structure/TrieStructure.java
+++ b/src/main/java/com/limechain/trie/structure/TrieStructure.java
@@ -563,9 +563,10 @@ public class TrieStructure<T> {
             parentNode.childrenIndices[parent.childIndexWithinParent().asInt()] = null;
             nodes.remove(nodeIndex);
 
-            if (parentChildren == 1 && !parentNode.hasStorageValue) {
-                return clearNodeValue(parent.parentNodeIndex());
-            } else if (parentChildren == 2) {
+            //A leaf node being single child of a it's parent is invalid scenario.
+            assert !(parentChildren == 1 && !parentNode.hasStorageValue) : "Unreachable state.";
+
+            if (parentChildren == 2) {
                 TrieNode.Parent grandparent = parentNode.parent;
                 getNodeAtIndexInner(grandparent.parentNodeIndex()).childrenIndices[grandparent.childIndexWithinParent()
                         .asInt()] = mergeParentIntoChild(parentNode);

--- a/src/main/java/com/limechain/trie/structure/TrieStructure.java
+++ b/src/main/java/com/limechain/trie/structure/TrieStructure.java
@@ -510,7 +510,7 @@ public class TrieStructure<T> {
         return clearNodeValueRecursive(nodeIndex.getValue(), limit);
     }
 
-    public int clearNodeValueRecursive(int nodeIndex, Long limit) {
+    private int clearNodeValueRecursive(int nodeIndex, Long limit) {
         int deleted = 0;
         TrieNode<T> trieNode = getNodeAtIndexInner(nodeIndex);
 
@@ -541,7 +541,7 @@ public class TrieStructure<T> {
         return clearNodeValue(nodeIndex.getValue());
     }
 
-    boolean clearNodeValue(int nodeIndex) {
+    private boolean clearNodeValue(int nodeIndex) {
         TrieNode<T> trieNode = getNodeAtIndexInner(nodeIndex);
 
         TrieNode.Parent parent = trieNode.parent;

--- a/src/main/java/com/limechain/trie/structure/database/InsertTrieBuilder.java
+++ b/src/main/java/com/limechain/trie/structure/database/InsertTrieBuilder.java
@@ -47,7 +47,7 @@ public class InsertTrieBuilder {
     private static InsertTrieNode prepareForInsert(TrieStructure<NodeData> trieStructure, TrieNodeIndex nodeIndex) {
         NodeData userData = trieStructure.getUserDataAtIndex(nodeIndex);
         if (userData == null || userData.getMerkleValue() == null) {
-            return null;
+            throw new TrieBuildException("Trying to save node without merkle value");
         }
 
         NodeHandle<NodeData> nodeHandle = trieStructure.nodeHandleAtIndex(nodeIndex);

--- a/src/main/java/com/limechain/trie/structure/database/InsertTrieBuilder.java
+++ b/src/main/java/com/limechain/trie/structure/database/InsertTrieBuilder.java
@@ -60,6 +60,7 @@ public class InsertTrieBuilder {
                 .startsWith(Nibbles.fromBytes(":child_storage:".getBytes()));
 
         return new InsertTrieNode(
+                !nodeHandle.hasStorageValue(),
                 userData.getValue(),
                 userData.getMerkleValue(),
                 childrenMerkleValues(nodeHandle),

--- a/src/main/java/com/limechain/trie/structure/node/InsertTrieNode.java
+++ b/src/main/java/com/limechain/trie/structure/node/InsertTrieNode.java
@@ -18,7 +18,8 @@ import java.util.Objects;
  * @param partialKeyNibbles    A list of nibbles representing the partial key associated with this trie node.
  * @param isReferenceValue     Notes if the value stored is a reference to another node
  */
-public record InsertTrieNode(byte[] storageValue, byte[] merkleValue, List<byte[]> childrenMerkleValues,
+public record InsertTrieNode(boolean isBranch, byte[] storageValue, byte[] merkleValue,
+                             List<byte[]> childrenMerkleValues,
                              Nibbles partialKeyNibbles, boolean isReferenceValue) {
 
     @Override
@@ -26,11 +27,12 @@ public record InsertTrieNode(byte[] storageValue, byte[] merkleValue, List<byte[
         if (obj == this) return true;
         if (obj == null || obj.getClass() != this.getClass()) return false;
         var that = (InsertTrieNode) obj;
-        return Arrays.equals(this.storageValue, that.storageValue) &&
-                Arrays.equals(this.merkleValue, that.merkleValue) &&
-                Objects.equals(this.childrenMerkleValues, that.childrenMerkleValues) &&
-                Objects.equals(this.partialKeyNibbles, that.partialKeyNibbles) &&
-                this.isReferenceValue == that.isReferenceValue;
+        return this.isBranch == that.isBranch
+               && Arrays.equals(this.storageValue, that.storageValue) &&
+               Arrays.equals(this.merkleValue, that.merkleValue) &&
+               Objects.equals(this.childrenMerkleValues, that.childrenMerkleValues) &&
+               Objects.equals(this.partialKeyNibbles, that.partialKeyNibbles) &&
+               this.isReferenceValue == that.isReferenceValue;
     }
 
     @Override
@@ -42,10 +44,11 @@ public record InsertTrieNode(byte[] storageValue, byte[] merkleValue, List<byte[
     @Override
     public String toString() {
         return "InsertTrieNode[" +
-                "storageValue=" + Arrays.toString(storageValue) + ", " +
-                "merkleValue=" + Arrays.toString(merkleValue) + ", " +
-                "childrenMerkleValues=" + childrenMerkleValues + ", " +
-                "partialKeyNibbles=" + partialKeyNibbles + ", " +
-                "isReferenceValue=" + isReferenceValue + ']';
+               "isBranch=" + isBranch + ", " +
+               "storageValue=" + Arrays.toString(storageValue) + ", " +
+               "merkleValue=" + Arrays.toString(merkleValue) + ", " +
+               "childrenMerkleValues=" + childrenMerkleValues + ", " +
+               "partialKeyNibbles=" + partialKeyNibbles + ", " +
+               "isReferenceValue=" + isReferenceValue + ']';
     }
 }

--- a/src/main/java/com/limechain/trie/structure/node/TrieNodeData.java
+++ b/src/main/java/com/limechain/trie/structure/node/TrieNodeData.java
@@ -18,6 +18,7 @@ import java.util.List;
 @EqualsAndHashCode
 @Getter
 public class TrieNodeData implements Serializable {
+    private boolean isBranchNode;
     private Nibbles partialKey;
     private List<byte[]> childrenMerkleValues;
     private byte[] value;
@@ -27,7 +28,8 @@ public class TrieNodeData implements Serializable {
     @Override
     public String toString() {
         return "TrieNodeData{" +
-               "partialKey=" + partialKey +
+               "isBranchNode=" + isBranchNode +
+               ", partialKey=" + partialKey +
                ", childrenMerkleValues=" + childrenMerkleValues +
                ", value=" + Arrays.toString(value) +
                ", trieRootRef=" + Arrays.toString(trieRootRef) +

--- a/src/test/java/com/limechain/runtime/hostapi/CryptoHostFunctionsTest.java
+++ b/src/test/java/com/limechain/runtime/hostapi/CryptoHostFunctionsTest.java
@@ -454,7 +454,7 @@ class CryptoHostFunctionsTest {
                             EcdsaUtils.recoverPublicKeyFromSignature(signData, hashedMessage, false))
                     .thenReturn(ecdsaKeyPair.getSecond().raw());
 
-            int result = cryptoHostFunctions.secp256k1EcdsaRecoverV1(signaturePosition, keyPosition);
+            long result = cryptoHostFunctions.secp256k1EcdsaRecoverV1(signaturePosition, keyPosition);
 
             assertEquals(returnPointer.pointer(), result);
         }
@@ -471,7 +471,7 @@ class CryptoHostFunctionsTest {
                             EcdsaUtils.recoverPublicKeyFromSignature(signData, hashedMessage, true))
                     .thenReturn(ecdsaKeyPair.getSecond().raw());
 
-            int result = cryptoHostFunctions.secp256k1EcdsaRecoverCompressedV1(signaturePosition, keyPosition);
+            long result = cryptoHostFunctions.secp256k1EcdsaRecoverCompressedV1(signaturePosition, keyPosition);
 
             assertEquals(returnPointer.pointer(), result);
         }

--- a/src/test/java/com/limechain/storage/trie/TrieStorageTest.java
+++ b/src/test/java/com/limechain/storage/trie/TrieStorageTest.java
@@ -50,6 +50,7 @@ class TrieStorageTest {
 
         final TrieNodeData trieNodeData =
                 new TrieNodeData(
+                        false,
                         key,
                         IntStream.range(0, 16).mapToObj(__ -> (byte[]) null).toList(),
                         expectedValue,
@@ -107,6 +108,7 @@ class TrieStorageTest {
 
         // Simulate a trie node that does not directly match the provided key
         TrieNodeData nonMatchingTrieNodeData = new TrieNodeData(
+                false,
                 Nibbles.fromHexString("01"), // Partial key that does not match the test key
                 IntStream.range(0, 16).mapToObj(__ -> (byte[]) null).toList(),
                 null,
@@ -134,6 +136,7 @@ class TrieStorageTest {
 
         // Setup a mock TrieNodeData that represents the next key
         TrieNodeData nextKeyNode = new TrieNodeData(
+                false,
                 actualKey,
                 new ArrayList<>(), "nextValue".getBytes(), new byte[0], (byte) 0);
 

--- a/src/test/java/com/limechain/trie/TrieAccessorTest.java
+++ b/src/test/java/com/limechain/trie/TrieAccessorTest.java
@@ -132,7 +132,7 @@ class TrieAccessorTest {
     }
 
     private void removeNode(Nibbles key) {
-        fullTrie.removeValueAtKey(key);
+        fullTrie.deleteNodeAt(key);
         trieAccessor.delete(key);
     }
 

--- a/src/test/java/com/limechain/trie/TrieAccessorTest.java
+++ b/src/test/java/com/limechain/trie/TrieAccessorTest.java
@@ -132,7 +132,7 @@ class TrieAccessorTest {
     }
 
     private void removeNode(Nibbles key) {
-        fullTrie.deleteNodeAt(key);
+        fullTrie.deleteStorageNodeAt(key);
         trieAccessor.delete(key);
     }
 


### PR DESCRIPTION
# Description

- What does this PR do?
- [x] Implement logic for loading the trie structure from the database
- [x] Fix ext_crypto_secp256k1_ecdsa_recover host api to unblock block execution
- [x] Fix the ext_storage_clear_prefix host api to unblock block execution
- [x] Fix the ext_storage_next_key host api to unblock block execution
- Why are these changes needed?
    - The logic to be able to load the state trie from the database is required to be able to set a given block state before executing a block.
    - The other changes were required, because they were blocking the block execution and full sync
- How were these changes implemented and what do they affect?


Fixes #352 

## Checklist:
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.