### PR TITLE
fix: Fix failing "generate_session_keys" runtime call on newer runtimes.

### DIFF
--- a/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
+++ b/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
@@ -70,113 +70,113 @@ public class CryptoHostFunctions implements PartialHostApi {
     @Override
     public Map<Endpoint, ImportObject.FuncImport> getFunctionImports() {
         return Map.ofEntries(
-            newImportObjectPair(Endpoint.ext_crypto_ed25519_public_keys_version_1, argv -> {
-                return ed25519PublicKeysV1(argv.get(0).intValue()).pointerSize();
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ed25519_generate_version_1, argv -> {
-                return ed25519GenerateV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)));
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ed25519_sign_version_1, argv -> {
-                return ed25519SignV1(
-                    argv.get(0).intValue(),
-                    argv.get(1).intValue(),
-                    new RuntimePointerSize(argv.get(2)));
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ed25519_verify_version_1, argv -> {
-                return ed25519VerifyV1(
-                    argv.get(0).intValue(),
-                    new RuntimePointerSize(argv.get(1)),
-                    argv.get(2).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ed25519_batch_verify_version_1, argv -> {
-                return ed25519BatchVerifyV1(
-                    argv.get(0).intValue(),
-                    new RuntimePointerSize(argv.get(1)),
-                    argv.get(2).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_sr25519_public_keys_version_1, argv -> {
-                return sr25519PublicKeysV1(argv.get(0).intValue()).pointerSize();
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_sr25519_generate_version_1, argv -> {
-                return sr25519GenerateV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)));
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_sr25519_sign_version_1, argv -> {
-                return sr25519SignV1(
-                    argv.get(0).intValue(),
-                    argv.get(1).intValue(),
-                    new RuntimePointerSize(argv.get(2)));
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_sr25519_verify_version_1, argv -> {
-                return sr25519VerifyV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)), argv.get(2).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_sr25519_verify_version_2, argv -> {
-                // NOTE: Intentionally does the same as V1, see: https://spec.polkadot.network/chap-host-api#sect-ext-crypto-sr25519-verify
-                return sr25519VerifyV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)), argv.get(2).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_sr25519_batch_verify_version_1, argv -> {
-                return sr25519BatchVerifyV1(
-                    argv.get(0).intValue(),
-                    new RuntimePointerSize(argv.get(1)),
-                    argv.get(2).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ecdsa_public_keys_version_1, argv -> {
-                return ecdsaPublicKeysV1(argv.get(0).intValue()).pointerSize();
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ecdsa_generate_version_1, argv -> {
-                return ecdsaGenerateV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)));
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ecdsa_sign_version_1, argv -> {
-                return ecdsaSignV1(argv.get(0).intValue(), argv.get(1).intValue(), new RuntimePointerSize(argv.get(2)));
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ecdsa_sign_prehashed_version_1, argv -> {
-                return ecdsaSignPrehashedV1(
-                    argv.get(0).intValue(),
-                    argv.get(1).intValue(),
-                    new RuntimePointerSize(argv.get(2)));
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ecdsa_verify_version_1, argv -> {
-                return ecdsaVerifyV1(
-                    argv.get(0).intValue(),
-                    new RuntimePointerSize(argv.get(1)),
-                    argv.get(2).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ecdsa_verify_version_2, argv -> {
-                return ecdsaVerifyV1(
-                    argv.get(0).intValue(),
-                    new RuntimePointerSize(argv.get(1)),
-                    argv.get(2).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ecdsa_verify_prehashed_version_1, argv -> {
-                return ecdsaVerifyPrehashedV1(
-                    argv.get(0).intValue(),
-                    argv.get(1).intValue(),
-                    argv.get(2).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_ecdsa_batch_verify_version_1, argv -> {
-                return ecdsaBatchVerifyV1(
-                    argv.get(0).intValue(),
-                    new RuntimePointerSize(argv.get(1)),
-                    argv.get(2).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_secp256k1_ecdsa_recover_version_1, argv -> {
-                return secp256k1EcdsaRecoverV1(argv.get(0).intValue(), argv.get(1).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_secp256k1_ecdsa_recover_version_2, argv -> {
-                // NOTE: Intentionally does the same as V1, see: https://spec.polkadot.network/chap-host-api#id-ext_crypto_secp256k1_ecdsa_recover
-                return secp256k1EcdsaRecoverV1(argv.get(0).intValue(), argv.get(1).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_secp256k1_ecdsa_recover_compressed_version_1, argv -> {
-                return secp256k1EcdsaRecoverCompressedV1(argv.get(0).intValue(), argv.get(1).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_secp256k1_ecdsa_recover_compressed_version_2, argv -> {
-                return secp256k1EcdsaRecoverCompressedV1(argv.get(0).intValue(), argv.get(1).intValue());
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_start_batch_verify_version_1, argv -> {
-                startBatchVerify();
-            }),
-            newImportObjectPair(Endpoint.ext_crypto_finish_batch_verify_version_1, argv -> {
-                return finishBatchVerify();
-            })
+                newImportObjectPair(Endpoint.ext_crypto_ed25519_public_keys_version_1, argv -> {
+                    return ed25519PublicKeysV1(argv.get(0).intValue()).pointerSize();
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ed25519_generate_version_1, argv -> {
+                    return ed25519GenerateV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)));
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ed25519_sign_version_1, argv -> {
+                    return ed25519SignV1(
+                            argv.get(0).intValue(),
+                            argv.get(1).intValue(),
+                            new RuntimePointerSize(argv.get(2)));
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ed25519_verify_version_1, argv -> {
+                    return ed25519VerifyV1(
+                            argv.get(0).intValue(),
+                            new RuntimePointerSize(argv.get(1)),
+                            argv.get(2).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ed25519_batch_verify_version_1, argv -> {
+                    return ed25519BatchVerifyV1(
+                            argv.get(0).intValue(),
+                            new RuntimePointerSize(argv.get(1)),
+                            argv.get(2).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_sr25519_public_keys_version_1, argv -> {
+                    return sr25519PublicKeysV1(argv.get(0).intValue()).pointerSize();
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_sr25519_generate_version_1, argv -> {
+                    return sr25519GenerateV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)));
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_sr25519_sign_version_1, argv -> {
+                    return sr25519SignV1(
+                            argv.get(0).intValue(),
+                            argv.get(1).intValue(),
+                            new RuntimePointerSize(argv.get(2)));
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_sr25519_verify_version_1, argv -> {
+                    return sr25519VerifyV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)), argv.get(2).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_sr25519_verify_version_2, argv -> {
+                    // NOTE: Intentionally does the same as V1, see: https://spec.polkadot.network/chap-host-api#sect-ext-crypto-sr25519-verify
+                    return sr25519VerifyV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)), argv.get(2).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_sr25519_batch_verify_version_1, argv -> {
+                    return sr25519BatchVerifyV1(
+                            argv.get(0).intValue(),
+                            new RuntimePointerSize(argv.get(1)),
+                            argv.get(2).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ecdsa_public_keys_version_1, argv -> {
+                    return ecdsaPublicKeysV1(argv.get(0).intValue()).pointerSize();
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ecdsa_generate_version_1, argv -> {
+                    return ecdsaGenerateV1(argv.get(0).intValue(), new RuntimePointerSize(argv.get(1)));
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ecdsa_sign_version_1, argv -> {
+                    return ecdsaSignV1(argv.get(0).intValue(), argv.get(1).intValue(), new RuntimePointerSize(argv.get(2)));
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ecdsa_sign_prehashed_version_1, argv -> {
+                    return ecdsaSignPrehashedV1(
+                            argv.get(0).intValue(),
+                            argv.get(1).intValue(),
+                            new RuntimePointerSize(argv.get(2)));
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ecdsa_verify_version_1, argv -> {
+                    return ecdsaVerifyV1(
+                            argv.get(0).intValue(),
+                            new RuntimePointerSize(argv.get(1)),
+                            argv.get(2).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ecdsa_verify_version_2, argv -> {
+                    return ecdsaVerifyV1(
+                            argv.get(0).intValue(),
+                            new RuntimePointerSize(argv.get(1)),
+                            argv.get(2).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ecdsa_verify_prehashed_version_1, argv -> {
+                    return ecdsaVerifyPrehashedV1(
+                            argv.get(0).intValue(),
+                            argv.get(1).intValue(),
+                            argv.get(2).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_ecdsa_batch_verify_version_1, argv -> {
+                    return ecdsaBatchVerifyV1(
+                            argv.get(0).intValue(),
+                            new RuntimePointerSize(argv.get(1)),
+                            argv.get(2).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_secp256k1_ecdsa_recover_version_1, argv -> {
+                    return secp256k1EcdsaRecoverV1(argv.get(0).intValue(), argv.get(1).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_secp256k1_ecdsa_recover_version_2, argv -> {
+                    // NOTE: Intentionally does the same as V1, see: https://spec.polkadot.network/chap-host-api#id-ext_crypto_secp256k1_ecdsa_recover
+                    return secp256k1EcdsaRecoverV1(argv.get(0).intValue(), argv.get(1).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_secp256k1_ecdsa_recover_compressed_version_1, argv -> {
+                    return secp256k1EcdsaRecoverCompressedV1(argv.get(0).intValue(), argv.get(1).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_secp256k1_ecdsa_recover_compressed_version_2, argv -> {
+                    return secp256k1EcdsaRecoverCompressedV1(argv.get(0).intValue(), argv.get(1).intValue());
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_start_batch_verify_version_1, argv -> {
+                    startBatchVerify();
+                }),
+                newImportObjectPair(Endpoint.ext_crypto_finish_batch_verify_version_1, argv -> {
+                    return finishBatchVerify();
+                })
         );
     }
 
@@ -449,7 +449,7 @@ public class CryptoHostFunctions implements PartialHostApi {
         byte[] keyTypeBytes = sharedMemory.readData(new RuntimePointerSize(keyTypeId, KeyType.KEY_TYPE_LEN));
         final KeyType keyType = KeyType.getByBytes(keyTypeBytes);
 
-        if (keyType == null || keyType.getKey() != Key.GENERIC) {
+        if (keyType == null || (keyType.getKey() != Key.ECDSA && keyType.getKey() != Key.GENERIC)) {
             throw new InvalidKeyTypeException(
                     String.format(TYPE_RECEIVED_STRING, keyType != null ? keyType.getKey() : null));
         }

--- a/src/main/java/com/limechain/storage/crypto/KeyType.java
+++ b/src/main/java/com/limechain/storage/crypto/KeyType.java
@@ -23,6 +23,10 @@ public enum KeyType {
      */
     GRANDPA("gran".getBytes(), Key.ED25519),
     /**
+     * Key type for the Beefy module
+     */
+    BEEFY("beef".getBytes(), Key.ECDSA),
+    /**
      * Key type for the ImOnline module
      */
     IM_ONLINE("imon".getBytes(), Key.SR25519),
@@ -38,6 +42,7 @@ public enum KeyType {
      * Key type for the Parachain Assignment Key
      */
     PARACHAIN_ASSIGNMENT_KEY("asgn".getBytes(), Key.SR25519);
+
 
     public static final int KEY_TYPE_LEN = 4;
 

--- a/src/main/java/com/limechain/storage/crypto/KeyType.java
+++ b/src/main/java/com/limechain/storage/crypto/KeyType.java
@@ -43,7 +43,6 @@ public enum KeyType {
      */
     PARACHAIN_ASSIGNMENT_KEY("asgn".getBytes(), Key.SR25519);
 
-
     public static final int KEY_TYPE_LEN = 4;
 
     private final byte[] bytes;

--- a/src/test/java/com/limechain/runtime/hostapi/CryptoHostFunctionsTest.java
+++ b/src/test/java/com/limechain/runtime/hostapi/CryptoHostFunctionsTest.java
@@ -310,19 +310,19 @@ class CryptoHostFunctionsTest {
         ArrayList<byte[]> pubKeys = new ArrayList<>();
         pubKeys.add(ecdsaKeyPair.getSecond().raw());
 
-        when(sharedMemory.readData(keyPointer)).thenReturn(KeyType.CONTROLLING_ACCOUNTS.getBytes());
-        when(keyStore.getPublicKeysByKeyType(KeyType.CONTROLLING_ACCOUNTS)).thenReturn(pubKeys);
+        when(sharedMemory.readData(keyPointer)).thenReturn(KeyType.BEEFY.getBytes());
+        when(keyStore.getPublicKeysByKeyType(KeyType.BEEFY)).thenReturn(pubKeys);
         when(sharedMemory.writeData(toScaleEncoded(pubKeys))).thenReturn(returnPointer);
 
         RuntimePointerSize result = cryptoHostFunctions.ecdsaPublicKeysV1(keyPosition);
 
-        verify(keyStore).getPublicKeysByKeyType(KeyType.CONTROLLING_ACCOUNTS);
+        verify(keyStore).getPublicKeysByKeyType(KeyType.BEEFY);
         assertEquals(returnPointer, result);
     }
 
     @Test
     void ecdsaGenerateV1_no_seed() {
-        when(sharedMemory.readData(keyPointer)).thenReturn(KeyType.CONTROLLING_ACCOUNTS.getBytes());
+        when(sharedMemory.readData(keyPointer)).thenReturn(KeyType.BEEFY.getBytes());
         when(sharedMemory.readData(seedPointer)).thenReturn(missingSeed);
         when(sharedMemory.writeData(ecdsaKeyPair.getSecond().raw())).thenReturn(returnPointer);
 
@@ -338,7 +338,7 @@ class CryptoHostFunctionsTest {
 
     @Test
     void ecdsaGenerateV1_use_seed() {
-        when(sharedMemory.readData(keyPointer)).thenReturn(KeyType.CONTROLLING_ACCOUNTS.getBytes());
+        when(sharedMemory.readData(keyPointer)).thenReturn(KeyType.BEEFY.getBytes());
         when(sharedMemory.readData(seedPointer)).thenReturn(existingSeed);
         when(sharedMemory.writeData(ecdsaKeyPair.getSecond().raw())).thenReturn(returnPointer);
 

--- a/src/test/java/com/limechain/storage/crypto/KeyStoreTest.java
+++ b/src/test/java/com/limechain/storage/crypto/KeyStoreTest.java
@@ -44,10 +44,10 @@ class KeyStoreTest {
         byte[] privKey3 = keyStore.get(KeyType.BABE, KEY_3);
         byte[] privKey4 = keyStore.get(KeyType.BEEFY, KEY_4);
 
-        assertArrayEquals(privKey, VALUE);
-        assertArrayEquals(privKey2, VALUE_2);
-        assertArrayEquals(privKey3, VALUE_3);
-        assertArrayEquals(privKey4, VALUE_4);
+        assertArrayEquals(VALUE, privKey);
+        assertArrayEquals(VALUE_2, privKey2);
+        assertArrayEquals(VALUE_3, privKey3);
+        assertArrayEquals(VALUE_4, privKey4);
 
         byte[] invPrivKey = keyStore.get(KeyType.GRANDPA, KEY_4);
         byte[] invPrivKey2 = keyStore.get(KeyType.BABE, KEY_2);

--- a/src/test/java/com/limechain/storage/crypto/KeyStoreTest.java
+++ b/src/test/java/com/limechain/storage/crypto/KeyStoreTest.java
@@ -14,12 +14,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class KeyStoreTest {
 
-    byte[] key = {1, 2, 3};
-    byte[] key2 = {4, 5, 6};
-    byte[] key3 = {7, 8, 9};
-    byte[] value = {1, 2, 3, 4};
-    byte[] value2 = {5, 6, 7, 8};
-    byte[] value3 = {9, 10, 11, 12};
+    private static final byte[] KEY = {1, 2, 3};
+    private static final byte[] KEY_2 = {4, 5, 6};
+    private static final byte[] KEY_3 = {7, 8, 9};
+    private static final byte[] KEY_4 = {10, 11, 12};
+    private static final byte[] VALUE = {1, 2, 3, 4};
+    private static final byte[] VALUE_2 = {5, 6, 7, 8};
+    private static final byte[] VALUE_3 = {9, 10, 11, 12};
+    private static final byte[] VALUE_4 = {13, 14, 15, 16};
+
     private DBRepository dbRepository;
     private KeyStore keyStore;
 
@@ -31,39 +34,45 @@ class KeyStoreTest {
 
     @Test
     void saveAndGetKey() {
-        keyStore.put(KeyType.BABE, key, value);
-        keyStore.put(KeyType.GRANDPA, key2, value2);
-        keyStore.put(KeyType.BABE, key3, value3);
+        keyStore.put(KeyType.BABE, KEY, VALUE);
+        keyStore.put(KeyType.GRANDPA, KEY_2, VALUE_2);
+        keyStore.put(KeyType.BABE, KEY_3, VALUE_3);
+        keyStore.put(KeyType.BEEFY, KEY_4, VALUE_4);
 
-        byte[] privKey = keyStore.get(KeyType.BABE, key);
-        byte[] privKey2 = keyStore.get(KeyType.GRANDPA, key2);
-        byte[] privKey3 = keyStore.get(KeyType.BABE, key3);
+        byte[] privKey = keyStore.get(KeyType.BABE, KEY);
+        byte[] privKey2 = keyStore.get(KeyType.GRANDPA, KEY_2);
+        byte[] privKey3 = keyStore.get(KeyType.BABE, KEY_3);
+        byte[] privKey4 = keyStore.get(KeyType.BEEFY, KEY_4);
 
-        assertArrayEquals(privKey, value);
-        assertArrayEquals(privKey2, value2);
-        assertArrayEquals(privKey3, value3);
+        assertArrayEquals(privKey, VALUE);
+        assertArrayEquals(privKey2, VALUE_2);
+        assertArrayEquals(privKey3, VALUE_3);
+        assertArrayEquals(privKey4, VALUE_4);
 
-        byte[] invPrivKey = keyStore.get(KeyType.GRANDPA, key);
-        byte[] invPrivKey2 = keyStore.get(KeyType.BABE, key2);
-        byte[] invPrivKey3 = keyStore.get(KeyType.GRANDPA, key3);
+        byte[] invPrivKey = keyStore.get(KeyType.GRANDPA, KEY_4);
+        byte[] invPrivKey2 = keyStore.get(KeyType.BABE, KEY_2);
+        byte[] invPrivKey3 = keyStore.get(KeyType.GRANDPA, KEY_3);
+        byte[] invPrivKey4 = keyStore.get(KeyType.BEEFY, KEY);
 
         assertNull(invPrivKey);
         assertNull(invPrivKey2);
         assertNull(invPrivKey3);
+        assertNull(invPrivKey4);
     }
 
     @Test
     void saveAndGetCommonKey() {
-        keyStore.put(KeyType.BABE, key, value);
-        keyStore.put(KeyType.GRANDPA, key2, value2);
-        keyStore.put(KeyType.BABE, key3, value3);
+        keyStore.put(KeyType.BABE, KEY, VALUE);
+        keyStore.put(KeyType.GRANDPA, KEY_2, VALUE_2);
+        keyStore.put(KeyType.BABE, KEY_3, VALUE_3);
+        keyStore.put(KeyType.BEEFY, KEY_4, VALUE_4);
 
         List<byte[]> publicKeysByKeyType = keyStore.getPublicKeysByKeyType(KeyType.BABE);
 
         assertEquals(2, publicKeysByKeyType.size());
 
         List<byte[]> publicKeysByKeyTypeGrandpa = keyStore.getPublicKeysByKeyType(KeyType.GRANDPA);
-        assertEquals(publicKeysByKeyTypeGrandpa.get(0).length, key2.length);
+        assertEquals(publicKeysByKeyTypeGrandpa.get(0).length, KEY_2.length);
     }
 
 }


### PR DESCRIPTION
A key type was missing, which resulted in runtime failure on newer runtimes.