### PR TITLE
refactor: dynamically load memory import

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 }
 
 dependencies {
+    implementation("com.dylibso.chicory:wasm:0.0.10")
     implementation("net.openhft:zero-allocation-hashing:0.16")
     implementation("org.rocksdb:rocksdbjni:9.1.1")
     compileOnly("org.projectlombok:lombok:1.18.32")

--- a/src/main/java/com/limechain/runtime/Runtime.java
+++ b/src/main/java/com/limechain/runtime/Runtime.java
@@ -15,7 +15,6 @@ import org.wasmer.Memory;
 import org.wasmer.Module;
 
 import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.logging.Level;
 
 import static com.limechain.runtime.RuntimeBuilder.getImports;

--- a/src/main/java/com/limechain/runtime/Runtime.java
+++ b/src/main/java/com/limechain/runtime/Runtime.java
@@ -8,11 +8,14 @@ import lombok.Getter;
 import lombok.extern.java.Log;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.wasmer.ImportObject;
+import org.wasmer.Imports;
 import org.wasmer.Instance;
 import org.wasmer.Memory;
 import org.wasmer.Module;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.logging.Level;
 
 import static com.limechain.runtime.RuntimeBuilder.getImports;
@@ -25,9 +28,9 @@ public class Runtime {
     private final int heapPages;
     private final FreeingBumpHeapAllocator allocator;
 
-    public Runtime(Module module, int heapPages) {
+    public Runtime(Module module, ImportObject.MemoryImport memoryImport, int heapPages) {
         this.heapPages = heapPages;
-        this.instance = module.instantiate(getImports(module, this));
+        this.instance = module.instantiate(Imports.from(getImports(memoryImport, this), module));
         this.allocator = new FreeingBumpHeapAllocator(getHeapBase());
     }
 

--- a/src/main/java/com/limechain/runtime/WasmSectionUtils.java
+++ b/src/main/java/com/limechain/runtime/WasmSectionUtils.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 public class WasmSectionUtils {
     private static final String RUNTIME_VERSION_SECTION_NAME = "runtime_version";
     private static final String RUNTIME_APIS_SECTION_NAME = "runtime_apis";
+    private static final int DEFAULT_MINIMUM_MEMORY_PAGES = 24;
 
     /**
      * Parses the runtime version if both wasm custom sections ("runtime_apis" and "runtime_version") are present.
@@ -66,7 +67,7 @@ public class WasmSectionUtils {
                 .findFirst()
                 .orElse(null);
         return new ImportObject.MemoryImport("env",
-                parsedMemoryImport != null ? parsedMemoryImport.limits().initialPages() : 24,
+                parsedMemoryImport != null ? parsedMemoryImport.limits().initialPages() : DEFAULT_MINIMUM_MEMORY_PAGES,
                 false);
     }
 

--- a/src/main/java/com/limechain/runtime/WasmSectionUtils.java
+++ b/src/main/java/com/limechain/runtime/WasmSectionUtils.java
@@ -1,21 +1,27 @@
 package com.limechain.runtime;
 
-import com.limechain.exception.misc.WasmRuntimeException;
-import com.limechain.runtime.version.scale.RuntimeVersionReader;
+import com.dylibso.chicory.log.SystemLogger;
+import com.dylibso.chicory.wasm.Module;
+import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.types.ImportSection;
+import com.dylibso.chicory.wasm.types.MemoryImport;
+import com.dylibso.chicory.wasm.types.SectionId;
+import com.dylibso.chicory.wasm.types.UnknownCustomSection;
 import com.limechain.runtime.version.ApiVersions;
 import com.limechain.runtime.version.RuntimeVersion;
-import com.limechain.utils.ByteArrayUtils;
+import com.limechain.runtime.version.scale.RuntimeVersionReader;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.Nullable;
+import org.wasmer.ImportObject;
 
-import java.util.Arrays;
+import java.io.ByteArrayInputStream;
 import java.util.Objects;
 
 @UtilityClass
 public class WasmSectionUtils {
-    private static final byte[] RUNTIME_VERSION_SECTION_NAME = "runtime_version".getBytes();
-    private static final byte[] RUNTIME_APIS_SECTION_NAME = "runtime_apis".getBytes();
+    private static final String RUNTIME_VERSION_SECTION_NAME = "runtime_version";
+    private static final String RUNTIME_APIS_SECTION_NAME = "runtime_apis";
 
     /**
      * Parses the runtime version if both wasm custom sections ("runtime_apis" and "runtime_version") are present.
@@ -23,18 +29,13 @@ public class WasmSectionUtils {
      * @return the parsed RuntimeVersion if both custom sections are present, null otherwise
      */
     @Nullable
-    public RuntimeVersion parseRuntimeVersionFromCustomSections(byte[] wasmBinary) {
-        // byte value of \0asm concatenated with 0x1, 0x0, 0x0, 0x0
-        // taken from Smoldot: https://github.com/smol-dot/smoldot/blob/21be5a1abaebeaf7270a744485b4551da8636fb1/lib/src/executor/host/runtime_version.rs#L97
-        byte[] searchKey = new byte[]{0x00, 0x61, 0x73, 0x6D, 0x1, 0x0, 0x0, 0x0};
+    public RuntimeVersion parseRuntimeVersionFromBinary(byte[] wasmBinary) {
+        Module moduleWithCustomSections = toModuleWithSections(wasmBinary, SectionId.CUSTOM);
 
-        int searchedKeyIndex = ByteArrayUtils.indexOf(wasmBinary, searchKey);
-        if (searchedKeyIndex < 0) {
-            throw new WasmRuntimeException("Key not found in runtime code.");
-        }
-
-        WasmCustomSection runtimeApis = findRuntimeApisCustomSection(wasmBinary);
-        WasmCustomSection runtimeVersion = findRuntimeVersionCustomSection(wasmBinary);
+        UnknownCustomSection runtimeApis = (UnknownCustomSection) moduleWithCustomSections
+                .customSection(RUNTIME_APIS_SECTION_NAME);
+        UnknownCustomSection runtimeVersion = (UnknownCustomSection) moduleWithCustomSections
+                .customSection(RUNTIME_VERSION_SECTION_NAME);
 
         // If we're missing any of the two custom sections, fallback to `Core_runtime`
         if (Objects.isNull(runtimeApis) || Objects.isNull(runtimeVersion)) {
@@ -42,83 +43,40 @@ public class WasmSectionUtils {
         }
 
         // Read as many api versions as there are (we don't know the length for some reason).
-        ApiVersions apiVersions = ApiVersions.decodeNoLength(runtimeApis.content());
+        ApiVersions apiVersions = ApiVersions.decodeNoLength(runtimeApis.bytes());
 
         // Construct the runtime version partially uninitialized,
         // and then immediately set its apis we've read from the custom section.
-        RuntimeVersion version = new RuntimeVersionReader().read(new ScaleCodecReader(runtimeVersion.content()));
+        RuntimeVersion version = new RuntimeVersionReader().read(new ScaleCodecReader(runtimeVersion.bytes()));
         version.setApis(apiVersions);
 
         return version;
     }
 
     /**
-     * Finds the "runtime_apis" custom section in the given wasm binary
+     * Parses the import section of a wasm blob and extracts the "memory" import if present.
+     * @param wasmBinary the wasm blob
+     * @return the parsed {@link org.wasmer.ImportObject.MemoryImport} if present,
+     * a default one with 24 initial pages otherwise
      */
-    @Nullable
-    public WasmCustomSection findRuntimeApisCustomSection(byte[] wasmBinary) {
-        return findCustomSection(wasmBinary, RUNTIME_APIS_SECTION_NAME);
+    public ImportObject.MemoryImport parseMemoryImportFromBinary(byte[] wasmBinary) {
+        ImportSection importSection = toModuleWithSections(wasmBinary, SectionId.IMPORT).importSection();
+        MemoryImport parsedMemoryImport = (MemoryImport) importSection.stream()
+                .filter(i -> i.name().equals("memory"))
+                .findFirst()
+                .orElse(null);
+        return new ImportObject.MemoryImport("env",
+                parsedMemoryImport != null ? parsedMemoryImport.limits().initialPages() : 24,
+                false);
     }
 
-    /**
-     * Finds the "runtime_version" custom section in the given wasm binary
-     */
-    @Nullable
-    public WasmCustomSection findRuntimeVersionCustomSection(byte[] wasmBinary) {
-        return WasmSectionUtils.findCustomSection(wasmBinary, RUNTIME_VERSION_SECTION_NAME);
-    }
+    private Module toModuleWithSections(byte[] wasmBinary, int... sectionIds) {
+        Parser parser = new Parser(new SystemLogger());
 
-    /**
-     * Finds a wasm custom section by name
-     * @param wasmBytes the wasm blob
-     * @param sectionName the name of the custom section we're looking for
-     * @return the parsed wasm custom section with the given name,
-     *         null if no section with this name is found in the wasm blob
-     * @see WasmCustomSection for the data conatined in a "found custom section"
-     */
-    @Nullable
-    public WasmCustomSection findCustomSection(byte[] wasmBytes, byte[] sectionName) {
-        // Start after the Wasm file header
-        int offset = 8;
-
-        while (offset < wasmBytes.length) {
-            // Read section ID
-            int sectionId = wasmBytes[offset++];
-
-            // Read section size (as varint)
-            int sectionSize = 0;
-            int shift = 0;
-            byte byteRead;
-            do {
-                byteRead = wasmBytes[offset++];
-                sectionSize |= (byteRead & 0x7f) << shift;
-                shift += 7;
-            } while (byteRead < 0);
-
-            if (sectionId == 0) {
-                // Custom section found
-                // Extract its name
-                byte[] customSectionNameAndContent = new byte[sectionSize];
-                System.arraycopy(wasmBytes, offset, customSectionNameAndContent, 0, sectionSize);
-
-                ScaleCodecReader reader = new ScaleCodecReader(customSectionNameAndContent);
-                int nameSize = reader.readUByte();
-                byte[] sectionNameDecoded = reader.readByteArray(nameSize);
-
-                // If it's the name we're looking for, parse and return
-                if (Arrays.equals(sectionNameDecoded, sectionName)) {
-                    int contentSize = sectionSize - nameSize - 1;
-                    byte[] sectionContent = new byte[contentSize];
-                    System.arraycopy(customSectionNameAndContent, nameSize + 1, sectionContent, 0, contentSize);
-
-                    return new WasmCustomSection(sectionNameDecoded, sectionContent);
-                }
-            }
-
-            // Move the offset to the next section
-            offset += sectionSize;
+        for (int sectionId : sectionIds) {
+            parser.includeSection(sectionId);
         }
 
-        return null;
+        return parser.parseModule(new ByteArrayInputStream(wasmBinary));
     }
 }

--- a/src/main/java/com/limechain/runtime/hostapi/MiscellaneousHostFunctions.java
+++ b/src/main/java/com/limechain/runtime/hostapi/MiscellaneousHostFunctions.java
@@ -3,6 +3,7 @@ package com.limechain.runtime.hostapi;
 import com.limechain.exception.scale.ScaleEncodingException;
 import com.limechain.runtime.Runtime;
 import com.limechain.runtime.RuntimeBuilder;
+import com.limechain.runtime.WasmSectionUtils;
 import com.limechain.runtime.hostapi.dto.RuntimePointerSize;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
 import lombok.AccessLevel;
@@ -110,7 +111,8 @@ public class MiscellaneousHostFunctions {
         try {
             // TODO: Refactor using RuntimeBuilder... when we're sure it works properly
             Module module = new Module(wasmBlob);
-            Runtime newRuntime = new Runtime(module, RuntimeBuilder.DEFAULT_HEAP_PAGES);
+            ImportObject.MemoryImport memoryImport = WasmSectionUtils.parseMemoryImportFromBinary(wasmBlob);
+            Runtime newRuntime = new Runtime(module, memoryImport, RuntimeBuilder.DEFAULT_HEAP_PAGES);
             byte[] runtimeVersionData = newRuntime.call("Core_version");
             versionOption = scaleEncodedOption(runtimeVersionData);
         } catch (UnsatisfiedLinkError e) {

--- a/src/test/java/com/limechain/runtime/RuntimeWasmTest.java
+++ b/src/test/java/com/limechain/runtime/RuntimeWasmTest.java
@@ -2,6 +2,7 @@ package com.limechain.runtime;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.wasmer.ImportObject;
 import org.wasmer.Module;
 
 import java.io.IOException;
@@ -14,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Disabled("This is an integration test")
 class RuntimeWasmTest {
     private static final Path HELLO_WORLD_PATH = Paths.get("src","test","resources","hello_world.wasm");
+    private static final ImportObject.MemoryImport MEMORY_IMPORT =
+            new ImportObject.MemoryImport("env", 24, false);
 
     // values extracted from a .wat file generated from hello_world.wasm,
     // using https://webassembly.github.io/wabt/demo/wasm2wat/
@@ -23,7 +26,7 @@ class RuntimeWasmTest {
     @Test
     void runtimeGetHeapBase() throws IOException {
         Module module = new Module(Files.readAllBytes(HELLO_WORLD_PATH));
-        Runtime runtime = new Runtime(module, 0);
+        Runtime runtime = new Runtime(module, MEMORY_IMPORT, 0);
 
         int heapBase = runtime.getHeapBase();
 
@@ -33,7 +36,7 @@ class RuntimeWasmTest {
     @Test
     void runtimeGetDataEnd() throws IOException {
         Module module = new Module(Files.readAllBytes(HELLO_WORLD_PATH));
-        Runtime runtime = new Runtime(module, 0);
+        Runtime runtime = new Runtime(module, MEMORY_IMPORT, 0);
 
         int dataEnd = runtime.getDataEnd();
 

--- a/src/test/java/com/limechain/runtime/WasmSectionUtilsTest.java
+++ b/src/test/java/com/limechain/runtime/WasmSectionUtilsTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class WasmSectionUtilsTest {
     @Test
-    void test_parseRuntimeVersionFromCustomSections_success() throws IOException {
+    void test_parseRuntimeVersionFromBinary_success() throws IOException {
         // expected data extracted from Smoldot, given the same wasm blob
         RuntimeVersion expectedRuntimeVersion = new RuntimeVersion();
         expectedRuntimeVersion.setSpecName("node-template");
@@ -85,7 +85,7 @@ class WasmSectionUtilsTest {
         try (InputStream wasmBytesInput = this.getClass().getResourceAsStream("/runtime_version_custom_section.wasm")) {
             byte[] wasmBytes = Objects.requireNonNull(wasmBytesInput).readAllBytes();
 
-            RuntimeVersion actualRuntimeVersion = WasmSectionUtils.parseRuntimeVersionFromCustomSections(wasmBytes);
+            RuntimeVersion actualRuntimeVersion = WasmSectionUtils.parseRuntimeVersionFromBinary(wasmBytes);
 
             assertEquals(expectedRuntimeVersion, actualRuntimeVersion);
         }


### PR DESCRIPTION
# Description
Switch to dynamically loading the memory import from the provided wasm files. Also removes the manual parsing logic for the custom sections.

- What does this PR do?
Loads the memory import dynamically from the provided runtime wasm. Further Improves the custom section parsing.

- Why are these changes needed?
Defining a static memory import causes runtime init failure when the runtimes change their minimum memory limits.

- How were these changes implemented and what do they affect?
They're implemented with the help of [this parser.](https://github.com/dylibso/chicory/tree/main/wasm). The memory import is extracted before the initialization of the runtime instance and loaded in its imports.

Fixes #445 
## Checklist:
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.