### PR TITLE
fix: use decoded value if it's hashed

### DIFF
--- a/src/main/java/com/limechain/trie/decoded/TrieProofLoader.java
+++ b/src/main/java/com/limechain/trie/decoded/TrieProofLoader.java
@@ -1,7 +1,7 @@
 package com.limechain.trie.decoded;
 
-import com.limechain.trie.decoded.decoder.TrieDecoder;
 import com.limechain.exception.trie.TrieDecoderException;
+import com.limechain.trie.decoded.decoder.TrieDecoder;
 import lombok.experimental.UtilityClass;
 import org.apache.tomcat.util.buf.HexUtils;
 
@@ -53,6 +53,11 @@ public class TrieProofLoader {
             // it becomes used with a database in the future, we set the dirty flag
             // to true.
             decodedChild.setDirty(true);
+
+            if(decodedChild.isValueHashed() &&
+               digestToEncoding.containsKey(HexUtils.toHexString(decodedChild.getStorageValue()))){
+                decodedChild.setStorageValue(digestToEncoding.get(HexUtils.toHexString(decodedChild.getStorageValue())));
+            }
 
             Node[] children = node.getChildren();
             children[i] = decodedChild;

--- a/src/main/java/com/limechain/trie/decoded/TrieProofLoader.java
+++ b/src/main/java/com/limechain/trie/decoded/TrieProofLoader.java
@@ -54,7 +54,7 @@ public class TrieProofLoader {
             // to true.
             decodedChild.setDirty(true);
 
-            if(decodedChild.isValueHashed() &&
+            if (decodedChild.isValueHashed() &&
                digestToEncoding.containsKey(HexUtils.toHexString(decodedChild.getStorageValue()))){
                 decodedChild.setStorageValue(digestToEncoding.get(HexUtils.toHexString(decodedChild.getStorageValue())));
             }


### PR DESCRIPTION
# Description

- What does this PR do?
Fix merkle proof decoding.
- Why are these changes needed?
Runtime was failing to load after warp sync
- How were these changes implemented and what do they affect?
Update the value of the trie node with the decoded value we receive in the proofs

Fixes #367

## Checklist:
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.