### PR TITLE
Slot Number Calculation

### DIFF
--- a/src/main/java/com/limechain/babe/state/EpochState.java
+++ b/src/main/java/com/limechain/babe/state/EpochState.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
+import java.time.Instant;
 
 /**
  * Represents the state information for an epoch in the system.
@@ -39,5 +40,9 @@ public class EpochState {
             case DISABLED_AUTHORITY -> this.disabledAuthority = babeConsensusMessage.getDisabledAuthority();
             case NEXT_EPOCH_DESCRIPTOR -> this.nextEpochDescriptor = babeConsensusMessage.getNextEpochDescriptor();
         }
+    }
+
+    public BigInteger getCurrentSlotNumber() {
+        return BigInteger.valueOf(Instant.now().toEpochMilli()).divide(slotDuration);
     }
 }

--- a/src/test/java/com/limechain/babe/state/EpochStateTest.java
+++ b/src/test/java/com/limechain/babe/state/EpochStateTest.java
@@ -1,0 +1,41 @@
+package com.limechain.babe.state;
+
+
+import com.limechain.babe.api.BabeApiConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigInteger;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class EpochStateTest {
+
+    @InjectMocks
+    private EpochState epochState;
+
+    @Mock
+    private BabeApiConfiguration babeApiConfiguration;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testGetCurrentSlotNumber() {
+        BigInteger slotDuration = BigInteger.valueOf(6000);
+        when(babeApiConfiguration.getSlotDuration()).thenReturn(slotDuration);
+        epochState.initialize(babeApiConfiguration);
+
+        Instant now = Instant.now();
+        long expectedSlotNumber = now.toEpochMilli() / slotDuration.longValue();
+        BigInteger currentSlotNumber = epochState.getCurrentSlotNumber();
+        assertEquals(BigInteger.valueOf(expectedSlotNumber), currentSlotNumber);
+    }
+}

--- a/src/test/java/com/limechain/babe/state/EpochStateTest.java
+++ b/src/test/java/com/limechain/babe/state/EpochStateTest.java
@@ -2,11 +2,11 @@ package com.limechain.babe.state;
 
 
 import com.limechain.babe.api.BabeApiConfiguration;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigInteger;
 import java.time.Instant;
@@ -14,6 +14,7 @@ import java.time.Instant;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class EpochStateTest {
 
     @InjectMocks
@@ -21,11 +22,6 @@ public class EpochStateTest {
 
     @Mock
     private BabeApiConfiguration babeApiConfiguration;
-
-    @BeforeEach
-    public void setup() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     public void testGetCurrentSlotNumber() {


### PR DESCRIPTION
- What does this PR do? Added current slot number calculation
- Why are these changes needed? https://github.com/LimeChain/Fruzhin/issues/384
- How were these changes implemented and what do they affect?
Basicaly calling getCurrentSlotNumber method would be in scope of another tasks

## Checklist:
- [x] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.