### PR TITLE
feat: handle block tree after warp sync 

### DIFF
--- a/src/main/java/com/limechain/client/FullNode.java
+++ b/src/main/java/com/limechain/client/FullNode.java
@@ -59,7 +59,7 @@ public class FullNode implements HostNode {
         switch (args.syncMode()) {
             case FULL -> fullSyncMachine.start();
             case WARP -> {
-                warpSyncMachine.onFinish(() -> fullSyncMachine.start());
+                warpSyncMachine.onFinish(fullSyncMachine::start);
                 warpSyncMachine.start();
             }
             default -> throw new IllegalStateException("Unexpected value: " + args.syncMode());

--- a/src/main/java/com/limechain/network/Network.java
+++ b/src/main/java/com/limechain/network/Network.java
@@ -120,16 +120,16 @@ public class Network {
 
         String pingProtocol = ProtocolUtils.PING_PROTOCOL;
         String chainId = chainService.getChainSpec().getProtocolId();
-        String protocolId = cliArgs.noLegacyProtocols()
-                ? StringUtils.remove0xPrefix(genesisBlockHash.getGenesisHash().toString())
-                : chainId;
+        boolean legacyProtocol = !cliArgs.noLegacyProtocols();
+        String protocolId = legacyProtocol ? chainId :
+                StringUtils.remove0xPrefix(genesisBlockHash.getGenesisHash().toString());
         String kadProtocolId = ProtocolUtils.getKadProtocol(chainId);
         String warpProtocolId = ProtocolUtils.getWarpSyncProtocol(protocolId);
         String lightProtocolId = ProtocolUtils.getLightMessageProtocol(protocolId);
         String syncProtocolId = ProtocolUtils.getSyncProtocol(protocolId);
         String stateProtocolId = ProtocolUtils.getStateProtocol(protocolId);
         String blockAnnounceProtocolId = ProtocolUtils.getBlockAnnounceProtocol(protocolId);
-        String grandpaProtocolId = ProtocolUtils.getGrandpaProtocol(protocolId);
+        String grandpaProtocolId = ProtocolUtils.getGrandpaProtocol(protocolId, legacyProtocol);
         String transactionsProtocolId = ProtocolUtils.getTransactionsProtocol(protocolId);
 
         kademliaService = new KademliaService(kadProtocolId, hostId, isLocalEnabled, clientMode);

--- a/src/main/java/com/limechain/network/ProtocolUtils.java
+++ b/src/main/java/com/limechain/network/ProtocolUtils.java
@@ -31,6 +31,10 @@ public final class ProtocolUtils {
         return String.format("/%s/kad", chainId);
     }
 
+    public static String getGrandpaProtocol(String chainId, boolean legacyProtocol) {
+        return String.format("/%s/grandpa/1", legacyProtocol ? "paritytech" : chainId);
+    }
+
     public static String getGrandpaProtocol(String chainId) {
         return String.format("/%s/grandpa/1", grandpaProtocolChain(chainId));
     }

--- a/src/main/java/com/limechain/network/ProtocolUtils.java
+++ b/src/main/java/com/limechain/network/ProtocolUtils.java
@@ -35,10 +35,6 @@ public final class ProtocolUtils {
         return String.format("/%s/grandpa/1", legacyProtocol ? "paritytech" : chainId);
     }
 
-    public static String getGrandpaProtocol(String chainId) {
-        return String.format("/%s/grandpa/1", grandpaProtocolChain(chainId));
-    }
-
     //TODO: figure out a more elegant solution
     private static String grandpaProtocolChain(String chainId) {
         return chainId.equals("dot") ? "paritytech" : chainId;

--- a/src/main/java/com/limechain/network/ProtocolUtils.java
+++ b/src/main/java/com/limechain/network/ProtocolUtils.java
@@ -35,11 +35,6 @@ public final class ProtocolUtils {
         return String.format("/%s/grandpa/1", legacyProtocol ? "paritytech" : chainId);
     }
 
-    //TODO: figure out a more elegant solution
-    private static String grandpaProtocolChain(String chainId) {
-        return chainId.equals("dot") ? "paritytech" : chainId;
-    }
-
     public static String getTransactionsProtocol(String chainId) {
         return String.format("/%s/transactions/1", chainId);
     }

--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
@@ -88,7 +88,9 @@ public class BlockAnnounceEngine {
                 " parentHash:" + announce.getHeader().getParentHash() +
                 " stateRoot:" + announce.getHeader().getStateRoot());
 
-        BlockState.getInstance().addBlockToBlockTree(announce.getHeader());
+        if (BlockState.getInstance().isInitialized()) {
+            BlockState.getInstance().addBlockToBlockTree(announce.getHeader());
+        }
     }
 
     public void writeHandshakeToStream(Stream stream, PeerId peerId) {

--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
@@ -1,7 +1,6 @@
 package com.limechain.network.protocol.blockannounce;
 
 import com.limechain.exception.scale.ScaleEncodingException;
-import com.limechain.exception.storage.BlockNodeNotFoundException;
 import com.limechain.network.ConnectionManager;
 import com.limechain.network.protocol.blockannounce.messages.BlockAnnounceHandshake;
 import com.limechain.network.protocol.blockannounce.messages.BlockAnnounceHandshakeBuilder;
@@ -9,8 +8,6 @@ import com.limechain.network.protocol.blockannounce.messages.BlockAnnounceMessag
 import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceHandshakeScaleReader;
 import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceHandshakeScaleWriter;
 import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceMessageScaleReader;
-import com.limechain.network.protocol.warp.dto.Block;
-import com.limechain.network.protocol.warp.dto.BlockBody;
 import com.limechain.rpc.server.AppBean;
 import com.limechain.storage.block.BlockState;
 import com.limechain.sync.warpsync.WarpSyncState;
@@ -24,7 +21,6 @@ import lombok.extern.java.Log;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.logging.Level;
 
 @Log

--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
@@ -92,26 +92,7 @@ public class BlockAnnounceEngine {
                 " parentHash:" + announce.getHeader().getParentHash() +
                 " stateRoot:" + announce.getHeader().getStateRoot());
 
-        if (BlockState.getInstance().isInitialized()) {
-            if (BlockState.getInstance().isFullSyncFinished()) {
-
-                BlockState.getInstance().processPendingBlocksFromQueue();
-
-                if (BlockState.getInstance().getPendingBlocksQueue().isEmpty()) {
-                    try {
-                        BlockState.getInstance().addBlock(new Block(announce.getHeader(), new BlockBody(new ArrayList<>())));
-                        return;
-                    } catch (BlockNodeNotFoundException ignored) {
-                        //TODO: Handle the error
-                        // Currently we ignore this exception, because our syncing strategy as full node is not implemented yet.
-                        // And thus when we receive a block announce and try to add it in the BlockState we will get this
-                        // exception because the parent block of the received one is not found in the BlockState.
-                    }
-                }
-            }
-
-            BlockState.getInstance().addBlockToQueue(announce.getHeader());
-        }
+        BlockState.getInstance().addBlockToBlockTree(announce.getHeader());
     }
 
     public void writeHandshakeToStream(Stream stream, PeerId peerId) {

--- a/src/main/java/com/limechain/storage/block/BlockState.java
+++ b/src/main/java/com/limechain/storage/block/BlockState.java
@@ -768,6 +768,10 @@ public class BlockState {
     public void setFinalizedHash(final Hash256 hash, final BigInteger round, final BigInteger setId) {
         if (!fullSyncFinished) return;
 
+        if (!initialized) {
+            throw new IllegalStateException("BlockState not initialized");
+        }
+
         if (!hasHeader(hash)) {
             throw new BlockNodeNotFoundException("Cannot finalise unknown block " + hash);
         }

--- a/src/main/java/com/limechain/storage/block/BlockState.java
+++ b/src/main/java/com/limechain/storage/block/BlockState.java
@@ -768,10 +768,6 @@ public class BlockState {
     public void setFinalizedHash(final Hash256 hash, final BigInteger round, final BigInteger setId) {
         if (!fullSyncFinished) return;
 
-        if (!initialized) {
-            throw new IllegalStateException("BlockState not initialized");
-        }
-
         if (!hasHeader(hash)) {
             throw new BlockNodeNotFoundException("Cannot finalise unknown block " + hash);
         }
@@ -929,10 +925,6 @@ public class BlockState {
     }
 
     public synchronized void addBlockToBlockTree(BlockHeader blockHeader) {
-        if (!initialized) {
-            throw new IllegalStateException("BlockState not initialized");
-        }
-
         if (!fullSyncFinished) {
             addBlockToQueue(blockHeader);
             return;

--- a/src/main/java/com/limechain/storage/block/SyncState.java
+++ b/src/main/java/com/limechain/storage/block/SyncState.java
@@ -76,7 +76,10 @@ public class SyncState {
                 this.stateRoot = blockByHash.getHeader().getStateRoot();
                 this.lastFinalizedBlockHash = commitMessage.getVote().getBlockHash();
                 this.lastFinalizedBlockNumber = commitMessage.getVote().getBlockNumber();
+
+                BlockState.getInstance().setFinalizedHash(commitMessage.getVote().getBlockHash(), commitMessage.getRoundNumber(), commitMessage.getSetId());
             }
+
         } catch (HeaderNotFoundException ignored) {
             log.fine("Received commit message for a block that is not in the block store");
         }

--- a/src/main/java/com/limechain/storage/block/SyncState.java
+++ b/src/main/java/com/limechain/storage/block/SyncState.java
@@ -77,7 +77,9 @@ public class SyncState {
                 this.lastFinalizedBlockHash = commitMessage.getVote().getBlockHash();
                 this.lastFinalizedBlockNumber = commitMessage.getVote().getBlockNumber();
 
-                BlockState.getInstance().setFinalizedHash(commitMessage.getVote().getBlockHash(), commitMessage.getRoundNumber(), commitMessage.getSetId());
+                if (BlockState.getInstance().isInitialized()) {
+                    BlockState.getInstance().setFinalizedHash(commitMessage.getVote().getBlockHash(), commitMessage.getRoundNumber(), commitMessage.getSetId());
+                }
             }
 
         } catch (HeaderNotFoundException ignored) {

--- a/src/main/java/com/limechain/storage/block/tree/BlockTree.java
+++ b/src/main/java/com/limechain/storage/block/tree/BlockTree.java
@@ -178,10 +178,6 @@ public class BlockTree {
             throw new BlockNodeNotFoundException("Start node not found");
         }
 
-        if (startBlockNode.getNumber() > endBlockNode.getNumber()) {
-            throw new BlockStorageGenericException("Start is greater than end");
-        }
-
         return accumulateHashesInDescendingOrder(endBlockNode, startBlockNode);
     }
 
@@ -196,7 +192,7 @@ public class BlockTree {
      */
     public List<Hash256> accumulateHashesInDescendingOrder(final BlockNode endNode, final BlockNode startNode) {
         if (startNode.getNumber() > endNode.getNumber()) {
-            throw new IllegalArgumentException("Start is greater than end");
+            throw new BlockStorageGenericException("Start is greater than end");
         }
 
         int blocksInRange = (int) (endNode.getNumber() - startNode.getNumber());
@@ -205,7 +201,7 @@ public class BlockTree {
         BlockNode tempNode = endNode;
         for (int position = blocksInRange - 1; position >= 0; position--) {
             hashes.add(tempNode.getHash());
-            tempNode = endNode.getParent();
+            tempNode = tempNode.getParent();
 
             if (tempNode == null) {
                 throw new BlockStorageGenericException("End node is null");

--- a/src/main/java/com/limechain/storage/block/tree/BlockTree.java
+++ b/src/main/java/com/limechain/storage/block/tree/BlockTree.java
@@ -6,7 +6,6 @@ import com.limechain.exception.storage.BlockStorageGenericException;
 import com.limechain.exception.storage.LowerThanRootException;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.runtime.Runtime;
-import com.limechain.storage.block.BlockState;
 import com.limechain.storage.block.map.HashToRuntime;
 import io.emeraldpay.polkaj.types.Hash256;
 import lombok.Getter;
@@ -85,8 +84,7 @@ public class BlockTree {
             throw new BlockNodeNotFoundException("Parent does not exist in tree");
         }
         if (getNode(header.getHash()) != null) {
-            //TODO: Remove
-            throw new BlockAlreadyExistsException("Block already exists in tree -> ["+header.getBlockNumber()+"] ["+header.getHash()+"]");
+            throw new BlockAlreadyExistsException("Block already exists in tree");
         }
 
         long number = parent.getNumber() + 1;
@@ -99,9 +97,6 @@ public class BlockTree {
             //TODO: Check if primary
         }
 
-        //TODO: Remove
-        System.out.println("Queue size: " + BlockState.getInstance().getPendingBlocksQueue().size());
-        System.out.println("Block [" + header.getBlockNumber() + "] with hash [" + header.getHash() + "] added to the BlockTree");
         BlockNode newBlockNode = new BlockNode(header.getHash(), parent, new ArrayList<>(),
                 number, arrivalTime, isPrimary);
         parent.addChild(newBlockNode);

--- a/src/main/java/com/limechain/storage/block/tree/BlockTree.java
+++ b/src/main/java/com/limechain/storage/block/tree/BlockTree.java
@@ -6,6 +6,7 @@ import com.limechain.exception.storage.BlockStorageGenericException;
 import com.limechain.exception.storage.LowerThanRootException;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.runtime.Runtime;
+import com.limechain.storage.block.BlockState;
 import com.limechain.storage.block.map.HashToRuntime;
 import io.emeraldpay.polkaj.types.Hash256;
 import lombok.Getter;
@@ -84,7 +85,8 @@ public class BlockTree {
             throw new BlockNodeNotFoundException("Parent does not exist in tree");
         }
         if (getNode(header.getHash()) != null) {
-            throw new BlockAlreadyExistsException("Block already exists in tree");
+            //TODO: Remove
+            throw new BlockAlreadyExistsException("Block already exists in tree -> ["+header.getBlockNumber()+"] ["+header.getHash()+"]");
         }
 
         long number = parent.getNumber() + 1;
@@ -97,6 +99,9 @@ public class BlockTree {
             //TODO: Check if primary
         }
 
+        //TODO: Remove
+        System.out.println("Queue size: " + BlockState.getInstance().getPendingBlocksQueue().size());
+        System.out.println("Block [" + header.getBlockNumber() + "] with hash [" + header.getHash() + "] added to the BlockTree");
         BlockNode newBlockNode = new BlockNode(header.getHash(), parent, new ArrayList<>(),
                 number, arrivalTime, isPrimary);
         parent.addChild(newBlockNode);

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -103,7 +103,6 @@ public class FullSyncMachine {
             receivedBlocks = requestBlocks(startNumber, blocksToFetch);
         }
 
-        BlockState.getInstance().mergeBlockStateWithAnnouncedBlocks();
         blockState.setFullSyncFinished(true);
     }
 

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -102,6 +102,9 @@ public class FullSyncMachine {
             startNumber += blocksToFetch;
             receivedBlocks = requestBlocks(startNumber, blocksToFetch);
         }
+
+        BlockState.getInstance().mergeBlockStateWithAnnouncedBlocks();
+        blockState.setFullSyncFinished(true);
     }
 
     private TrieStructure<NodeData> loadStateAtBlockFromPeer(Hash256 lastFinalizedBlockHash) {
@@ -207,7 +210,7 @@ public class FullSyncMachine {
      */
     private void executeBlocks(List<Block> receivedBlockDatas, TrieAccessor trieAccessor) {
         for (Block block : receivedBlockDatas) {
-            log.fine("Block number to be executed is " + block.getHeader().getBlockNumber());
+            log.info("Block number to be executed is " + block.getHeader().getBlockNumber());
 
             try {
                 blockState.addBlock(block);

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -209,7 +209,7 @@ public class FullSyncMachine {
      */
     private void executeBlocks(List<Block> receivedBlockDatas, TrieAccessor trieAccessor) {
         for (Block block : receivedBlockDatas) {
-            log.info("Block number to be executed is " + block.getHeader().getBlockNumber());
+            log.fine("Block number to be executed is " + block.getHeader().getBlockNumber());
 
             try {
                 blockState.addBlock(block);

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
@@ -5,6 +5,7 @@ import com.limechain.chain.lightsyncstate.Authority;
 import com.limechain.chain.lightsyncstate.LightSyncState;
 import com.limechain.network.Network;
 import com.limechain.network.protocol.warp.dto.WarpSyncFragment;
+import com.limechain.storage.block.BlockState;
 import com.limechain.storage.block.SyncState;
 import com.limechain.sync.warpsync.action.FinishedAction;
 import com.limechain.sync.warpsync.action.RequestFragmentsAction;
@@ -101,6 +102,12 @@ public class WarpSyncMachine {
         this.warpState.setWarpSyncFinished(true);
         this.networkService.handshakeBootNodes();
         this.syncState.persistState();
+
+        BlockState.getInstance().initializeWarp(
+                syncState.getLastFinalizedBlockHash(),
+                syncState.getLastFinalizedBlockNumber()
+        );
+
         log.info("Warp sync finished.");
         this.onFinishCallbacks.forEach(executor::submit);
     }

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
@@ -103,7 +103,7 @@ public class WarpSyncMachine {
         this.networkService.handshakeBootNodes();
         this.syncState.persistState();
 
-        BlockState.getInstance().initializeWarp(
+        BlockState.getInstance().initializeAfterWarpSync(
                 syncState.getLastFinalizedBlockHash(),
                 syncState.getLastFinalizedBlockNumber()
         );

--- a/src/test/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngineTest.java
+++ b/src/test/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngineTest.java
@@ -24,7 +24,12 @@ import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unused")
 @ExtendWith(MockitoExtension.class)
@@ -129,7 +134,7 @@ class BlockAnnounceEngineTest {
     }
 
     @Test
-    void receiveBlockAnnounceWhenConnectedShouldSyncMessage() throws IllegalAccessException, NoSuchFieldException {
+    void receiveBlockAnnounceWhenConnectedShouldSyncMessage() {
         byte[] message = new byte[] { 1, 2, 3 };
         BlockAnnounceMessage blockAnnounceMessage = mock(BlockAnnounceMessage.class);
         when(blockAnnounceMessage.getHeader()).thenReturn(mock(BlockHeader.class));


### PR DESCRIPTION
# Description

- Introduced a mechanism to handle block announcements before the finish of the full-sync. Blocks received during the block announcement events are first collected into a queue. After the full-sync process, these queued blocks are processed and added into the block tree. After full-sync is complete, new blocks from block announcements are directly inserted into the block tree, bypassing the queue to streamline the process. Block announcement events happen concurrently and that's the reason why the method that interacts with them is marked as synchronized.

- When running the node in warp-sync mode, the block tree initialization starts from the last finalized block rather than the genesis block, setting this block as the root.

- Block finalization has been enabled for Kusama and Westend networks.

Closes -> https://github.com/LimeChain/Fruzhin/issues/389