### PR TITLE
Logic to support safe and unsafe behavior for local and public rpc

### DIFF
--- a/src/main/java/com/limechain/rpc/config/RpcMethods.java
+++ b/src/main/java/com/limechain/rpc/config/RpcMethods.java
@@ -2,11 +2,6 @@ package com.limechain.rpc.config;
 
 public enum RpcMethods {
     /**
-     * Expose every RPC method only when RPC is listening on
-     * `localhost`, otherwise serve only safe RPC methods
-     */
-    AUTO,
-    /**
      * Allow only a safe subset of RPC methods
      */
     SAFE,

--- a/src/test/java/com/limechain/cli/CliTest.java
+++ b/src/test/java/com/limechain/cli/CliTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class CliTest {
     private Cli cli;
@@ -31,6 +32,8 @@ class CliTest {
         assertTrue(options.hasOption("mode"));
         assertTrue(options.hasOption("no-legacy-protocols"));
         assertTrue(options.hasOption("sync-mode"));
+        assertTrue(options.hasOption("public-rpc"));
+        assertTrue(options.hasOption("rpc-methods"));
         assertEquals(0, options.getRequiredOptions().size());
     }
 
@@ -38,6 +41,30 @@ class CliTest {
     void parseArgs_returns_networkParameter() {
         CliArguments arguments = cli.parseArgs(new String[]{"--network", "polkadot"});
         assertEquals("polkadot", arguments.network());
+    }
+
+    @Test
+    void parseArgs_returns_defaultLocalUnsafeRpcEnabled() {
+        CliArguments arguments = cli.parseArgs(new String[]{});
+        assertTrue(arguments.unsafeRpcEnabled());
+    }
+
+    @Test
+    void parseArgs_returns_defaultPublicSafeRpcEnabled() {
+        CliArguments arguments = cli.parseArgs(new String[]{"--public-rpc"});
+        assertFalse(arguments.unsafeRpcEnabled());
+    }
+
+    @Test
+    void parseArgs_returns_localSafeRpcEnabled() {
+        CliArguments arguments = cli.parseArgs(new String[]{"--rpc-methods", "safe"});
+        assertFalse(arguments.unsafeRpcEnabled());
+    }
+
+    @Test
+    void parseArgs_returns_publicUnsafeRpcEnabled() {
+        CliArguments arguments = cli.parseArgs(new String[]{"--rpc-methods", "unsafe", "--public-rpc"});
+        assertTrue(arguments.unsafeRpcEnabled());
     }
 
     @Test

--- a/src/test/java/com/limechain/network/kad/KademliaServiceTest.java
+++ b/src/test/java/com/limechain/network/kad/KademliaServiceTest.java
@@ -2,26 +2,9 @@ package com.limechain.network.kad;
 
 import org.junit.jupiter.api.Test;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class KademliaServiceTest {
-
-    /**
-     * Test might throw UnknownHostException and fail if domain is no longer accessible
-     *
-     * @throws UnknownHostException
-     */
-    @Test
-    void dnsNodeToIp4_TransformDnsNode() throws UnknownHostException {
-        String bootNode = "/dns/p2p.0.polkadot.network/tcp/30333/p2p/12D3KooWHsvEicXjWWraktbZ4MQBizuyADQtuEGr3NbDvtm5rFA5";
-        InetAddress address = InetAddress.getByName("p2p.0.polkadot.network");
-        String expected = "/ip4/" + address.getHostAddress() + "/tcp/30333/p2p/12D3KooWHsvEicXjWWraktbZ4MQBizuyADQtuEGr3NbDvtm5rFA5";
-
-        assertEquals(expected, DnsUtils.dnsNodeToIp4(bootNode));
-    }
 
     @Test
     void dnsNodeToIp4_UnchangedAddress_ifInvalidDomain() {


### PR DESCRIPTION
- What does this PR do?
   Adding logic to support safe and unsafe behavior for local and public rpc methods
- Why are these changes needed?
  https://github.com/LimeChain/Fruzhin/issues/552
- How were these changes implemented and what do they affect?
 They affect setting safe or unsafe rpc methods via Cli arguments on start-up

## Checklist:
- [x] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.