### PR TITLE
chore(deps): bump org.web3j:crypto from '5.0.0' to '4.11.3'

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ java.sourceCompatibility = JavaVersion.VERSION_21
 repositories {
     mavenCentral()
     maven("https://jitpack.io")
+    maven("https://artifacts.consensys.net/public/maven/maven/")
 }
 
 dependencies {
@@ -24,7 +25,7 @@ dependencies {
     implementation("org.rocksdb:rocksdbjni:9.1.1")
     compileOnly("org.projectlombok:lombok:1.18.32")
     implementation("org.projectlombok:lombok:1.18.32")
-    implementation("org.web3j:crypto:5.0.0")
+    implementation("org.web3j:crypto:4.11.3")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.3")


### PR DESCRIPTION
# Description

The version 5.0.0 is 4 years old, and a error on web3j's side and discontinued version. Updating to latest supported one.

## Checklist:
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.