### PR TITLE
refactor(block execution)!: showcase a MWE with explicit `Context` object

### DIFF
--- a/src/main/java/com/limechain/client/FullNode.java
+++ b/src/main/java/com/limechain/client/FullNode.java
@@ -70,8 +70,7 @@ public class FullNode implements HostNode {
         if (db == null) {
             throw new IllegalStateException("Database is not initialized");
         }
-        TrieStorage trieStorage = TrieStorage.getInstance();
-        trieStorage.initialize(db);
+        TrieStorage trieStorage = AppBean.getBean(TrieStorage.class);
         // if: database has some persisted storage
         if (db.find(new BlockStateHelper().headerHashKey(BigInteger.ZERO)).isPresent()) {
             BlockState.getInstance().initialize(db);//Initialize BlockState from already existing data

--- a/src/main/java/com/limechain/rpc/config/CommonConfig.java
+++ b/src/main/java/com/limechain/rpc/config/CommonConfig.java
@@ -12,6 +12,7 @@ import com.limechain.rpc.server.UnsafeInterceptor;
 import com.limechain.storage.DBInitializer;
 import com.limechain.storage.DBRepository;
 import com.limechain.storage.KVRepository;
+import com.limechain.storage.trie.TrieStorage;
 import com.limechain.sync.fullsync.FullSyncMachine;
 import com.limechain.sync.warpsync.SyncedState;
 import com.limechain.sync.warpsync.WarpSyncMachine;
@@ -54,6 +55,11 @@ public class CommonConfig {
                 hostConfig.getChain(), hostConfig.isDbRecreate());
         SyncedState.getInstance().setRepository(repository);
         return repository;
+    }
+
+    @Bean
+    public TrieStorage trieStorage(KVRepository<String, Object> repository) {
+        return new TrieStorage(repository);
     }
 
     @Bean

--- a/src/main/java/com/limechain/rpc/methods/childstate/ChildStateRPCImpl.java
+++ b/src/main/java/com/limechain/rpc/methods/childstate/ChildStateRPCImpl.java
@@ -120,8 +120,9 @@ public class ChildStateRPCImpl {
     }
 
     private byte[] getChildMerkle(Hash256 blockHash, Nibbles childKey) {
+        Hash256 mainTrieMerkle = blockState.getBlockStateRoot(blockHash);
         return trieStorage
-                .getByKeyFromBlock(blockHash, Nibbles.fromBytes(":child_storage:default:".getBytes(StandardCharsets.US_ASCII)).addAll(childKey))
+                .getByKeyFromMerkle(mainTrieMerkle.getBytes(), Nibbles.fromBytes(":child_storage:default:".getBytes(StandardCharsets.US_ASCII)).addAll(childKey))
                 .map(NodeData::getValue)
                 .orElse(null);
     }

--- a/src/main/java/com/limechain/rpc/methods/childstate/ChildStateRPCImpl.java
+++ b/src/main/java/com/limechain/rpc/methods/childstate/ChildStateRPCImpl.java
@@ -6,6 +6,7 @@ import com.limechain.trie.structure.database.NodeData;
 import com.limechain.trie.structure.nibble.Nibbles;
 import com.limechain.utils.StringUtils;
 import io.emeraldpay.polkaj.types.Hash256;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.lang.reflect.Array;
@@ -15,8 +16,9 @@ import java.util.List;
 
 @Service
 public class ChildStateRPCImpl {
+    @Autowired
+    private TrieStorage trieStorage;
 
-    private final TrieStorage trieStorage = TrieStorage.getInstance();
     private final BlockState blockState = BlockState.getInstance();
 
     /**

--- a/src/main/java/com/limechain/rpc/methods/state/StateRPCImpl.java
+++ b/src/main/java/com/limechain/rpc/methods/state/StateRPCImpl.java
@@ -1,6 +1,7 @@
 package com.limechain.rpc.methods.state;
 
 import com.limechain.rpc.methods.state.dto.StorageChangeSet;
+import com.limechain.rpc.server.AppBean;
 import com.limechain.runtime.Runtime;
 import com.limechain.storage.block.BlockState;
 import com.limechain.storage.trie.TrieStorage;
@@ -10,6 +11,7 @@ import com.limechain.trie.structure.database.NodeData;
 import com.limechain.trie.structure.nibble.Nibbles;
 import com.limechain.utils.StringUtils;
 import io.emeraldpay.polkaj.types.Hash256;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.lang.reflect.Array;
@@ -24,7 +26,9 @@ import java.util.Optional;
 @Service
 public class StateRPCImpl {
 
-    private final TrieStorage trieStorage = TrieStorage.getInstance();
+    @Autowired
+    private TrieStorage trieStorage;
+
     private final BlockState blockState = BlockState.getInstance();
 
     /**

--- a/src/main/java/com/limechain/runtime/hostapi/MiscellaneousHostFunctions.java
+++ b/src/main/java/com/limechain/runtime/hostapi/MiscellaneousHostFunctions.java
@@ -4,6 +4,8 @@ import com.limechain.exception.scale.ScaleEncodingException;
 import com.limechain.runtime.Runtime;
 import com.limechain.runtime.RuntimeBuilder;
 import com.limechain.runtime.hostapi.dto.RuntimePointerSize;
+import com.limechain.runtime.version.scale.RuntimeVersionWriter;
+import com.limechain.utils.scale.ScaleUtils;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -11,7 +13,6 @@ import lombok.extern.java.Log;
 import org.apache.tomcat.util.buf.HexUtils;
 import org.springframework.lang.Nullable;
 import org.wasmer.ImportObject;
-import org.wasmer.Module;
 import org.wasmer.Type;
 
 import java.io.ByteArrayOutputStream;
@@ -108,10 +109,11 @@ public class MiscellaneousHostFunctions {
         byte[] versionOption;
 
         try {
-            // TODO: Refactor using RuntimeBuilder... when we're sure it works properly
-            Module module = new Module(wasmBlob);
-            Runtime newRuntime = new Runtime(module, RuntimeBuilder.DEFAULT_HEAP_PAGES);
-            byte[] runtimeVersionData = newRuntime.call("Core_version");
+            byte[] runtimeVersionData =
+                ScaleUtils.Encode.encode(
+                    new RuntimeVersionWriter(),
+                    new RuntimeBuilder().buildRuntime(wasmBlob).getVersion());
+
             versionOption = scaleEncodedOption(runtimeVersionData);
         } catch (UnsatisfiedLinkError e) {
             log.log(Level.SEVERE, "Error loading wasm module: " + e.getMessage());

--- a/src/main/java/com/limechain/runtime/hostapi/TrieHostFunctions.java
+++ b/src/main/java/com/limechain/runtime/hostapi/TrieHostFunctions.java
@@ -254,7 +254,7 @@ public class TrieHostFunctions {
 
     @Getter
     @AllArgsConstructor
-    enum HashFunction {
+    public enum HashFunction {
         BLAKE2B(HashUtils::hashWithBlake2b), KECCAK256(HashUtils::hashWithKeccak256);
 
         private static final byte[] EMPTY_BLAKE2_TRIE_MERKLE_VALUE =
@@ -273,7 +273,7 @@ public class TrieHostFunctions {
         }
     }
 
-    record TrieRootCalculator(HashFunction hashFunction, StateVersion stateVersion) {
+    public record TrieRootCalculator(HashFunction hashFunction, StateVersion stateVersion) {
         public byte[] trieRoot(List<Pair<byte[], byte[]>> entries) {
             Map<ByteString, ByteString> entriesMap = entries.stream().collect(
                     Collectors.toMap(p -> ByteString.copyFrom(p.getValue0()), p -> ByteString.copyFrom(p.getValue1())));
@@ -301,7 +301,7 @@ public class TrieHostFunctions {
     }
 
     @AllArgsConstructor
-    class ArgParser {
+    public class ArgParser {
         private final List<Number> args;
 
         public StateVersion parseStateVersion(int index) {

--- a/src/main/java/com/limechain/runtime/research/hybrid/WasmRuntimeInstance.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/WasmRuntimeInstance.java
@@ -1,0 +1,117 @@
+package com.limechain.runtime.research.hybrid;
+
+import com.limechain.runtime.hostapi.WasmExports;
+import com.limechain.runtime.hostapi.dto.RuntimePointerSize;
+import com.limechain.runtime.research.hybrid.allocator.Allocator;
+import com.limechain.runtime.research.hybrid.allocator.freeingbumpheap.FreeingBumpHeapAllocator;
+import com.limechain.runtime.research.hybrid.context.Context;
+import com.limechain.runtime.research.hybrid.hostapi.MinimalHostapiImpl;
+import com.limechain.runtime.research.hybrid.hostapi.SharedMemory;
+import com.limechain.runtime.research.hybrid.memory.WasmMemory;
+import com.limechain.runtime.version.RuntimeVersion;
+import lombok.extern.java.Log;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.wasmer.ImportObject;
+import org.wasmer.Imports;
+import org.wasmer.Instance;
+import org.wasmer.Memory;
+import org.wasmer.Module;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+
+@Log
+public class WasmRuntimeInstance {
+    Module module; // used to open/close all its instances
+
+    Instance instance;
+    Context context;
+
+    Allocator allocator;
+
+    private RuntimeVersion version;
+
+    // TODO: Reconsider whether `Context` should be a constructor argument or (dependency injected)
+    //                       OR an argument of `call()` (dependency parameterized)
+    //  The former necessitates the explicit passing of a context for every build of the runtime (we can't build the underlying module only - we always instantiate and tie the instance to the context)
+    //          - In more lightweight cases (i.e. only build to fetch the version), we'll have to explicitly provide a "partial" context; "partial" meaning with some of the services inside being null (or partially implemented) since we know they are not going to be used)
+    //  The latter necessitates the explicit re-instantiating of the underlying `org.wasmer.Instance` for each RuntimeAPI call (they do that in Gossamer), but allows for easy caching of the compiled wasm module (thus we can pass that around, e.g. in the BlockState) and instantiate with a context only when invocation is necessary
+    public WasmRuntimeInstance(Module module, Context context) {
+        this.context = context;
+
+        SharedMemory sharedMemory = new SharedMemory(null, null);
+        context.setSharedMemory(sharedMemory);
+
+        // getting imports
+        ImportObject.MemoryImport memory = new ImportObject.MemoryImport("env", 22, false);
+        List<ImportObject> functionImports = new MinimalHostapiImpl(context).getFunctionImports(); // NOTE: We could even inject the "Implementation" object from outside, if we'd want more granularity
+
+        List<ImportObject> imports = new ArrayList<>(functionImports);
+        imports.add(memory);
+
+        this.instance = module.instantiate(Imports.from(imports, module));
+        this.allocator = new FreeingBumpHeapAllocator(this.getHeapBase());
+        sharedMemory.setMemory(new WasmMemory(getMemory()));
+        sharedMemory.setAllocator(this.allocator);
+    }
+
+    /**
+     * Calls an exported runtime function with no parameters.
+     * @param functionName the name of the function
+     * @return the SCALE encoded response
+     */
+    @Nullable
+    public byte[] call(String functionName) {
+        return callInner(functionName, new RuntimePointerSize(0, 0));
+    }
+
+    /**
+     * Calls an exported runtime function with parameters.
+     * @param functionName the name of the function
+     * @param parameter the SCALE encoded tuple of parameters
+     * @return the SCALE encoded response
+     */
+    @Nullable
+    public byte[] call(String functionName, @NotNull byte[] parameter) {
+        return callInner(functionName, context.getSharedMemory().writeData(parameter));
+    }
+
+    @Nullable
+    private byte[] callInner(String functionName, RuntimePointerSize parameterPtrSize) {
+        log.log(Level.INFO, "Making a runtime call: " + functionName);
+        Object[] response = instance.exports.getFunction(functionName)
+            .apply(parameterPtrSize.pointer(), parameterPtrSize.size());
+
+        if (response == null) {
+            return null;
+        }
+
+        RuntimePointerSize responsePtrSize = new RuntimePointerSize((long) response[0]);
+        return context.getSharedMemory().readData(responsePtrSize);
+    }
+
+    /**
+     * This setter exists to be used only in the RuntimeBuilder, since the RuntimeVersion is essentially an attribute
+     * of the Runtime, thus modeled as its field. If we can't find it in a custom section directly from the binary
+     * though, we'll still need an instance of `Runtime` in order to obtain the version by calling `Core_version`,
+     * and set it afterward via this setter.
+     */
+    void setVersion(@NotNull RuntimeVersion runtimeVersion) {
+        this.version = runtimeVersion;
+    }
+
+    public int getHeapBase() {
+        return instance.exports.getGlobal(WasmExports.HEAP_BASE.getValue()).getIntValue();
+    }
+
+    public int getDataEnd() {
+        return instance.exports.getGlobal(WasmExports.DATA_END.getValue()).getIntValue();
+    }
+
+    private Memory getMemory() {
+        return instance.exports.getMemory(WasmExports.MEMORY.getValue());
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/WasmRuntimeInstanceBuilder.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/WasmRuntimeInstanceBuilder.java
@@ -1,0 +1,63 @@
+package com.limechain.runtime.research.hybrid;
+
+import com.github.luben.zstd.Zstd;
+import com.limechain.runtime.WasmSectionUtils;
+import com.limechain.runtime.research.hybrid.context.Context;
+import com.limechain.runtime.version.RuntimeVersion;
+import com.limechain.runtime.version.scale.RuntimeVersionReader;
+import io.emeraldpay.polkaj.scale.ScaleCodecReader;
+import lombok.extern.java.Log;
+import org.wasmer.Module;
+
+import java.util.Arrays;
+import java.util.logging.Level;
+
+@Log
+public class WasmRuntimeInstanceBuilder {
+    private static final byte[] ZSTD_PREFIX = new byte[] {82, -68, 83, 118, 70, -37, -114, 5};
+    private static final int MAX_ZSTD_DECOMPRESSED_SIZE = 50 * 1024 * 1024;
+
+    /**
+     * Builds and returns a Runtime object for executing WebAssembly code.
+     *
+     * @param code The WebAssembly bytecode.
+     * @return A Runtime object.
+     */
+    public WasmRuntimeInstance buildRuntime(byte[] code, Context context) {
+        byte[] wasmBinary = zstDecompressIfNecessary(code);
+
+        Module module = new Module(wasmBinary);
+        WasmRuntimeInstance instance = new WasmRuntimeInstance(module, context);
+
+        RuntimeVersion runtimeVersion = WasmSectionUtils.parseRuntimeVersionFromCustomSections(wasmBinary);
+
+        //If we couldn't get the data from the wasm custom sections fallback to Core_version call
+        if (runtimeVersion == null) {
+            log.log(Level.INFO, "Couldn't fetch runtime version from custom section, calling 'Core_version'.");
+            runtimeVersion = this.getRuntimeVersionFromInstance(instance);
+        }
+
+        instance.setVersion(runtimeVersion);
+        return instance;
+    }
+
+    private byte[] zstDecompressIfNecessary(byte[] code) {
+        byte[] wasmBinaryPrefix = Arrays.copyOfRange(code, 0, 8);
+        if (Arrays.equals(wasmBinaryPrefix, ZSTD_PREFIX)) {
+            return Zstd.decompress(
+                Arrays.copyOfRange(code, ZSTD_PREFIX.length, code.length),
+                MAX_ZSTD_DECOMPRESSED_SIZE
+            );
+        }
+
+        return code;
+    }
+
+    private RuntimeVersion getRuntimeVersionFromInstance(WasmRuntimeInstance instance) {
+        byte[] data = instance.call("Core_version");
+
+        ScaleCodecReader reader = new ScaleCodecReader(data);
+        RuntimeVersionReader runtimeVersionReader = new RuntimeVersionReader();
+        return runtimeVersionReader.read(reader);
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/allocator/Allocator.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/allocator/Allocator.java
@@ -1,0 +1,10 @@
+package com.limechain.runtime.research.hybrid.allocator;
+
+import com.limechain.runtime.hostapi.dto.RuntimePointerSize;
+import com.limechain.runtime.research.hybrid.memory.Memory;
+
+// TODO: Abstract `org.wasmer.WasmMemory` into a new wrapper type
+public interface Allocator {
+    RuntimePointerSize allocate(int size, Memory memory);
+    void deallocate(int pointer, Memory memory);
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/AllocationError.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/AllocationError.java
@@ -1,0 +1,7 @@
+package com.limechain.runtime.research.hybrid.allocator.freeingbumpheap;
+
+public class AllocationError extends RuntimeException {
+    public AllocationError(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/AllocationStats.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/AllocationStats.java
@@ -1,0 +1,24 @@
+package com.limechain.runtime.research.hybrid.allocator.freeingbumpheap;
+
+import lombok.Data;
+
+import java.math.BigInteger;
+
+@Data
+public class AllocationStats {
+    private int bytesAllocated;
+    private int bytesAllocatedPeak;
+    private BigInteger bytesAllocatedSum = BigInteger.ZERO;
+    private int addressSpaceUsed;
+
+    public void allocated(int allocatedSize, int addressSpaceUsed) {
+        bytesAllocated += allocatedSize;
+        bytesAllocatedSum = bytesAllocatedSum.add(BigInteger.valueOf(allocatedSize));
+        bytesAllocatedPeak = Math.max(bytesAllocatedPeak, bytesAllocated);
+        this.addressSpaceUsed = addressSpaceUsed;
+    }
+
+    public void deallocated(int deallocateSize) {
+        bytesAllocated -= deallocateSize;
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/FreeingBumpHeapAllocator.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/FreeingBumpHeapAllocator.java
@@ -1,0 +1,231 @@
+package com.limechain.runtime.research.hybrid.allocator.freeingbumpheap;
+
+import com.limechain.runtime.hostapi.dto.RuntimePointerSize;
+import com.limechain.runtime.research.hybrid.allocator.Allocator;
+import lombok.AllArgsConstructor;
+import lombok.extern.java.Log;
+import com.limechain.runtime.research.hybrid.memory.Memory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.limechain.runtime.allocator.Order.MAX_POSSIBLE_ALLOCATION;
+import static com.limechain.runtime.allocator.Order.MIN_POSSIBLE_ALLOCATION;
+import static com.limechain.runtime.allocator.Order.NUMBER_OF_ORDERS;
+
+/**
+ * <b>Freeing-bump allocator implementation.</b>
+ * <br>
+ * The heap is a continuous linear memory and chunks are allocated using a bump allocator.
+ * <br>
+ * Only allocations with sizes of power of two can be allocated. If the incoming request has a non-power
+ * of two size it is increased to the nearest power of two. The power of two of size is
+ * referred as an {@link Order}.
+ * <br>
+ * Each allocation has a {@link Header} immediately preceding it. The header is always 8 bytes and can
+ * be either free or occupied.
+ * <br>
+ * For implementing freeing we maintain a linked lists for each order, by each order pointing to the
+ * {@link Order#getFreeHeaderPointer() next free header}
+ * and each free header pointing to the {@link Header#getNextFreeHeaderPointer() next free one}.
+ * <br>
+ * The maximum supported allocation size is capped, therefore the number of orders and thus the linked lists is as well
+ * limited. Currently, the maximum size of an allocation is 32 MiB.
+ * <br>
+ * When the allocator serves an allocation request it first checks the linked list for the
+ * respective order. If it doesn't have any free chunks, the allocator requests memory from the
+ * bump allocator. In any case the order is stored in the header of the allocation.
+ * <br>
+ * Upon deallocation, we get the order of the allocation from its header and then add that
+ * allocation to the linked list for the respective order.
+ * <br><br>
+ * <b>Caveats</b>
+ * <br>
+ * This is a fast allocator, but it is also dumb. There are specifically two main shortcomings
+ * that the user should keep in mind:
+ * <ul>
+ * <li>
+ *   Once the bump allocator space is exhausted, there is no way to reclaim the memory. This means
+ *   that it's possible to end up in a situation where there are no live allocations yet a new
+ *   allocation will fail.
+ *   <br>
+ *   Let's look into an example. Given a heap of 32 MiB. The user makes a 32 MiB allocation that we
+ *   call `X` . Now the heap is full. Then user deallocates `X`. Since all the space in the bump
+ *   allocator was consumed by the 32 MiB allocation, allocations of all sizes except 32 MiB will
+ *   fail.
+ * </li>
+ * <li>
+ *   Sizes of allocations are rounded up to the nearest order. That is, an allocation of 2,00001
+ *   MiB will be put into the bucket of 4 MiB. Therefore, any allocation of size `(N, 2N]` will
+ *   take up to `2N`, thus assuming a uniform distribution of allocation sizes, the average amount
+ *   in use of a `2N` space on the heap will be `(3N + ε) / 2`. So average utilization is going to
+ *   be around 75% (`(3N + ε) / 2 / 2N`) meaning that around 25% of the space in allocation will be
+ *   wasted. This is more pronounced (in terms of absolute heap amounts) with larger allocation
+ *   sizes.
+ * </li>
+ * </ul>
+ */
+@Log
+@AllArgsConstructor
+public class FreeingBumpHeapAllocator implements Allocator {
+    private static final int ALIGNMENT = 8;
+    private static final int HEADER_SIZE = 8;
+    private static final int PAGE_SIZE = 65536;
+    private static final int MAX_WASM_PAGES = (int) (4L * 1024 * 1024 * 1024 / PAGE_SIZE); // 4GB
+
+    private final int originalHeapBase;
+    private final List<Order> orders;
+    private final AllocationStats stats;
+    private int lastObservedMemorySize;
+    private int bumper;
+
+    public FreeingBumpHeapAllocator(int heapBase) {
+        int alignedHeapBase = (heapBase + ALIGNMENT - 1) / ALIGNMENT * ALIGNMENT;
+
+        this.originalHeapBase = alignedHeapBase;
+        this.bumper = alignedHeapBase;
+        this.orders = new ArrayList<>(NUMBER_OF_ORDERS);
+        this.lastObservedMemorySize = 0;
+        this.stats = new AllocationStats();
+
+        for (int i = 0; i < NUMBER_OF_ORDERS; i++) {
+            orders.add(new Order(i));
+        }
+    }
+
+    /**
+     * Allocates a block for given size in memory.
+     * <br>The block allocated will have size equal to the next power of 2, relative to the given size.
+     * <br>The block will be allocated at the next free header pointed by the {@link Order order} of this size, if any.
+     * Otherwise, memory will be bumped and the new space will be allocated.
+     * <br>An occupied {@link Header header} is written before the allocated block.
+     *
+     * @param size   size to be allocated; max size is 32MB
+     * @param memory memory
+     * @return pointer-size to the allocated memory
+     * @throws AllocationError when a block of this size can't be allocated
+     */
+    public RuntimePointerSize allocate(int size, Memory memory) {
+        log.finer("Allocating memory... size=" + size);
+        verifyMemorySize(memory);
+        Order order = getOrderForSize(size);
+        int headerPointer = nextFreeHeaderPointer(order, memory);
+        writeOccupiedHeader(headerPointer, order.getValue(), memory);
+        stats.allocated(order.getBlockSize() + HEADER_SIZE, bumper - originalHeapBase);
+        log.finer("Allocated " + stats.getBytesAllocated() + " bytes successfully");
+        log.finer("Total Allocated WasmMemory: " + stats.getBytesAllocatedSum().toString());
+        return new RuntimePointerSize(headerPointer + HEADER_SIZE, size);
+
+    }
+
+    private Order getOrderForSize(int size) {
+        if (size > MAX_POSSIBLE_ALLOCATION) {
+            throw new AllocationError("Requested allocation size is too large");
+        }
+        if (size <= MIN_POSSIBLE_ALLOCATION) {
+            return orders.get(0);
+        }
+
+        int order = nextPowerOfTwo(size) - nextPowerOfTwo(MIN_POSSIBLE_ALLOCATION);
+        return orders.get(order);
+    }
+
+    private int nextPowerOfTwo(int value) {
+        return Integer.SIZE - Integer.numberOfLeadingZeros(value - 1);
+    }
+
+    private int nextFreeHeaderPointer(Order order, Memory memory) {
+        return order.popFreeHeaderPointer(memory)
+                .orElseGet(() -> bump(order.getBlockSize() + HEADER_SIZE, memory));
+    }
+
+    private int bump(int size, Memory memory) {
+        long requiredSize = (long) bumper + size;
+
+        if (requiredSize > memory.buffer().limit()) {
+            growPages(size, memory);
+        }
+
+        int pointer = bumper;
+        bumper += size;
+        return pointer;
+    }
+
+    private void growPages(int size, Memory memory) {
+        int requiredPages = pagesFromSize(size);
+        int currentPages = pagesFromSize(memory.buffer().limit());
+
+        if (currentPages >= MAX_WASM_PAGES) {
+            throw new AllocationError("Max pages already reached.");
+        }
+
+        if (requiredPages > MAX_WASM_PAGES) {
+            throw new AllocationError(String.format(
+                    "Failed to grow memory from %d pages to at least %d pages due to the maximum limit of %d pages",
+                    currentPages, requiredPages, MAX_WASM_PAGES)
+            );
+        }
+
+        int nextPages = Math.min(currentPages * 2, MAX_WASM_PAGES);
+        nextPages = Math.max(nextPages, requiredPages);
+
+        memory.grow(nextPages - currentPages);
+    }
+
+    private int pagesFromSize(long size) {
+        long pages = (size + PAGE_SIZE - 1) / PAGE_SIZE;
+        if (pages > Integer.MAX_VALUE) {
+            throw new AllocationError("Allocator ran out of space");
+        }
+        return (int) pages;
+    }
+
+    private void writeOccupiedHeader(int pointer, int order, Memory memory) {
+        Header header = Header.occupied(order);
+        memory.buffer().putLong(pointer, header.raw());
+    }
+
+    /**
+     * Deallocate a block of memory.
+     * <br> The header of the deallocated block is set to free with a pointer to the current
+     * {@link Order#getFreeHeaderPointer() free header pointer} of its order.
+     * The pointer of the order is set to the deallocated header.
+     *
+     * @param pointer pointer to the block
+     * @param memory  memory
+     * @throws AllocationError when the memory cannot be deallocated
+     */
+    public void deallocate(int pointer, Memory memory) {
+        verifyMemorySize(memory);
+        int headerPointer = pointer - HEADER_SIZE;
+        Order order = getOrderFromHeader(headerPointer, memory);
+        writeFreeHeader(headerPointer, order.getFreeHeaderPointer(), memory);
+        order.setFreeHeaderPointer(headerPointer);
+        stats.deallocated(order.getBlockSize());
+    }
+
+    private Order getOrderFromHeader(int headerPointer, Memory memory) {
+        if (headerPointer < originalHeapBase) {
+            throw new AllocationError("Invalid pointer for deallocation");
+        }
+        Header header = Header.fromMemory(headerPointer, memory);
+        if (!header.isOccupied() || header.getOrder() == null) {
+            throw new AllocationError("No occupied header found at address");
+        }
+
+        return orders.get(header.getOrder());
+    }
+
+    private void verifyMemorySize(Memory memory) throws AllocationError {
+        int memorySize = memory.buffer().limit();
+        if (memorySize < lastObservedMemorySize) {
+            throw new AllocationError("WasmMemory shrank");
+        }
+        lastObservedMemorySize = memorySize;
+    }
+
+    private void writeFreeHeader(int pointer, Integer nextFreeHeaderPointer, Memory memory) {
+        Header header = Header.free(nextFreeHeaderPointer == null ? Integer.MAX_VALUE : nextFreeHeaderPointer);
+        memory.buffer().putLong(pointer, header.raw());
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/Header.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/Header.java
@@ -1,0 +1,89 @@
+package com.limechain.runtime.research.hybrid.allocator.freeingbumpheap;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import com.limechain.runtime.research.hybrid.memory.Memory;
+
+/**
+ * Allocation header preceding a memory block.
+ * <br>
+ * Can be one of two types:
+ * <ul>
+ *     <li>Free: containing a pointer to the next free block and signifying that the block after it is free.</li>
+ *     <li>
+ *         Occupied: containing the {@link Order order} of the block following it and signifying that it is occupied.
+ *     </li>
+ * </ul>
+ * The header is written in memory as 64 bits: the most significant ones denoting its type
+ * and the least significant - the header data (next free block or order).
+ */
+@Log
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Header {
+    private static final long OCCUPIED_HEADER_MASK = 0x00000001_00000000L;
+    private static final long FREE_HEADER_MASK = 0x00000000_00000000L;
+
+    private final boolean occupied;
+
+    private Integer nextFreeHeaderPointer;
+    private Integer order;
+
+    /**
+     * Creates a header for an occupied block.
+     *
+     * @param order order of the occupied block
+     * @return occupied header
+     */
+    public static Header occupied(int order) {
+        Header header = new Header(true);
+        log.finer( "Creating occupied header, order=" + order);
+        header.order = order;
+        return header;
+    }
+
+    /**
+     * Creates a header for a free block.
+     *
+     * @param next pointer to the next free block of this order
+     * @return free header
+     */
+    public static Header free(int next) {
+        Header header = new Header(false);
+        header.nextFreeHeaderPointer = next;
+        log.finer("Creating free header, next=" + next);
+
+        return header;
+    }
+
+    /**
+     * Read a header from memory.
+     *
+     * @param pointer header address
+     * @param memory  memory to read from
+     * @return parsed header
+     */
+    public static Header fromMemory(int pointer, Memory memory) {
+        log.finer("Reading header from memory, pointer=" + pointer);
+        long rawHeader = memory.buffer().getLong(pointer);
+        boolean occupied = (rawHeader & OCCUPIED_HEADER_MASK) != 0;
+        int data = (int) rawHeader;
+
+        return occupied ? Header.occupied(data) : Header.free(data);
+    }
+
+    /**
+     * Returns the raw 64-bit representation of this header.
+     *
+     * @return 64-bit header
+     */
+    public long raw() {
+        if (occupied) {
+            return (long) order | OCCUPIED_HEADER_MASK;
+        } else {
+            return (long) nextFreeHeaderPointer | FREE_HEADER_MASK;
+        }
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/Order.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/allocator/freeingbumpheap/Order.java
@@ -1,0 +1,61 @@
+package com.limechain.runtime.research.hybrid.allocator.freeingbumpheap;
+
+import lombok.Data;
+import lombok.extern.java.Log;
+import com.limechain.runtime.research.hybrid.memory.Memory;
+
+import java.util.Optional;
+
+/**
+ * <b>Order for blocks of certain size.</b>
+ * <br> The block size of an order is a power of 2, relative to the order value.
+ * <br> Orders with value 0 have size {@value MIN_POSSIBLE_ALLOCATION} bytes, with each consecutive value
+ * corresponding to a size equal to the next power of 2, up to a size of {@value MAX_POSSIBLE_ALLOCATION} bytes.
+ * (orders with value 1 have size 16 bytes; with value 2 - 32 bytes, etc.)
+ * <br> An order includes a pointer to the next free header of this order, if any.
+ */
+@Log
+@Data
+public class Order {
+    // This number corresponds to the number of powers between the minimum possible allocation and
+    // maximum possible allocation, or: 2^3...2^25 (both ends inclusive, hence 23).
+    public static final int NUMBER_OF_ORDERS = 23;
+
+    public static final int MIN_POSSIBLE_ALLOCATION = 8; // 2^3 bytes, 8 bytes
+    public static final int MAX_POSSIBLE_ALLOCATION = 32 * 1024 * 1024; // 2^25 bytes, 32 MiB
+
+    private final int value;
+    private final int blockSize;
+    /**
+     * Pointer to the header of the next free block of this order.
+     */
+    private Integer freeHeaderPointer;
+
+    /**
+     * Create an order with given value, calculating the block size of the order.
+     *
+     * @param value order
+     */
+    public Order(int value) {
+        this.value = value;
+        this.blockSize = MIN_POSSIBLE_ALLOCATION << value;
+    }
+
+    /**
+     * Pop the pointer to the next free header for this order. Replace its value with the one written
+     * in the {@link Header} being pointed at.
+     *
+     * @param memory memory to read from
+     * @return Optional of the popped value or empty if there was no value.
+     */
+    public Optional<Integer> popFreeHeaderPointer(Memory memory) {
+        if (freeHeaderPointer == null || freeHeaderPointer == Integer.MAX_VALUE) {
+            return Optional.empty();
+        }
+
+        int result = freeHeaderPointer;
+        freeHeaderPointer = Header.fromMemory(freeHeaderPointer, memory).getNextFreeHeaderPointer();
+        log.finer("Next free header pointer=" + freeHeaderPointer);
+        return Optional.of(result);
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/context/BasicStorage.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/context/BasicStorage.java
@@ -1,0 +1,7 @@
+package com.limechain.runtime.research.hybrid.context;
+
+public interface BasicStorage {
+    void put(byte[] key, byte[] value);
+    byte[] get(byte[] key);
+    void delete(byte[] key);
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/context/Context.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/context/Context.java
@@ -1,0 +1,26 @@
+package com.limechain.runtime.research.hybrid.context;
+
+import com.limechain.runtime.research.hybrid.hostapi.SharedMemory;
+import com.limechain.runtime.research.hybrid.trieaccessor.TrieAccessor;
+import com.limechain.storage.crypto.KeyStore;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class Context {
+    TrieAccessor trieAccessor;
+    KeyStore keyStore;
+    NodeStorage nodeStorage;
+    boolean isValidator;
+
+    // Inner context fields (i.e. dependent on the `org.wasmer.Instance`), manipulated by the runtime for proper endpoint execution
+    @Setter
+    SharedMemory sharedMemory;
+
+    public Context(TrieAccessor trieAccessor, KeyStore keyStore, NodeStorage nodeStorage, boolean isValidator) {
+        this.trieAccessor = trieAccessor;
+        this.keyStore = keyStore;
+        this.nodeStorage = nodeStorage;
+        this.isValidator = isValidator;
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/context/NodeStorage.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/context/NodeStorage.java
@@ -1,0 +1,7 @@
+package com.limechain.runtime.research.hybrid.context;
+
+public class NodeStorage {
+    BasicStorage localStorage;
+    BasicStorage persistentStorage;
+    BasicStorage baseStorage; // for offchain_index host APIs
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/hostapi/Endpoint.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/hostapi/Endpoint.java
@@ -1,0 +1,166 @@
+package com.limechain.runtime.research.hybrid.hostapi;
+
+import com.limechain.exception.NotImplementedException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.java.Log;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.wasmer.ImportObject;
+import org.wasmer.Type;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@Log
+@Getter
+@AllArgsConstructor
+public enum Endpoint {
+    ext_allocator_free_version_1("ext_allocator_free_version_1", List.of(Type.I32), null),
+    ext_allocator_malloc_version_1("ext_allocator_malloc_version_1", List.of(Type.I32), Type.I32),
+    ext_storage_set_version_1("ext_storage_set_version_1", List.of(Type.I64, Type.I64), null),
+    ext_storage_get_version_1("ext_storage_get_version_1", List.of(Type.I64), Type.I64),
+    ext_storage_read_version_1("ext_storage_read_version_1", List.of(Type.I64, Type.I64, Type.I32), Type.I64),
+    ext_storage_clear_version_1("ext_storage_clear_version_1", List.of(Type.I64), null),
+    ext_storage_exists_version_1("ext_storage_exists_version_1", List.of(Type.I64), Type.I32),
+    ext_storage_clear_prefix_version_1("ext_storage_clear_prefix_version_1", List.of(Type.I64), null),
+    ext_storage_clear_prefix_version_2("ext_storage_clear_prefix_version_2", List.of(Type.I64, Type.I64), Type.I64),
+    ext_storage_append_version_1("ext_storage_append_version_1", List.of(Type.I64, Type.I64), null),
+    ext_storage_root_version_1("ext_storage_root_version_1", List.of(), Type.I64),
+    ext_storage_root_version_2("ext_storage_root_version_2", List.of(Type.I32), Type.I64),
+    ext_storage_changes_root_version_1("ext_storage_changes_root_version_1", List.of(Type.I64), Type.I64),
+    ext_storage_next_key_version_1("ext_storage_next_key_version_1", List.of(Type.I64), Type.I64),
+    ext_storage_start_transaction_version_1("ext_storage_start_transaction_version_1", List.of(), null),
+    ext_storage_rollback_transaction_version_1("ext_storage_rollback_transaction_version_1", List.of(), null),
+    ext_storage_commit_transaction_version_1("ext_storage_commit_transaction_version_1", List.of(), null),
+    ext_trie_blake2_256_root_version_1("ext_trie_blake2_256_root_version_1", List.of(Type.I64), Type.I32),
+    ext_trie_blake2_256_root_version_2("ext_trie_blake2_256_root_version_2", List.of(Type.I64, Type.I32), Type.I32),
+    ext_trie_blake2_256_ordered_root_version_1("ext_trie_blake2_256_ordered_root_version_1", List.of(Type.I64), Type.I32),
+    ext_trie_blake2_256_ordered_root_version_2("ext_trie_blake2_256_ordered_root_version_2", List.of(Type.I64, Type.I32), Type.I32),
+    ext_trie_keccak_256_root_version_1("ext_trie_keccak_256_root_version_1", List.of(Type.I64), Type.I32),
+    ext_trie_keccak_256_root_version_2("ext_trie_keccak_256_root_version_2", List.of(Type.I64, Type.I32), Type.I32),
+    ext_trie_keccak_256_ordered_root_version_1("ext_trie_keccak_256_ordered_root_version_1", List.of(Type.I64), Type.I32),
+    ext_trie_keccak_256_ordered_root_version_2("ext_trie_keccak_256_ordered_root_version_2", List.of(Type.I64, Type.I32), Type.I32),
+    ext_trie_blake2_256_verify_proof_version_1("ext_trie_blake2_256_verify_proof_version_1", List.of(Type.I32, Type.I64, Type.I64, Type.I64), Type.I32),
+    ext_trie_blake2_256_verify_proof_version_2("ext_trie_blake2_256_verify_proof_version_2", List.of(Type.I32, Type.I64, Type.I64, Type.I64, Type.I32), Type.I32),
+    ext_trie_keccak_256_verify_proof_version_1("ext_trie_keccak_256_verify_proof_version_1", List.of(Type.I32, Type.I64, Type.I64, Type.I64), Type.I32),
+    ext_trie_keccak_256_verify_proof_version_2("ext_trie_keccak_256_verify_proof_version_2", List.of(Type.I32, Type.I64, Type.I64, Type.I64, Type.I32), Type.I32),
+    ext_offchain_is_validator_version_1("ext_offchain_is_validator_version_1", List.of(), Type.I32),
+    ext_offchain_submit_transaction_version_1("ext_offchain_submit_transaction_version_1", List.of(Type.I64), Type.I64),
+    ext_offchain_network_state_version_1("ext_offchain_network_state_version_1", List.of(), Type.I64),
+    ext_offchain_timestamp_version_1("ext_offchain_timestamp_version_1", List.of(), Type.I64),
+    ext_offchain_sleep_until_version_1("ext_offchain_sleep_until_version_1", List.of(Type.I64), null),
+    ext_offchain_random_seed_version_1("ext_offchain_random_seed_version_1", List.of(), Type.I32),
+    ext_offchain_local_storage_set_version_1("ext_offchain_local_storage_set_version_1", List.of(Type.I32, Type.I64, Type.I64), null),
+    ext_offchain_local_storage_clear_version_1("ext_offchain_local_storage_clear_version_1", List.of(Type.I32, Type.I64), null),
+    ext_offchain_local_storage_compare_and_set_version_1("ext_offchain_local_storage_compare_and_set_version_1", List.of(Type.I32, Type.I64, Type.I64, Type.I64), Type.I32),
+    ext_offchain_local_storage_get_version_1("ext_offchain_local_storage_get_version_1", List.of(Type.I32, Type.I64), Type.I64),
+    ext_offchain_http_request_start_version_1("ext_offchain_http_request_start_version_1", List.of(Type.I64, Type.I64, Type.I64), Type.I64),
+    ext_offchain_http_request_add_header_version_1("ext_offchain_http_request_add_header_version_1", List.of(Type.I32, Type.I64, Type.I64), Type.I64),
+    ext_offchain_http_request_write_body_version_1("ext_offchain_http_request_write_body_version_1", List.of(Type.I32, Type.I64, Type.I64), Type.I64),
+    ext_offchain_http_response_wait_version_1("ext_offchain_http_response_wait_version_1", List.of(Type.I64, Type.I64), Type.I64),
+    ext_offchain_http_response_headers_version_1("ext_offchain_http_response_headers_version_1", List.of(Type.I32), Type.I64),
+    ext_offchain_http_response_read_body_version_1("ext_offchain_http_response_read_body_version_1", List.of(Type.I32, Type.I64, Type.I64), Type.I64),
+    ext_offchain_index_set_version_1("ext_offchain_index_set_version_1", List.of(Type.I64, Type.I64), null),
+    ext_offchain_index_clear_version_1("ext_offchain_index_clear_version_1", List.of(Type.I64), null),
+    ext_misc_print_num_version_1("ext_misc_print_num_version_1", List.of(Type.I64), null),
+    ext_misc_print_utf8_version_1("ext_misc_print_utf8_version_1", List.of(Type.I64), null),
+    ext_misc_print_hex_version_1("ext_misc_print_hex_version_1", List.of(Type.I64), null),
+    ext_misc_runtime_version_version_1("ext_misc_runtime_version_version_1", List.of(Type.I64), Type.I64),
+    ext_logging_log_version_1("ext_logging_log_version_1", List.of(Type.I32, Type.I64, Type.I64), null),
+    ext_logging_max_level_version_1("ext_logging_max_level_version_1", List.of(), Type.I32),
+    ext_hashing_keccak_256_version_1("ext_hashing_keccak_256_version_1", List.of(Type.I64), Type.I32),
+    ext_hashing_keccak_512_version_1("ext_hashing_keccak_512_version_1", List.of(Type.I64), Type.I32),
+    ext_hashing_sha2_256_version_1("ext_hashing_sha2_256_version_1", List.of(Type.I64), Type.I32),
+    ext_hashing_blake2_128_version_1("ext_hashing_blake2_128_version_1", List.of(Type.I64), Type.I32),
+    ext_hashing_blake2_256_version_1("ext_hashing_blake2_256_version_1", List.of(Type.I64), Type.I32),
+    ext_hashing_twox_64_version_1("ext_hashing_twox_64_version_1", List.of(Type.I64), Type.I32),
+    ext_hashing_twox_128_version_1("ext_hashing_twox_128_version_1", List.of(Type.I64), Type.I32),
+    ext_hashing_twox_256_version_1("ext_hashing_twox_256_version_1", List.of(Type.I64), Type.I32),
+    ext_crypto_ed25519_public_keys_version_1("ext_crypto_ed25519_public_keys_version_1", List.of(Type.I32), Type.I64),
+    ext_crypto_ed25519_generate_version_1("ext_crypto_ed25519_generate_version_1", List.of(Type.I32, Type.I64), Type.I32),
+    ext_crypto_ed25519_sign_version_1("ext_crypto_ed25519_sign_version_1", List.of(Type.I32, Type.I32, Type.I64), Type.I64),
+    ext_crypto_ed25519_verify_version_1("ext_crypto_ed25519_verify_version_1", List.of(Type.I32, Type.I64, Type.I32), Type.I32),
+    ext_crypto_ed25519_batch_verify_version_1("ext_crypto_ed25519_batch_verify_version_1", List.of(Type.I32, Type.I64, Type.I32), Type.I32),
+    ext_crypto_sr25519_public_keys_version_1("ext_crypto_sr25519_public_keys_version_1", List.of(Type.I32), Type.I64),
+    ext_crypto_sr25519_generate_version_1("ext_crypto_sr25519_generate_version_1", List.of(Type.I32, Type.I64), Type.I32),
+    ext_crypto_sr25519_sign_version_1("ext_crypto_sr25519_sign_version_1", List.of(Type.I32, Type.I32, Type.I64), Type.I64),
+    ext_crypto_sr25519_verify_version_1("ext_crypto_sr25519_verify_version_1", List.of(Type.I32, Type.I64, Type.I32), Type.I32),
+    ext_crypto_sr25519_verify_version_2("ext_crypto_sr25519_verify_version_2", List.of(Type.I32, Type.I64, Type.I32), Type.I32),
+    ext_crypto_sr25519_batch_verify_version_1("ext_crypto_sr25519_batch_verify_version_1", List.of(Type.I32, Type.I64, Type.I32), Type.I32),
+    ext_crypto_ecdsa_public_keys_version_1("ext_crypto_ecdsa_public_keys_version_1", List.of(Type.I64), Type.I64),
+    ext_crypto_ecdsa_generate_version_1("ext_crypto_ecdsa_generate_version_1", List.of(Type.I32, Type.I64), Type.I32),
+    ext_crypto_ecdsa_sign_version_1("ext_crypto_ecdsa_sign_version_1", List.of(Type.I32, Type.I32, Type.I64), Type.I64),
+    ext_crypto_ecdsa_sign_prehashed_version_1("ext_crypto_ecdsa_sign_prehashed_version_1", List.of(Type.I32, Type.I32, Type.I64), Type.I64),
+    ext_crypto_ecdsa_verify_version_1("ext_crypto_ecdsa_verify_version_1", List.of(Type.I32, Type.I64, Type.I32), Type.I32),
+    ext_crypto_ecdsa_verify_version_2("ext_crypto_ecdsa_verify_version_2", List.of(Type.I32, Type.I64, Type.I32), Type.I32),
+    ext_crypto_ecdsa_verify_prehashed_version_1("ext_crypto_ecdsa_verify_prehashed_version_1", List.of(Type.I32, Type.I32, Type.I32), Type.I32),
+    ext_crypto_ecdsa_batch_verify_version_1("ext_crypto_ecdsa_batch_verify_version_1", List.of(Type.I32, Type.I64, Type.I32), Type.I32),
+    ext_crypto_secp256k1_ecdsa_recover_version_1("ext_crypto_secp256k1_ecdsa_recover_version_1", List.of(Type.I32, Type.I32), Type.I64),
+    ext_crypto_secp256k1_ecdsa_recover_version_2("ext_crypto_secp256k1_ecdsa_recover_version_2", List.of(Type.I32, Type.I32), Type.I64),
+    ext_crypto_secp256k1_ecdsa_recover_compressed_version_1("ext_crypto_secp256k1_ecdsa_recover_compressed_version_1", List.of(Type.I32, Type.I32), Type.I64),
+    ext_crypto_secp256k1_ecdsa_recover_compressed_version_2("ext_crypto_secp256k1_ecdsa_recover_compressed_version_2", List.of(Type.I32, Type.I32), Type.I64),
+    ext_crypto_start_batch_verify_version_1("ext_crypto_start_batch_verify_version_1", List.of(), null),
+    ext_crypto_finish_batch_verify_version_1("ext_crypto_finish_batch_verify_version_1", List.of(), null),
+    ext_default_child_storage_set_version_1("ext_default_child_storage_set_version_1", List.of(Type.I64, Type.I64, Type.I64), null),
+    ext_default_child_storage_get_version_1("ext_default_child_storage_get_version_1", List.of(Type.I64, Type.I64), Type.I64),
+    ext_default_child_storage_read_version_1("ext_default_child_storage_read_version_1", List.of(Type.I64, Type.I64, Type.I64, Type.I32), Type.I64),
+    ext_default_child_storage_clear_version_1("ext_default_child_storage_clear_version_1", List.of(Type.I64, Type.I64), null),
+    ext_default_child_storage_storage_kill_version_1("ext_default_child_storage_storage_kill_version_1", List.of(Type.I64), null),
+    ext_default_child_storage_storage_kill_version_2("ext_default_child_storage_storage_kill_version_2", List.of(Type.I64, Type.I64), Type.I32),
+    ext_default_child_storage_storage_kill_version_3("ext_default_child_storage_storage_kill_version_3", List.of(Type.I64, Type.I64), Type.I64),
+    ext_default_child_storage_exists_version_1("ext_default_child_storage_exists_version_1", List.of(Type.I64, Type.I64), Type.I32),
+    ext_default_child_storage_clear_prefix_version_1("ext_default_child_storage_clear_prefix_version_1", List.of(Type.I64, Type.I64), null),
+    ext_default_child_storage_clear_prefix_version_2("ext_default_child_storage_clear_prefix_version_2", List.of(Type.I64, Type.I64, Type.I64), Type.I64),
+    ext_default_child_storage_root_version_1("ext_default_child_storage_root_version_1", List.of(Type.I64), Type.I64),
+    ext_default_child_storage_root_version_2("ext_default_child_storage_root_version_2", List.of(Type.I64, Type.I32), Type.I64),
+    ext_default_child_storage_next_key_version_1("ext_default_child_storage_next_key_version_1", List.of(Type.I64, Type.I64), Type.I64),
+    ;
+
+    @NotNull
+    private final String functionName;
+    @NotNull
+    private final List<Type> args;
+    @Nullable
+    private final Type retType;
+
+    /**
+     * An implementation for an endpoint with a non-void return type.
+     */
+    public ImportObject getImportObject(Function<List<Number>, Number> impl) {
+        if (retType == null) {
+            throw new RuntimeException(String.format("The Host API endpoint '%s' returns no value, wrong implementation provided.", functionName));
+        }
+
+        return new ImportObject.FuncImport("env", functionName, argv -> {
+            log.info(String.format("Host API endpoint invoked: '%s'%n", functionName));
+            return Collections.singletonList(impl.apply(argv));
+        }, args, Collections.singletonList(retType));
+    }
+
+    /**
+     * An implementation for an endpoint with a void return type.
+     */
+    public ImportObject getImportObject(Consumer<List<Number>> impl) {
+        if (retType != null) {
+            throw new RuntimeException(String.format("The Host API endpoint '%s' does return a value, wrong implementation provided.", functionName));
+        }
+
+        return new ImportObject.FuncImport("env", functionName, argv -> {
+            log.info(String.format("Host API endpoint invoked '%s'%n", functionName));
+            impl.accept(argv);
+            return List.of();
+        }, args, List.of());
+    }
+
+    /**
+     * An implementation throwing a `NotImplementedException`.
+     */
+    public ImportObject getImportObjectNotImplemented() {
+        return new ImportObject.FuncImport("env", functionName, argv -> {
+            throw new NotImplementedException(String.format("The Host API endpoint '%s' is not yet implemented.", functionName));
+        }, args, this.retType == null ? List.of() : List.of(this.retType));
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/hostapi/HostApiImpl.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/hostapi/HostApiImpl.java
@@ -1,0 +1,18 @@
+package com.limechain.runtime.research.hybrid.hostapi;
+
+import com.limechain.runtime.research.hybrid.context.Context;
+import org.wasmer.ImportObject;
+
+import java.util.List;
+
+public abstract class HostApiImpl {
+    protected Context context;
+    protected SharedMemory sharedMemory;
+
+    protected HostApiImpl(Context context) {
+        this.context = context;
+        this.sharedMemory = context.getSharedMemory();
+    }
+
+    abstract List<ImportObject> getFunctionImports();
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/hostapi/MinimalHostapiImpl.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/hostapi/MinimalHostapiImpl.java
@@ -1,0 +1,207 @@
+package com.limechain.runtime.research.hybrid.hostapi;
+
+import com.limechain.runtime.hostapi.StorageHostFunctions;
+import com.limechain.runtime.hostapi.TrieHostFunctions;
+import com.limechain.runtime.hostapi.dto.RuntimePointerSize;
+import com.limechain.runtime.research.hybrid.context.Context;
+import com.limechain.runtime.version.StateVersion;
+import com.limechain.trie.structure.nibble.Nibbles;
+import com.limechain.utils.HashUtils;
+import com.limechain.utils.scale.ScaleUtils;
+import io.emeraldpay.polkaj.scale.ScaleCodecReader;
+import lombok.extern.java.Log;
+import org.wasmer.ImportObject;
+
+import java.util.Arrays;
+import java.util.List;
+
+@SuppressWarnings("SequencedCollectionMethodCanBeUsed")
+@Log
+public class MinimalHostapiImpl extends HostApiImpl {
+    public MinimalHostapiImpl(Context context) {
+        super(context);
+    }
+
+    @Override
+    public List<ImportObject> getFunctionImports() {
+        return Arrays.stream(Endpoint.values()).map(this::getFunctionImport).toList();
+    }
+
+    private ImportObject getFunctionImport(Endpoint endpoint) {
+        return switch (endpoint) {
+            case ext_allocator_free_version_1 -> Endpoint.ext_allocator_free_version_1.getImportObject(argv -> {
+                extAllocatorFreeVersion1(argv.get(0).intValue());
+            });
+            case ext_allocator_malloc_version_1 -> Endpoint.ext_allocator_malloc_version_1.getImportObject(argv -> {
+                return extAllocatorMallocVersion1(argv.get(0).intValue());
+            });
+            case ext_hashing_blake2_256_version_1 -> Endpoint.ext_hashing_blake2_256_version_1.getImportObject(argv -> {
+                return blake2256V1(new RuntimePointerSize(argv.get(0)));
+            });
+            case ext_hashing_twox_128_version_1 -> Endpoint.ext_hashing_twox_128_version_1.getImportObject(argv -> {
+                return twox128V1(new RuntimePointerSize(argv.get(0)));
+            });
+            case ext_storage_changes_root_version_1 ->
+                Endpoint.ext_storage_changes_root_version_1.getImportObject(argv -> {
+                    return extStorageChangesRootVersion1(new RuntimePointerSize(argv.get(0))).pointerSize();
+                });
+            case ext_storage_clear_prefix_version_1 ->
+                Endpoint.ext_storage_clear_prefix_version_1.getImportObject(argv -> {
+                    extStorageClearPrefixVersion1(new RuntimePointerSize(argv.get(0)));
+                });
+            case ext_storage_clear_version_1 -> Endpoint.ext_storage_clear_version_1.getImportObject(argv -> {
+                extStorageClearVersion1(new RuntimePointerSize(argv.get(0)));
+            });
+            case ext_storage_get_version_1 -> Endpoint.ext_storage_get_version_1.getImportObject(argv -> {
+                return extStorageGetVersion1(new RuntimePointerSize(argv.get(0))).pointerSize();
+            });
+            case ext_storage_read_version_1 -> Endpoint.ext_storage_read_version_1.getImportObject(argv -> {
+                return extStorageReadVersion1(
+                    new RuntimePointerSize(argv.get(0)), new RuntimePointerSize(argv.get(1)),
+                    argv.get(2).intValue()).pointerSize();
+            });
+            case ext_storage_root_version_1 -> Endpoint.ext_storage_root_version_1.getImportObject(argv -> {
+                return extStorageRootVersion1().pointerSize();
+            });
+            case ext_storage_set_version_1 -> Endpoint.ext_storage_set_version_1.getImportObject(argv -> {
+                extStorageSetVersion1(
+                    new RuntimePointerSize(argv.get(0)),
+                    new RuntimePointerSize(argv.get(1)));
+            });
+            case ext_trie_blake2_256_ordered_root_version_1 ->
+                Endpoint.ext_trie_blake2_256_ordered_root_version_1.getImportObject(argv -> {
+                    var encodedVals = sharedMemory.readData(new RuntimePointerSize(argv.get(0)));
+                    List<byte[]> values = ScaleUtils.Decode.decodeList(encodedVals, ScaleCodecReader::readByteArray);
+
+                    byte[] trieRoot = new TrieHostFunctions.TrieRootCalculator(TrieHostFunctions.HashFunction.BLAKE2B,
+                        StateVersion.V0).orderedTrieRoot(values);
+
+                    return sharedMemory.writeData(trieRoot).pointer();
+                });
+            default -> endpoint.getImportObjectNotImplemented();
+        };
+    }
+
+    /**
+     * Allocates the given number of bytes and returns the pointer to that memory location.
+     *
+     * @param size the size of the buffer to be allocated.
+     * @return a pointer to the allocated buffer.
+     */
+    public int extAllocatorMallocVersion1(int size) {
+        log.finest("extAllocatorMallocVersion1");
+        return sharedMemory.allocate(size).pointer();
+
+    }
+
+    /**
+     * Free the given pointer.
+     *
+     * @param pointer a pointer to the memory buffer to be freed.
+     */
+    public void extAllocatorFreeVersion1(int pointer) {
+        log.finest("extAllocatorFreeVersion1");
+        sharedMemory.deallocate(pointer);
+    }
+
+    /**
+     * Conducts a 256-bit Blake2 hash.
+     *
+     * @param data a pointer-size to the data to be hashed.
+     * @return a pointer to the buffer containing the 256-bit hash result.
+     */
+    public int blake2256V1(RuntimePointerSize data) {
+        log.fine("blake2256V1");
+
+        byte[] dataToHash = sharedMemory.readData(data);
+
+        byte[] hash = HashUtils.hashWithBlake2b(dataToHash);
+
+        return sharedMemory.writeData(hash).pointer();
+    }
+
+    /**
+     * Conducts a 128-bit xxHash hash.
+     *
+     * @param data a pointer-size to the data to be hashed.
+     * @return a pointer to the buffer containing the 128-bit hash result.
+     */
+    public int twox128V1(final RuntimePointerSize data) {
+        log.fine("twox128V1");
+
+        byte[] dataToHash = sharedMemory.readData(data);
+        log.fine("with data to hash: " + new String(dataToHash));
+
+        byte[] hash = HashUtils.hashXx128(0, dataToHash);
+
+        return sharedMemory.writeData(hash).pointer();
+    }
+
+    public RuntimePointerSize extStorageChangesRootVersion1(RuntimePointerSize parentHashPointer) {
+        log.fine("extStorageChangesRootVersion1");
+
+        return sharedMemory.writeData(StorageHostFunctions.scaleEncodedOption(null));
+    }
+
+    public void extStorageClearPrefixVersion1(RuntimePointerSize prefixPointer) {
+        log.fine("extStorageClearPrefixVersion1");
+        Nibbles prefix = Nibbles.fromBytes(sharedMemory.readData(prefixPointer));
+        context.getTrieAccessor().deleteByPrefix(prefix, null);
+    }
+
+    public void extStorageClearVersion1(RuntimePointerSize keyPointer) {
+        log.fine("extStorageClearVersion1");
+        Nibbles key = Nibbles.fromBytes(sharedMemory.readData(keyPointer));
+        context.getTrieAccessor().delete(key);
+    }
+
+    public RuntimePointerSize extStorageGetVersion1(RuntimePointerSize keyPointer) {
+        Nibbles key = Nibbles.fromBytes(sharedMemory.readData(keyPointer));
+        byte[] value = context.getTrieAccessor().find(key).orElse(null);
+
+        log.fine("");
+        log.fine("extStorageGetVersion1");
+        log.fine("key: " + key);
+        log.fine("");
+
+        return sharedMemory.writeData(StorageHostFunctions.scaleEncodedOption(value));
+    }
+
+    public RuntimePointerSize extStorageReadVersion1(RuntimePointerSize keyPointer, RuntimePointerSize valueOutPointer,
+                                                     int offset) {
+        log.fine("extStorageReadVersion1");
+        Nibbles key = Nibbles.fromBytes(sharedMemory.readData(keyPointer));
+        byte[] value = context.getTrieAccessor().find(key).orElse(null);
+
+        if (value == null) {
+            return sharedMemory.writeData(StorageHostFunctions.scaleEncodedOption(null));
+        }
+
+        int size = 0;
+        if (offset <= value.length) {
+            size = value.length - offset;
+            sharedMemory.writeData(Arrays.copyOfRange(value, offset, value.length), valueOutPointer);
+        }
+
+        return sharedMemory.writeData(StorageHostFunctions.scaleEncodedOption(size));
+    }
+
+    public RuntimePointerSize extStorageRootVersion1() {
+        log.fine("extStorageRootVersion1");
+        byte[] rootHash = context.getTrieAccessor().getMerkleRoot(StateVersion.V0);
+
+        return sharedMemory.writeData(rootHash);
+    }
+
+    public void extStorageSetVersion1(RuntimePointerSize keyPointer, RuntimePointerSize valuePointer) {
+        Nibbles key = Nibbles.fromBytes(sharedMemory.readData(keyPointer));
+        byte[] value = sharedMemory.readData(valuePointer);
+
+        log.fine("");
+        log.fine("extStorageSetVersion1 with ");
+        log.fine("key: " + key);
+        log.fine("value: " + Arrays.toString(value));
+        log.fine("");
+        context.getTrieAccessor().save(key, value);
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/hostapi/SharedMemory.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/hostapi/SharedMemory.java
@@ -1,0 +1,77 @@
+package com.limechain.runtime.research.hybrid.hostapi;
+
+import com.limechain.runtime.hostapi.dto.RuntimePointerSize;
+import com.limechain.runtime.research.hybrid.allocator.Allocator;
+import com.limechain.runtime.research.hybrid.memory.Memory;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+
+import java.nio.ByteBuffer;
+
+// TODO: I don't like the public setters...
+@Setter
+@AllArgsConstructor
+public class SharedMemory {
+    private Memory memory;
+    private Allocator allocator;
+
+    /**
+     * Get the data stored in memory using a {@link  RuntimePointerSize}
+     *
+     * @param runtimePointerSize pointer to data and its size
+     * @return byte array with read data
+     */
+    public byte[] readData(RuntimePointerSize runtimePointerSize) {
+        ByteBuffer memoryBuffer = this.memory.buffer();
+        byte[] data = new byte[runtimePointerSize.size()];
+        memoryBuffer.position(runtimePointerSize.pointer());
+        memoryBuffer.get(data);
+        return data;
+    }
+
+    /**
+     * Write data to memory, by allocating space in memory and then writing to it.
+     *
+     * @param data data to be written
+     * @return a pointer size to the written data
+     */
+    public RuntimePointerSize writeData(byte[] data) {
+        RuntimePointerSize allocatedPointer = allocate(data.length);
+        writeData(data, allocatedPointer);
+        return allocatedPointer;
+    }
+
+    /**
+     * Write data to memory, by using a {@link RuntimePointerSize}.
+     * <br>Data will be written at the given {@link RuntimePointerSize#pointer() pointer}.
+     * <br>Only the first bytes up to the given {@link RuntimePointerSize#size() size} will be written.
+     *
+     * @param data               data to be written to memory
+     * @param runtimePointerSize pointer to memory and size of data to be stored.
+     */
+    public void writeData(byte[] data, RuntimePointerSize runtimePointerSize) {
+        ByteBuffer memoryBuffer = memory.buffer();
+        memoryBuffer.position(runtimePointerSize.pointer());
+        memoryBuffer.put(data, 0, runtimePointerSize.size());
+    }
+
+    /**
+     * Allocate a number of bytes in memory.
+     *
+     * @param numberOfBytes number of bytes to be allocated
+     * @return a pointer-size to the allocated space in memory
+     */
+    public RuntimePointerSize allocate(int numberOfBytes) {
+        return allocator.allocate(numberOfBytes, memory);
+    }
+
+    /**
+     * Deallocate the space at given memory pointer
+     *
+     * @param pointer position in memory
+     */
+    public void deallocate(int pointer) {
+        allocator.deallocate(pointer, memory);
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/memory/Memory.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/memory/Memory.java
@@ -1,0 +1,8 @@
+package com.limechain.runtime.research.hybrid.memory;
+
+import java.nio.ByteBuffer;
+
+public interface Memory {
+    ByteBuffer buffer();
+    int grow(int page);
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/memory/WasmMemory.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/memory/WasmMemory.java
@@ -1,0 +1,15 @@
+package com.limechain.runtime.research.hybrid.memory;
+
+import java.nio.ByteBuffer;
+
+public record WasmMemory(org.wasmer.Memory memory) implements Memory {
+    @Override
+    public ByteBuffer buffer() {
+        return memory.buffer();
+    }
+
+    @Override
+    public int grow(int page) {
+        return memory.grow(page);
+    }
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/trieaccessor/BlockTrieAccessor.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/trieaccessor/BlockTrieAccessor.java
@@ -1,0 +1,28 @@
+package com.limechain.runtime.research.hybrid.trieaccessor;
+
+import com.limechain.storage.block.BlockState;
+import com.limechain.storage.trie.TrieStorage;
+import io.emeraldpay.polkaj.types.Hash256;
+
+/**
+ * BlockTrieAccessor provides access to the trie structure of a specific block.
+ * It extends TrieAccessor and inherits its functionalities for key-value storage and retrieval.
+ */
+public class BlockTrieAccessor extends TrieAccessor {
+
+    /**
+     * Constructs a new BlockTrieAccessor using a {@link Hash256} block hash.
+     *
+     * @param blockHash the block hash of the block whose trie is to be accessed
+     */
+    public BlockTrieAccessor(TrieStorage trieStorage, Hash256 blockHash) {
+        super(trieStorage, BlockState.getInstance().isInitialized() ?
+                BlockState.getInstance().getHeader(blockHash).getStateRoot().getBytes() :
+                null);
+    }
+
+    public BlockTrieAccessor(TrieStorage trieStorage, byte[] stateRoot) {
+        super(trieStorage, stateRoot);
+    }
+
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/trieaccessor/ChildTrieAccessor.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/trieaccessor/ChildTrieAccessor.java
@@ -1,0 +1,29 @@
+package com.limechain.runtime.research.hybrid.trieaccessor;
+
+import com.limechain.storage.trie.TrieStorage;
+import com.limechain.trie.structure.nibble.Nibbles;
+import lombok.Getter;
+
+/**
+ * ChildTrieAccessor provides access to a child trie within a parent trie structure.
+ * It extends TrieAccessor and inherits its functionalities for key-value storage and retrieval.
+ */
+public class ChildTrieAccessor extends TrieAccessor {
+
+    private final TrieAccessor parentTrie;
+    @Getter
+    private final Nibbles childTrieKey;
+
+    public ChildTrieAccessor(TrieStorage trieStorage, TrieAccessor parentTrie, Nibbles trieKey, byte[] merkleRoot) {
+        super(trieStorage, merkleRoot);
+        this.parentTrie = parentTrie;
+        this.childTrieKey = trieKey;
+    }
+
+    @Override
+    public void persistUpdates() {
+        super.persistUpdates();
+        parentTrie.save(childTrieKey, mainTrieRoot);
+    }
+
+}

--- a/src/main/java/com/limechain/runtime/research/hybrid/trieaccessor/TrieAccessor.java
+++ b/src/main/java/com/limechain/runtime/research/hybrid/trieaccessor/TrieAccessor.java
@@ -1,0 +1,223 @@
+package com.limechain.runtime.research.hybrid.trieaccessor;
+
+import com.limechain.runtime.version.StateVersion;
+import com.limechain.storage.DeleteByPrefixResult;
+import com.limechain.storage.KVRepository;
+import com.limechain.storage.trie.TrieStorage;
+import com.limechain.trie.TrieStructureFactory;
+import com.limechain.trie.structure.NodeHandle;
+import com.limechain.trie.structure.TrieNodeIndex;
+import com.limechain.trie.structure.TrieStructure;
+import com.limechain.trie.structure.database.NodeData;
+import com.limechain.trie.structure.nibble.Nibble;
+import com.limechain.trie.structure.nibble.Nibbles;
+import com.limechain.utils.HashUtils;
+import lombok.AllArgsConstructor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@AllArgsConstructor
+public class TrieAccessor implements KVRepository<Nibbles, byte[]> {
+
+    public static final String TRANSACTIONS_NOT_SUPPORTED = "Block Trie Accessor does not support transactions.";
+
+    protected final TrieStorage trieStorage;
+    protected byte[] mainTrieRoot;
+
+    private final Map<Nibbles, ChildTrieAccessor> loadedChildTries;
+    private TrieStructure<NodeData> initialTrie;
+    private List<TrieNodeIndex> updates;
+
+    public TrieAccessor(TrieStorage trieStorage, byte[] mainTrieRoot) {
+        this.trieStorage = trieStorage;
+        this.mainTrieRoot = mainTrieRoot;
+
+        this.loadedChildTries = new HashMap<>();
+        this.initialTrie = trieStorage.loadTrieStructure(mainTrieRoot);
+    }
+
+    /**
+     * Retrieves the child trie accessor for the given key.
+     *
+     * @param key The key corresponding to the child trie accessor.
+     * @return The ChildTrieAccessor for the specified key.
+     */
+    public ChildTrieAccessor getChildTrie(Nibbles key) {
+        Nibbles trieKey = Nibbles.fromBytes(":child_storage:default:".getBytes()).addAll(key);
+        byte[] merkleRoot = find(trieKey).orElse(null);
+        return loadedChildTries.computeIfAbsent(trieKey, k -> new ChildTrieAccessor(this.trieStorage, this, trieKey, merkleRoot));
+    }
+
+    /**
+     * Saves a key-value pair to the trie.
+     *
+     * @param key   The key to save.
+     * @param value The value to save.
+     * @return True if the operation was successful, false otherwise.
+     */
+    @Override
+    public boolean save(Nibbles key, byte[] value) {
+        NodeData nodeData = new NodeData(value);
+        initialTrie.insertNode(key, nodeData);
+        return true;
+    }
+
+    /**
+     * Finds the value associated with the given key in the trie.
+     *
+     * @param key The key to search for.
+     * @return An Optional containing the value if found, or empty otherwise.
+     */
+    @Override
+    public Optional<byte[]> find(Nibbles key) {
+        return initialTrie.existingNode(key)
+                .map(NodeHandle::getUserData)
+                .map(NodeData::getValue);
+    }
+
+    /**
+     * Finds the Merkle value associated with the given key in the trie.
+     *
+     * @param key The key to search for.
+     * @return An Optional containing the Merkle value if found, or empty otherwise.
+     */
+    public Optional<byte[]> findMerkleValue(Nibbles key) {
+        return trieStorage.getByKeyFromMerkle(mainTrieRoot, key)
+                .map(NodeData::getMerkleValue);
+    }
+
+    /**
+     * Deletes the value associated with the given key from the trie.
+     *
+     * @param key The key to delete.
+     * @return True if the operation was successful, false otherwise.
+     */
+    @Override
+    public boolean delete(Nibbles key) {
+        return initialTrie.deleteStorageNodeAt(key);
+    }
+
+    @Override
+    public List<byte[]> findKeysByPrefix(Nibbles prefixSeek, int limit) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
+     * Deletes keys in the trie that match the given prefix.
+     *
+     * @param prefix The prefix to match for deletion.
+     * @param limit  The maximum number of keys to delete.
+     * @return A DeleteByPrefixResult indicating the number of keys deleted and whether all keys were deleted.
+     */
+    @Override
+    public DeleteByPrefixResult deleteByPrefix(Nibbles prefix, Long limit) {
+        Optional<NodeHandle<NodeData>> optionalNodeHandle = initialTrie.existingNode(prefix);
+
+        if (!optionalNodeHandle.isPresent()) {
+            return new DeleteByPrefixResult(0, true);
+        }
+
+        NodeHandle<NodeData> nodeHandle = optionalNodeHandle.get();
+        AtomicInteger deleted = new AtomicInteger(0);
+
+        for (Nibble nibble : Nibbles.ALL) {
+            nodeHandle.getChild(nibble)
+                    .map(NodeHandle::getNodeIndex)
+                    .ifPresent(childIndex -> initialTrie.deleteNodesRecursively(childIndex, limit, deleted));
+        }
+
+        if (limit != null && deleted.get() >= limit) {
+            return new DeleteByPrefixResult(deleted.get(), false);
+        }
+
+        if (nodeHandle.hasStorageValue()) {
+            initialTrie.deleteStorageNodeAt(nodeHandle.getFullKey());
+            deleted.incrementAndGet();
+        }else{
+            initialTrie.deleteInternalNodeAt(nodeHandle.getFullKey());
+        }
+
+        return new DeleteByPrefixResult(deleted.get(), true);
+    }
+
+    public void persistUpdates() {
+        for (ChildTrieAccessor value : loadedChildTries.values()) value.persistUpdates();
+        loadedChildTries.clear();
+
+        trieStorage.updateTrieStorage(initialTrie, updates, StateVersion.V0);
+    }
+
+    @Override
+    public Optional<Nibbles> getNextKey(Nibbles key) {
+        NodeHandle<NodeData> rootHandle = initialTrie.getRootNode().orElse(null);
+        return findNextKey(rootHandle, key, Nibbles.EMPTY);
+    }
+
+    private Optional<Nibbles> findNextKey(NodeHandle<NodeData> node, Nibbles prefix, Nibbles currentPath) {
+        if (node == null) {
+            return Optional.empty();
+        }
+
+        // If the current node is a leaf and the fullPath is greater than the prefix, it's a candidate.
+        if (node.getUserData() != null && node.getUserData().getValue() != null && currentPath.compareTo(prefix) > 0) {
+            return Optional.of(currentPath);
+        }
+
+        for (Nibble nibble : Nibbles.ALL) {
+            NodeHandle<NodeData> childNode = node.getChild(nibble).orElse(null);
+            if (childNode == null) continue;
+            Nibbles nextPath = currentPath.add(nibble).addAll(childNode.getPartialKey());
+            Optional<Nibbles> result = findNextKey(childNode, prefix, nextPath);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public void startTransaction() {
+        throw new UnsupportedOperationException(TRANSACTIONS_NOT_SUPPORTED);
+
+    }
+
+    @Override
+    public void rollbackTransaction() {
+        throw new UnsupportedOperationException(TRANSACTIONS_NOT_SUPPORTED);
+
+    }
+
+    @Override
+    public void commitTransaction() {
+        throw new UnsupportedOperationException(TRANSACTIONS_NOT_SUPPORTED);
+
+    }
+
+    @Override
+    public void closeConnection() {
+        throw new UnsupportedOperationException(TRANSACTIONS_NOT_SUPPORTED);
+    }
+
+    /**
+     * Retrieves the Merkle root hash of the trie with the specified state version.
+     *
+     * @param version The state version.
+     * @return The Merkle root hash.
+     */
+    public byte[] getMerkleRoot(StateVersion version) {
+        this.updates = TrieStructureFactory.recalculateMerkleValues(initialTrie, version, HashUtils::hashWithBlake2b);
+
+        this.mainTrieRoot = initialTrie.getRootNode()
+                .map(NodeHandle::getUserData)
+                .map(NodeData::getMerkleValue)
+                .orElseThrow();
+
+        return mainTrieRoot;
+    }
+
+}

--- a/src/main/java/com/limechain/runtime/version/ApiVersions.java
+++ b/src/main/java/com/limechain/runtime/version/ApiVersions.java
@@ -4,6 +4,7 @@ import com.limechain.runtime.version.scale.ApiVersionReader;
 import com.limechain.exception.scale.ScaleDecodingException;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleReader;
+import lombok.Getter;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -13,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class ApiVersions {
+    @Getter // NOTE: Only necessary to be visible to the scale writer; think about reordering
     private final List<ApiVersion> entries;
 
     private ApiVersions(List<ApiVersion> entries) {

--- a/src/main/java/com/limechain/runtime/version/scale/ApiVersionWriter.java
+++ b/src/main/java/com/limechain/runtime/version/scale/ApiVersionWriter.java
@@ -1,0 +1,15 @@
+package com.limechain.runtime.version.scale;
+
+import com.limechain.runtime.version.ApiVersion;
+import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import io.emeraldpay.polkaj.scale.ScaleWriter;
+
+import java.io.IOException;
+
+public class ApiVersionWriter implements ScaleWriter<ApiVersion> {
+    @Override
+    public void write(ScaleCodecWriter scaleCodecWriter, ApiVersion apiVersion) throws IOException {
+        scaleCodecWriter.writeByteArray(apiVersion.nameHash());
+        scaleCodecWriter.writeUint32(apiVersion.version().longValueExact());
+    }
+}

--- a/src/main/java/com/limechain/runtime/version/scale/RuntimeVersionWriter.java
+++ b/src/main/java/com/limechain/runtime/version/scale/RuntimeVersionWriter.java
@@ -1,0 +1,32 @@
+package com.limechain.runtime.version.scale;
+
+import com.limechain.runtime.version.RuntimeVersion;
+import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import io.emeraldpay.polkaj.scale.ScaleWriter;
+import io.emeraldpay.polkaj.scale.writer.ListWriter;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+public class RuntimeVersionWriter implements ScaleWriter<RuntimeVersion> {
+    @Override
+    public void write(ScaleCodecWriter scaleCodecWriter, RuntimeVersion runtimeVersion) throws IOException {
+        scaleCodecWriter.writeAsList(runtimeVersion.getSpecName().getBytes());
+        scaleCodecWriter.writeAsList(runtimeVersion.getImplementationName().getBytes());
+        scaleCodecWriter.writeUint32(runtimeVersion.getAuthoringVersion().longValueExact());
+        scaleCodecWriter.writeUint32(runtimeVersion.getSpecVersion().longValueExact());
+        scaleCodecWriter.writeUint32(runtimeVersion.getImplementationVersion().longValueExact());
+
+        // Write the api versions
+        scaleCodecWriter.write(new ListWriter<>(new ApiVersionWriter()), runtimeVersion.getApis().getEntries());
+
+        // Write transaction version if it's present (older runtimes don't include that field)
+        BigInteger transactionVersion = runtimeVersion.getTransactionVersion();
+        if (transactionVersion != null) {
+            scaleCodecWriter.writeUint32(transactionVersion.longValueExact());
+        }
+
+        // Write the state version if it's present. Older runtimes miss this field, so StateVersion 0 is to be presumed.
+        scaleCodecWriter.writeByte(runtimeVersion.getStateVersion().asInt());
+    }
+}

--- a/src/main/java/com/limechain/storage/trie/TrieStorage.java
+++ b/src/main/java/com/limechain/storage/trie/TrieStorage.java
@@ -1,9 +1,7 @@
 package com.limechain.storage.trie;
 
-import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.runtime.version.StateVersion;
 import com.limechain.storage.KVRepository;
-import com.limechain.storage.block.BlockState;
 import com.limechain.trie.dto.node.StorageNode;
 import com.limechain.trie.structure.TrieNodeIndex;
 import com.limechain.trie.structure.TrieStructure;
@@ -14,7 +12,6 @@ import com.limechain.trie.structure.nibble.Nibbles;
 import com.limechain.trie.structure.node.InsertTrieNode;
 import com.limechain.trie.structure.node.TrieNodeData;
 import io.emeraldpay.polkaj.types.Hash256;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.java.Log;
 import org.jetbrains.annotations.NotNull;
@@ -32,29 +29,9 @@ import java.util.logging.Level;
 public class TrieStorage {
 
     private static final String TRIE_NODE_PREFIX = "tn:";
-    @Getter
-    private static final TrieStorage instance = new TrieStorage();
     private KVRepository<String, Object> db;
 
-    /**
-     * Initializes the TrieStorage with a given key-value repository.
-     * This method must be called before using the TrieStorage instance.
-     *
-     * @param db The key-value repository to be used for storing trie nodes.
-     */
-
-    public void initialize(final KVRepository<String, Object> db) {
-        initialize(db, BlockState.getInstance());
-    }
-
-    /**
-     * Initializes the TrieStorage with a given key-value repository.
-     * This method must be called before using the TrieStorage instance.
-     *
-     * @param db         The key-value repository to be used for storing trie nodes.
-     * @param blockState The block state to be used for retrieving block headers.
-     */
-    protected void initialize(final KVRepository<String, Object> db, final BlockState blockState) {
+    public TrieStorage(KVRepository<String, Object> db) {
         this.db = db;
     }
 
@@ -312,68 +289,6 @@ public class TrieStorage {
                 collectKeysWithPrefix(childNode, fullPath, prefix, startKey, limit, keys, startKeyFound);
             }
         }
-    }
-
-    /**
-     * Retrieves trie entries within a specified range.
-     * <p>
-     * Fetches entries from the trie that fall within the range defined by the given search key,
-     * starting from the node identified by the provided merkle value.
-     *
-     * @param merkleValue The merkle value identifying the starting node in the trie.
-     * @param searchKey   The key defining the upper limit of the search range.
-     * @return A list of pairs, each containing a set of nibbles (representing a key within the trie)
-     * and the corresponding node data.
-     */
-    public List<StorageNode> entriesBetween(byte[] merkleValue, Nibbles searchKey) {
-        List<StorageNode> entries = new ArrayList<>();
-        TrieNodeData rootNode = getTrieNodeFromMerkleValue(merkleValue);
-
-        if (rootNode == null) {
-            return entries;
-        }
-
-        entries.add(
-                new StorageNode(rootNode.getPartialKey(),
-                        new NodeData(rootNode.getValue(), merkleValue)));
-
-        collectEntriesUpTo(rootNode, searchKey, rootNode.getPartialKey(), entries);
-
-        return entries;
-    }
-
-    private void collectEntriesUpTo(TrieNodeData node, Nibbles key, Nibbles currentPath, List<StorageNode> entries) {
-        if (node == null || key.isEmpty()) {
-            return;
-        }
-
-        var keyIter = key.iterator();
-        Nibble childIndexWithinParent = keyIter.next();
-        for (Nibble nibble : node.getPartialKey()) {
-            if (!childIndexWithinParent.equals(nibble)) {
-                break;
-            }
-
-            if (!keyIter.hasNext()) {
-                return;
-            }
-
-            childIndexWithinParent = keyIter.next();
-        }
-
-        byte[] childMerkleValue = node.getChildrenMerkleValues().get(childIndexWithinParent.asInt());
-        if (childMerkleValue == null) return; // Skip empty slots.
-
-        TrieNodeData childNode = getTrieNodeFromMerkleValue(childMerkleValue);
-        if (childNode == null) {
-            return;
-        }
-
-        Nibbles nextPath = currentPath.add(childIndexWithinParent).addAll(childNode.getPartialKey());
-
-        entries.add(new StorageNode(nextPath, new NodeData(childNode.getValue(), childMerkleValue)));
-
-        collectEntriesUpTo(childNode, Nibbles.of(keyIter), nextPath, entries);
     }
 
     /**

--- a/src/main/java/com/limechain/trie/TrieAccessor.java
+++ b/src/main/java/com/limechain/trie/TrieAccessor.java
@@ -1,5 +1,6 @@
 package com.limechain.trie;
 
+import com.limechain.rpc.server.AppBean;
 import com.limechain.runtime.version.StateVersion;
 import com.limechain.storage.DeleteByPrefixResult;
 import com.limechain.storage.KVRepository;
@@ -32,7 +33,7 @@ public class TrieAccessor implements KVRepository<Nibbles, byte[]> {
     public TrieAccessor(byte[] trieRoot) {
         this.lastRoot = trieRoot;
         this.loadedChildTries = new HashMap<>();
-        this.trieStorage = TrieStorage.getInstance();
+        this.trieStorage = AppBean.getBean(TrieStorage.class);
         this.initialTrie = trieStorage.loadTrieStructure(trieRoot);
     }
 

--- a/src/test/java/com/limechain/storage/trie/TrieStorageTest.java
+++ b/src/test/java/com/limechain/storage/trie/TrieStorageTest.java
@@ -44,9 +44,9 @@ class TrieStorageTest {
     void testGetByKeyFromBlock() {
         Nibbles key = Nibbles.fromBytes("testKey".getBytes());
         byte[] expectedValue = "testValue".getBytes();
-        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
-        BlockHeader mockBlockHeader = mock(BlockHeader.class);
-        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
+//        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
+//        BlockHeader mockBlockHeader = mock(BlockHeader.class);
+//        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
 
         final TrieNodeData trieNodeData =
                 new TrieNodeData(
@@ -60,9 +60,11 @@ class TrieStorageTest {
 
 
         when(db.find(anyString())).thenReturn(Optional.of(trieNodeData));
-        when(blockState.getHeader(mockBlockHash)).thenReturn(mockBlockHeader);
+//        when(blockState.getHeader(mockBlockHash)).thenReturn(mockBlockHeader);
+//        when(blockState.getBlockStateRoot(mockBlockHash)).thenReturn(mockBlockHash);
 
-        Optional<NodeData> result = trieStorage.getByKeyFromBlock(mockBlockHash, key);
+        byte[] blockStateRoot = Hash256.from(ROOT_HASH).getBytes();
+        Optional<NodeData> result = trieStorage.getByKeyFromMerkle(blockStateRoot, key);
 
         assertTrue(result.isPresent());
         assertArrayEquals(expectedValue, result.get().getValue());
@@ -73,38 +75,40 @@ class TrieStorageTest {
     @Test
     void testGetByKeyFromBlockWithNonMatchingKey() {
         String keyStr = "nonMatchingKey";
-        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
-        BlockHeader mockBlockHeader = mock(BlockHeader.class);
-        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
-        when(blockState.getHeader(mockBlockHash)).thenReturn(mockBlockHeader);
+//        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
+//        BlockHeader mockBlockHeader = mock(BlockHeader.class);
+//        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
+//        when(blockState.getHeader(mockBlockHash)).thenReturn(mockBlockHeader);
 
         when(db.find(anyString())).thenReturn(Optional.empty());
 
-        Optional<NodeData> result = trieStorage.getByKeyFromBlock(mockBlockHash, Nibbles.fromBytes(keyStr.getBytes()));
+        byte[] blockStateRoot = Hash256.from(ROOT_HASH).getBytes();
+        Optional<NodeData> result = trieStorage.getByKeyFromMerkle(blockStateRoot, Nibbles.fromBytes(keyStr.getBytes()));
 
         assertTrue(result.isEmpty());
 
         verify(db).find(anyString());
     }
 
-    @Test
-    void testGetByKeyFromBlockWithNullBlockHeader() {
-        Nibbles key = Nibbles.fromBytes("testKey".getBytes());
-        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
-
-        when(blockState.getHeader(mockBlockHash)).thenReturn(null);
-
-        Optional<NodeData> result = trieStorage.getByKeyFromBlock(mockBlockHash, key);
-
-        assertTrue(result.isEmpty());
-    }
+//    @Test
+//    void testGetByKeyFromBlockWithNullBlockHeader() {
+//        Nibbles key = Nibbles.fromBytes("testKey".getBytes());
+////        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
+////
+////        when(blockState.getHeader(mockBlockHash)).thenReturn(null);
+//
+//        byte[] blockStateRoot = Hash256.from(ROOT_HASH).getBytes();
+//        Optional<NodeData> result = trieStorage.getByKeyFromMerkle(blockStateRoot, key);
+//
+//        assertTrue(result.isEmpty());
+//    }
 
     @Test
     void testGetByKeyFromBlockWhenTrieNodeDoesNotMatch() {
         Nibbles key = Nibbles.fromBytes("testKey".getBytes());
-        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
-        BlockHeader mockBlockHeader = mock(BlockHeader.class);
-        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
+//        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
+//        BlockHeader mockBlockHeader = mock(BlockHeader.class);
+//        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
 
         // Simulate a trie node that does not directly match the provided key
         TrieNodeData nonMatchingTrieNodeData = new TrieNodeData(
@@ -115,10 +119,11 @@ class TrieStorageTest {
                 new byte[0],
                 (byte) 0);
         when(db.find(anyString())).thenReturn(Optional.of(nonMatchingTrieNodeData));
-        when(blockState.getHeader(mockBlockHash)).thenReturn(mockBlockHeader);
+//        when(blockState.getHeader(mockBlockHash)).thenReturn(mockBlockHeader);
 
         // Action
-        Optional<NodeData> result = trieStorage.getByKeyFromBlock(mockBlockHash, key);
+        byte[] blockStateRoot = Hash256.from(ROOT_HASH).getBytes();
+        Optional<NodeData> result = trieStorage.getByKeyFromMerkle(blockStateRoot, key);
 
         // Assert
         assertTrue(result.isEmpty());
@@ -128,11 +133,11 @@ class TrieStorageTest {
     void testGetNextKey() {
         Nibbles prefix = Nibbles.fromBytes("nextKe".getBytes());
         Nibbles actualKey = Nibbles.fromBytes("nextKey".getBytes());
-        Hash256 blockHash = Hash256.from(BLOCK_HASH);
-        BlockHeader mockBlockHeader = mock(BlockHeader.class);
-
-        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
-        when(blockState.getHeader(blockHash)).thenReturn(mockBlockHeader);
+//        Hash256 blockHash = Hash256.from(BLOCK_HASH);
+//        BlockHeader mockBlockHeader = mock(BlockHeader.class);
+//
+//        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
+//        when(blockState.getHeader(blockHash)).thenReturn(mockBlockHeader);
 
         // Setup a mock TrieNodeData that represents the next key
         TrieNodeData nextKeyNode = new TrieNodeData(
@@ -144,7 +149,8 @@ class TrieStorageTest {
         when(db.find(anyString())).thenReturn(Optional.of(nextKeyNode));
 
         // Action
-        Nibbles result = trieStorage.getNextKey(blockHash, prefix);
+        byte[] blockStateRoot = Hash256.from(ROOT_HASH).getBytes();
+        Nibbles result = trieStorage.getNextKeyByMerkleValue(blockStateRoot, prefix);
 
         // Assert
         assertEquals(actualKey, result);

--- a/src/test/java/com/limechain/storage/trie/TrieStorageTest.java
+++ b/src/test/java/com/limechain/storage/trie/TrieStorageTest.java
@@ -1,17 +1,16 @@
 package com.limechain.storage.trie;
 
 
-import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.storage.KVRepository;
-import com.limechain.storage.block.BlockState;
 import com.limechain.trie.structure.database.NodeData;
 import com.limechain.trie.structure.nibble.Nibbles;
 import com.limechain.trie.structure.node.TrieNodeData;
 import io.emeraldpay.polkaj.types.Hash256;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -21,47 +20,35 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class TrieStorageTest {
-
-    private static final String BLOCK_HASH = "0x7b22fc4469863c9671686c189a3238708033d364a77ba8d83e78777e7563f346";
     private static final String ROOT_HASH = "0x7b22fc4469863c9671686c189a3238708033d364a77ba8d83e78777e7563f347";
-    private final TrieStorage trieStorage = TrieStorage.getInstance();
-    private final BlockState blockState = mock(BlockState.class);
+
     @Mock
     private KVRepository<String, Object> db;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        trieStorage.initialize(db, blockState);
-    }
+    @InjectMocks
+    private TrieStorage trieStorage;
 
     @Test
     void testGetByKeyFromBlock() {
         Nibbles key = Nibbles.fromBytes("testKey".getBytes());
         byte[] expectedValue = "testValue".getBytes();
-//        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
-//        BlockHeader mockBlockHeader = mock(BlockHeader.class);
-//        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
 
         final TrieNodeData trieNodeData =
-                new TrieNodeData(
-                        false,
-                        key,
-                        IntStream.range(0, 16).mapToObj(__ -> (byte[]) null).toList(),
-                        expectedValue,
-                        new byte[0],
-                        (byte) 0
-                );
-
+            new TrieNodeData(
+                false,
+                key,
+                IntStream.range(0, 16).mapToObj(__ -> (byte[]) null).toList(),
+                expectedValue,
+                new byte[0],
+                (byte) 0
+            );
 
         when(db.find(anyString())).thenReturn(Optional.of(trieNodeData));
-//        when(blockState.getHeader(mockBlockHash)).thenReturn(mockBlockHeader);
-//        when(blockState.getBlockStateRoot(mockBlockHash)).thenReturn(mockBlockHash);
 
         byte[] blockStateRoot = Hash256.from(ROOT_HASH).getBytes();
         Optional<NodeData> result = trieStorage.getByKeyFromMerkle(blockStateRoot, key);
@@ -75,51 +62,31 @@ class TrieStorageTest {
     @Test
     void testGetByKeyFromBlockWithNonMatchingKey() {
         String keyStr = "nonMatchingKey";
-//        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
-//        BlockHeader mockBlockHeader = mock(BlockHeader.class);
-//        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
-//        when(blockState.getHeader(mockBlockHash)).thenReturn(mockBlockHeader);
 
         when(db.find(anyString())).thenReturn(Optional.empty());
 
         byte[] blockStateRoot = Hash256.from(ROOT_HASH).getBytes();
-        Optional<NodeData> result = trieStorage.getByKeyFromMerkle(blockStateRoot, Nibbles.fromBytes(keyStr.getBytes()));
+        Optional<NodeData> result =
+            trieStorage.getByKeyFromMerkle(blockStateRoot, Nibbles.fromBytes(keyStr.getBytes()));
 
         assertTrue(result.isEmpty());
 
         verify(db).find(anyString());
     }
 
-//    @Test
-//    void testGetByKeyFromBlockWithNullBlockHeader() {
-//        Nibbles key = Nibbles.fromBytes("testKey".getBytes());
-////        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
-////
-////        when(blockState.getHeader(mockBlockHash)).thenReturn(null);
-//
-//        byte[] blockStateRoot = Hash256.from(ROOT_HASH).getBytes();
-//        Optional<NodeData> result = trieStorage.getByKeyFromMerkle(blockStateRoot, key);
-//
-//        assertTrue(result.isEmpty());
-//    }
-
     @Test
     void testGetByKeyFromBlockWhenTrieNodeDoesNotMatch() {
         Nibbles key = Nibbles.fromBytes("testKey".getBytes());
-//        Hash256 mockBlockHash = Hash256.from(BLOCK_HASH);
-//        BlockHeader mockBlockHeader = mock(BlockHeader.class);
-//        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
 
         // Simulate a trie node that does not directly match the provided key
         TrieNodeData nonMatchingTrieNodeData = new TrieNodeData(
-                false,
-                Nibbles.fromHexString("01"), // Partial key that does not match the test key
-                IntStream.range(0, 16).mapToObj(__ -> (byte[]) null).toList(),
-                null,
-                new byte[0],
-                (byte) 0);
+            false,
+            Nibbles.fromHexString("01"), // Partial key that does not match the test key
+            IntStream.range(0, 16).mapToObj(__ -> (byte[]) null).toList(),
+            null,
+            new byte[0],
+            (byte) 0);
         when(db.find(anyString())).thenReturn(Optional.of(nonMatchingTrieNodeData));
-//        when(blockState.getHeader(mockBlockHash)).thenReturn(mockBlockHeader);
 
         // Action
         byte[] blockStateRoot = Hash256.from(ROOT_HASH).getBytes();
@@ -133,17 +100,12 @@ class TrieStorageTest {
     void testGetNextKey() {
         Nibbles prefix = Nibbles.fromBytes("nextKe".getBytes());
         Nibbles actualKey = Nibbles.fromBytes("nextKey".getBytes());
-//        Hash256 blockHash = Hash256.from(BLOCK_HASH);
-//        BlockHeader mockBlockHeader = mock(BlockHeader.class);
-//
-//        when(mockBlockHeader.getStateRoot()).thenReturn(Hash256.from(ROOT_HASH));
-//        when(blockState.getHeader(blockHash)).thenReturn(mockBlockHeader);
 
         // Setup a mock TrieNodeData that represents the next key
         TrieNodeData nextKeyNode = new TrieNodeData(
-                false,
-                actualKey,
-                new ArrayList<>(), "nextValue".getBytes(), new byte[0], (byte) 0);
+            false,
+            actualKey,
+            new ArrayList<>(), "nextValue".getBytes(), new byte[0], (byte) 0);
 
         // Assuming the database returns the mock TrieNodeData for the next key
         when(db.find(anyString())).thenReturn(Optional.of(nextKeyNode));

--- a/src/test/java/com/limechain/sync/fullsync/BlockExecutorIsolatedTest.java
+++ b/src/test/java/com/limechain/sync/fullsync/BlockExecutorIsolatedTest.java
@@ -1,0 +1,119 @@
+package com.limechain.sync.fullsync;
+
+import com.google.protobuf.ByteString;
+import com.limechain.chain.spec.ChainSpec;
+import com.limechain.network.protocol.blockannounce.scale.BlockHeaderScaleWriter;
+import com.limechain.network.protocol.warp.dto.Block;
+import com.limechain.network.protocol.warp.dto.BlockBody;
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import com.limechain.network.protocol.warp.dto.Extrinsics;
+import com.limechain.network.protocol.warp.dto.HeaderDigest;
+import com.limechain.network.protocol.warp.scale.reader.HeaderDigestReader;
+import com.limechain.network.protocol.warp.scale.writer.BlockBodyWriter;
+import com.limechain.runtime.research.hybrid.WasmRuntimeInstance;
+import com.limechain.runtime.research.hybrid.WasmRuntimeInstanceBuilder;
+import com.limechain.runtime.research.hybrid.context.Context;
+import com.limechain.runtime.research.hybrid.trieaccessor.TrieAccessor;
+import com.limechain.runtime.version.StateVersion;
+import com.limechain.storage.KVRepository;
+import com.limechain.storage.trie.TrieStorage;
+import com.limechain.trie.TrieStructureFactory;
+import com.limechain.utils.StringUtils;
+import com.limechain.utils.scale.ScaleUtils;
+import com.limechain.utils.scale.readers.PairReader;
+import io.emeraldpay.polkaj.scale.ScaleCodecReader;
+import io.emeraldpay.polkaj.scale.reader.ListReader;
+import io.emeraldpay.polkaj.types.Hash256;
+import lombok.extern.java.Log;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Log
+class BlockExecutorIsolatedTest {
+    @Test
+    void kusamaFirstBlock() throws IOException {
+        final byte[] genesisStateRoot =
+            StringUtils.hexToBytes("b0006203c3a6e6bd2c6a17b1d4ae8ca49a31da0f4579da950b127774b44aef6b");
+        Block block = getKusamaFirstBlock();
+
+        ChainSpec chainSpec = ChainSpec.newFromJSON("genesis/ksmcc3.json");
+        var genesisStorage = chainSpec.getGenesis().getTop();
+        var runtimeByteCode = genesisStorage.get(ByteString.copyFrom(":code".getBytes())).toByteArray();
+        var genesisTrie = TrieStructureFactory.buildFromKVPs(genesisStorage, StateVersion.V0);
+
+        KVRepository<String, Object> db = new InMemoryDB();
+
+        TrieStorage trieStorage = new TrieStorage(db);
+        trieStorage.insertTrieStorage(genesisTrie, StateVersion.V0);
+
+        TrieAccessor trieAccessor = new TrieAccessor(trieStorage, genesisStateRoot);
+
+        Context context = new Context(trieAccessor, null, null, false);
+
+        WasmRuntimeInstance genesisRuntime = new WasmRuntimeInstanceBuilder().buildRuntime(runtimeByteCode, context);
+
+        byte[] encodedUnsealedHeader =
+            ScaleUtils.Encode.encode(BlockHeaderScaleWriter.getInstance()::writeUnsealed, block.getHeader());
+
+        var encodedBody = ScaleUtils.Encode.encode(BlockBodyWriter.getInstance(), block.getBody());
+
+        var executeBlockParam = ArrayUtils.addAll(encodedUnsealedHeader, encodedBody);
+        var checkInherentsParam = FullSyncMachine.getCheckInherentsParameter(executeBlockParam);
+
+        // Check_inherents is ok
+        byte[] checkInherentsResponse = genesisRuntime.call("BlockBuilder_check_inherents", checkInherentsParam);
+
+        // Parse an expected babeslot error (expected since older runtimes since think this inherent will be passed to them, but it's deprecated)
+        boolean checkOk = checkInherentsResponse[0] == 1;
+        boolean fatalErrorEncountered = checkInherentsResponse[1] == 1;
+        var data =
+            ScaleUtils.Decode.decode(ArrayUtils.subarray(checkInherentsResponse, 2, checkInherentsResponse.length),
+                new ListReader<>(
+                    new PairReader<>(scr -> new String(scr.readByteArray(8)), scr -> new String(scr.readByteArray()))));
+
+        // Assert that the first kusama block is properly encoded as a parameter to the runtime
+        assertArrayEquals(
+            StringUtils.hexToBytes(
+                "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe04fabb0c6e92d29e8bb2167f3c6fb0ddeb956a4278a3cf853661af74a076fc9cb7a35fb7f7616f5c979d48222b3d2fa7cb2331ef73954726714d91ca945cc34fd8080642414245340201000000ef55a50f00000000044241424549040118ca239392960473fe1bc65f94ee27d890a49c1b200c006ff5dcc525330ecc16770100000000000000b46f01874ce7abbb5220e8fd89bede0adad14c73039d91e28e881823433e723f0100000000000000d684d9176d6eb69887540c9a89fa6097adea82fc4b0ff26d1062b488f352e179010000000000000068195a71bdde49117a616424bdc60a1733e96acb1da5aeab5d268cf2a572e94101000000000000001a0575ef4ae24bdfd31f4cb5bd61239ae67c12d4e64ae51ac756044aa6ad8200010000000000000018168f2aad0081a25728961ee00627cfe35e39833c805016632bf7c14da580090100000000000000000000000000000000000000000000000000000000000000000000000000000008280402000b90110eb36e011004140000"),
+            executeBlockParam);
+
+        // Attempt to execute a block
+        log.info("Executing block");
+        byte[] executeBlockResponse = genesisRuntime.call("Core_execute_block", executeBlockParam);
+
+        // This recalculates it again... where do we fetch the actual result from... the db?
+        byte[] actualRoot = context.getTrieAccessor().getMerkleRoot(StateVersion.V0);
+
+        byte[] expectedRoot = Hash256.from("0xfabb0c6e92d29e8bb2167f3c6fb0ddeb956a4278a3cf853661af74a076fc9cb7").getBytes();
+        assertArrayEquals(expectedRoot, actualRoot, "State root must mach the one in the block header.");
+
+        assertTrue(true);
+    }
+
+    private Block getKusamaFirstBlock() {
+        byte[] scaleEncodedBody = new byte[] {8, 40, 4, 2, 0, 11, -112, 17, 14, -77, 110, 1, 16, 4, 20, 0, 0};
+        byte[] scaleEncodedDigest = StringUtils.hexToBytes(
+            "0x0c0642414245340201000000ef55a50f00000000044241424549040118ca239392960473fe1bc65f94ee27d890a49c1b200c006ff5dcc525330ecc16770100000000000000b46f01874ce7abbb5220e8fd89bede0adad14c73039d91e28e881823433e723f0100000000000000d684d9176d6eb69887540c9a89fa6097adea82fc4b0ff26d1062b488f352e179010000000000000068195a71bdde49117a616424bdc60a1733e96acb1da5aeab5d268cf2a572e94101000000000000001a0575ef4ae24bdfd31f4cb5bd61239ae67c12d4e64ae51ac756044aa6ad8200010000000000000018168f2aad0081a25728961ee00627cfe35e39833c805016632bf7c14da5800901000000000000000000000000000000000000000000000000000000000000000000000000000000054241424501014625284883e564bc1e4063f5ea2b49846cdddaa3761d04f543b698c1c3ee935c40d25b869247c36c6b8a8cbbd7bb2768f560ab7c276df3c62df357a7e3b1ec8d");
+
+        BlockHeader header = new BlockHeader();
+        header.setParentHash(Hash256.from("0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe"));
+        header.setBlockNumber(BigInteger.valueOf(1));
+        header.setStateRoot(Hash256.from("0xfabb0c6e92d29e8bb2167f3c6fb0ddeb956a4278a3cf853661af74a076fc9cb7"));
+        header.setExtrinsicsRoot(Hash256.from("0xa35fb7f7616f5c979d48222b3d2fa7cb2331ef73954726714d91ca945cc34fd8"));
+        header.setDigest(
+            ScaleUtils.Decode.decodeList(scaleEncodedDigest, new HeaderDigestReader()).toArray(HeaderDigest[]::new));
+
+        var exts = ScaleUtils.Decode.decodeList(scaleEncodedBody, ScaleCodecReader::readByteArray);
+        assertEquals(2, exts.size());
+        BlockBody body = new BlockBody(exts.stream().map(Extrinsics::new).toList());
+
+        return new Block(header, body);
+    }
+}

--- a/src/test/java/com/limechain/sync/fullsync/InMemoryDB.java
+++ b/src/test/java/com/limechain/sync/fullsync/InMemoryDB.java
@@ -1,0 +1,74 @@
+package com.limechain.sync.fullsync;
+
+import com.limechain.storage.DeleteByPrefixResult;
+import com.limechain.storage.KVRepository;
+import org.apache.commons.collections4.trie.PatriciaTrie;
+
+import java.util.List;
+import java.util.Optional;
+
+public class InMemoryDB implements KVRepository<String, Object> {
+    private final PatriciaTrie<Object> storage = new PatriciaTrie<>();
+
+    @Override
+    public boolean save(String key, Object value) {
+        storage.put(key, value);
+        return true;
+    }
+
+    @Override
+    public Optional<Object> find(String key) {
+        return Optional.ofNullable(storage.get(key));
+    }
+
+    @Override
+    public boolean delete(String key) {
+        storage.remove(key);
+        return true;
+    }
+
+    @Override
+    public List<byte[]> findKeysByPrefix(String prefixSeek, int limit) {
+        return storage.prefixMap(prefixSeek).keySet().stream().map(String::getBytes).limit(limit).toList();
+    }
+
+    @Override
+    public DeleteByPrefixResult deleteByPrefix(String prefix, Long limit) {
+        var keys = this.findKeysByPrefix(prefix, limit.intValue());
+
+        int deleted = 0;
+        for (var key : keys) {
+            storage.remove(new String(key));
+            deleted++;
+        }
+
+        boolean allDeleted = this.findKeysByPrefix(prefix, limit.intValue()).isEmpty();
+
+        return new DeleteByPrefixResult(deleted, allDeleted);
+    }
+
+    @Override
+    public Optional<String> getNextKey(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void startTransaction() {
+
+    }
+
+    @Override
+    public void rollbackTransaction() {
+
+    }
+
+    @Override
+    public void commitTransaction() {
+
+    }
+
+    @Override
+    public void closeConnection() {
+
+    }
+}


### PR DESCRIPTION
# Description

Decouple the Spring app from runtime invocations. This PR showcases a variant of this decoupling using an explicit `Context` object to pass to the runtime builder, in which object all necessary dependencies for the host API endpoints are contained, thus granting the caller the ability to define all interactions from the runtime to the outside world through the behaviour of these dependencies.

The main goal of this MWE is to execute the first block in Kusama without ever starting the Spring app (i.e. in isolation). In more practical terms: to rewrite the previously existing `BlockExecutorTest`, and the new variant can be found in [BlockExecutorIsolatedTest](https://github.com/LimeChain/Fruzhin/blob/5d313edcb5d1c3ef99d0ff188d2f9096e9f0f7a3/src/test/java/com/limechain/sync/fullsync/BlockExecutorIsolatedTest.java#L41). The diff between the two tests is the starting point for grasping all the changes. 

The bulk of refactoring is isolated in the package `com.limechain.runtime.research.hybrid`, where I've copied a lot of existing classes in an isolated environment and made changes on the copies, since applying changes in the already existing production classes quickly proved to be non-viable for the purpose of achieving a MWE.

Breakdown on the main changes within `com.limechain.runtime.research.hybrid`:
- `org.wasmer.Memory` and `FreeingBumpHeapAllocator` have been put behind interfaces;
- `TrieAccessor`s are now injected the `TrieStorage` dependency on construction;
- regarding the host api:
  - an `Endpoint` enumeration of all host api endpoints has been introduced, holding "just data", i.e. the signatures of the host api endpoints;
  - a `HostApiImpl` class is introduced to explicitly hold implementations of the endpoints and to simplify creation of `ImportObject`s exhaustively;
- `Runtime` and `RuntimeBuilder` have been renamed to `WasmRuntimeInstace` and `WasmRuntimeInstanceBuilder` (names are WIP) and now obtain an explicit `Context` object on construction;

Other notable changes (outside the `hybrid` package) which were necessary to achieve this decoupling:
- remove the `BlockState` field of `TrieStorage`, as it breaks separation of concerns;
- `TrieStorage` is no longer a static singleton instance, as it is an implicit member of the `Context` (through the `TrieAccessor`);
- [SIDE FIX / QUESTIONABLE] The runtime builder is now used for [the runtimeVersionV1 endpoint](https://github.com/LimeChain/Fruzhin/blob/21547d7005434d58ac867b4bca050219a99987fc/src/main/java/com/limechain/runtime/hostapi/MiscellaneousHostFunctions.java#L106) instead of manual instantiation. More details at this commit: 21547d7005434d58ac867b4bca050219a99987fc.