### PR TITLE
Change data types for slot/epoch number to BigInteger

### DIFF
--- a/src/main/java/com/limechain/babe/Authorship.java
+++ b/src/main/java/com/limechain/babe/Authorship.java
@@ -21,12 +21,12 @@ public class Authorship {
 
     public static BabePreDigest claimPrimarySlot(final byte[] randomness,
                                                  final BigInteger slotNumber,
-                                                 final long epochNumber,
+                                                 final BigInteger epochNumber,
                                                  final Schnorrkel.KeyPair keyPair,
                                                  final int authorityIndex,
                                                  final BigInteger threshold) {
 
-        var transcript = makeTranscript(randomness, slotNumber.longValue(), epochNumber);
+        var transcript = makeTranscript(randomness, slotNumber, epochNumber);
 
         Schnorrkel schnorrkel = Schnorrkel.getInstance();
         VrfOutputAndProof vrfOutputAndProof = schnorrkel.vrfSign(keyPair, transcript);
@@ -105,10 +105,10 @@ public class Authorship {
         return c;
     }
 
-    private static TranscriptData makeTranscript(byte[] randomness, long slotNumber, long epochNumber) {
+    private static TranscriptData makeTranscript(byte[] randomness, BigInteger slotNumber, BigInteger epochNumber) {
         var transcript = new TranscriptData("BABE".getBytes());
-        transcript.appendMessage("slot number", LittleEndianUtils.longToLittleEndianBytes(slotNumber));
-        transcript.appendMessage("current epoch", LittleEndianUtils.longToLittleEndianBytes(epochNumber));
+        transcript.appendMessage("slot number", LittleEndianUtils.toLittleEndianBytes(slotNumber));
+        transcript.appendMessage("current epoch", LittleEndianUtils.toLittleEndianBytes(epochNumber));
         transcript.appendMessage("chain randomness", randomness);
         return transcript;
     }

--- a/src/main/java/com/limechain/utils/LittleEndianUtils.java
+++ b/src/main/java/com/limechain/utils/LittleEndianUtils.java
@@ -62,16 +62,14 @@ public class LittleEndianUtils {
     }
 
     /**
-     * Converts a long value into a little-endian byte array.
+     * Converts a BigInteger value into a little-endian byte array.
      *
-     * @param value the long value to convert to a byte array
+     * @param value the BigInteger value to convert to a byte array
      * @return a byte array representing the long value in little-endian order
      */
-    public static byte[] longToLittleEndianBytes(long value) {
-        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-        buffer.order(ByteOrder.LITTLE_ENDIAN);
-        buffer.putLong(value);
-        return buffer.array();
+    public static byte[] toLittleEndianBytes(BigInteger value) {
+        byte[] bigEndianBytes = value.toByteArray();
+        return bytesToFixedLength(bigEndianBytes, 8);
     }
 
     /**

--- a/src/test/java/com/limechain/utils/LittleEndianUtilsTest.java
+++ b/src/test/java/com/limechain/utils/LittleEndianUtilsTest.java
@@ -39,26 +39,25 @@ class LittleEndianUtilsTest {
     }
 
     @Test
-    void testLongToLittleEndianBytesWithMaxLongValue() {
+    void testToLittleEndianBytesWithMaxLongValue() {
         long value = Long.MAX_VALUE;
         byte[] expected = new byte[]{-1, -1, -1, -1, -1, -1, -1, 127}; // Expected little-endian bytes for Long.MAX_VALUE
-        byte[] result = LittleEndianUtils.longToLittleEndianBytes(value);
+        byte[] result = LittleEndianUtils.toLittleEndianBytes(BigInteger.valueOf(value));
         assertArrayEquals(expected, result);
     }
 
     @Test
-    void testLongToLittleEndianBytesWithMinLongValue() {
+    void testToLittleEndianBytesWithMinLongValue() {
         long value = Long.MIN_VALUE;
         byte[] expected = new byte[]{0, 0, 0, 0, 0, 0, 0, -128}; // Expected little-endian bytes for Long.MIN_VALUE
-        byte[] result = LittleEndianUtils.longToLittleEndianBytes(value);
+        byte[] result = LittleEndianUtils.toLittleEndianBytes(BigInteger.valueOf(value));
         assertArrayEquals(expected, result);
     }
 
     @Test
-    void testLongToLittleEndianBytesWithZero() {
-        long value = 0L;
+    void testToLittleEndianBytesWithZero() {
         byte[] expected = new byte[]{0, 0, 0, 0, 0, 0, 0, 0}; // Expected little-endian bytes for 0
-        byte[] result = LittleEndianUtils.longToLittleEndianBytes(value);
+        byte[] result = LittleEndianUtils.toLittleEndianBytes(BigInteger.ZERO);
         assertArrayEquals(expected, result);
     }
 


### PR DESCRIPTION
# Description
Data types for slot/epoch numbers are changed from long to BigInteger, and the calculations to little endian byte array are adjusted.

Related to https://github.com/LimeChain/Fruzhin/issues/547