### PR TITLE
Implement ExecuteEpochLottery (EpochAuthorship)

### DIFF
--- a/src/main/java/com/limechain/babe/Authorship.java
+++ b/src/main/java/com/limechain/babe/Authorship.java
@@ -29,11 +29,10 @@ import java.util.logging.Level;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Authorship {
 
-    public static BabePreDigest claimSlot(EpochState epochState, KeyStore keyStore) {
+    public static BabePreDigest claimSlot(EpochState epochState, BigInteger slotNumber, KeyStore keyStore) {
 
         var randomness = epochState.getCurrentEpochData().getRandomness();
-        var slotNumber = epochState.getCurrentSlotNumber();
-        var epochIndex = epochState.getEpochIndex();
+        var epochIndex = epochState.getCurrentEpochIndex();
         var c = epochState.getCurrentEpochDescriptor().getConstant();
         var authorities = epochState.getCurrentEpochData().getAuthorities();
         var allowedSlots = epochState.getCurrentEpochDescriptor().getAllowedSlots();

--- a/src/main/java/com/limechain/babe/BabeService.java
+++ b/src/main/java/com/limechain/babe/BabeService.java
@@ -1,0 +1,35 @@
+package com.limechain.babe;
+
+import com.limechain.babe.predigest.BabePreDigest;
+import com.limechain.babe.state.EpochState;
+import com.limechain.storage.crypto.KeyStore;
+import org.apache.commons.collections4.map.HashedMap;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.util.Map;
+
+@Component
+public class BabeService {
+
+    private final EpochState epochState;
+    private final KeyStore keyStore;
+    private final Map<BigInteger, BabePreDigest> slotToPreRuntimeDigest = new HashedMap<>();
+
+    public BabeService(EpochState epochState, KeyStore keyStore) {
+        this.epochState = epochState;
+        this.keyStore = keyStore;
+    }
+
+    private void epochAuthorship() {
+        var epochStartSlotNumber = epochState.getCurrentEpochStartSlotNumer();
+        var epochEndSlotNumber = epochStartSlotNumber.add(epochState.getEpochLength());
+
+        for (BigInteger slot = epochStartSlotNumber; slot.compareTo(epochEndSlotNumber) < 0; slot = slot.add(BigInteger.ONE)) {
+            BabePreDigest babePreDigest = Authorship.claimSlot(epochState, slot, keyStore);
+            if (babePreDigest != null) {
+                slotToPreRuntimeDigest.put(slot, babePreDigest);
+            }
+        }
+    }
+}

--- a/src/main/java/com/limechain/babe/BabeService.java
+++ b/src/main/java/com/limechain/babe/BabeService.java
@@ -21,7 +21,7 @@ public class BabeService {
         this.keyStore = keyStore;
     }
 
-    private void epochAuthorship() {
+    private void executeEpochLottery() {
         var epochStartSlotNumber = epochState.getCurrentEpochStartSlotNumer();
         var epochEndSlotNumber = epochStartSlotNumber.add(epochState.getEpochLength());
 

--- a/src/main/java/com/limechain/babe/state/EpochState.java
+++ b/src/main/java/com/limechain/babe/state/EpochState.java
@@ -11,8 +11,9 @@ import java.math.BigInteger;
 import java.time.Instant;
 
 /**
- * Represents the state information for an epoch in the system.
- * This class encapsulates all the necessary configuration and parameters related to a specific epoch.
+ * Represents the state information for the current/next epoch that is needed
+ * for block production with BABE.
+ * Note: Intended for use only when the host is configured as an Authoring Node.
  */
 @Getter
 @Component
@@ -22,9 +23,9 @@ public class EpochState {
     private EpochData currentEpochData;
     private EpochDescriptor currentEpochDescriptor;
     private EpochData nextEpochData;
-    private long disabledAuthority;
     private EpochDescriptor nextEpochDescriptor;
-    private BigInteger epochIndex;
+    private long disabledAuthority;
+    private BigInteger genesisSlotNumber;
 
     public void initialize(BabeApiConfiguration babeApiConfiguration) {
         this.slotDuration = babeApiConfiguration.getSlotDuration();
@@ -45,5 +46,13 @@ public class EpochState {
 
     public BigInteger getCurrentSlotNumber() {
         return BigInteger.valueOf(Instant.now().toEpochMilli()).divide(slotDuration);
+    }
+
+    public BigInteger getCurrentEpochStartSlotNumer() {
+        return getCurrentEpochIndex().multiply(epochLength).add(genesisSlotNumber);
+    }
+
+    public BigInteger getCurrentEpochIndex() {
+        return getCurrentSlotNumber().subtract(genesisSlotNumber).divide(epochLength);
     }
 }

--- a/src/main/java/com/limechain/babe/state/EpochState.java
+++ b/src/main/java/com/limechain/babe/state/EpochState.java
@@ -48,10 +48,17 @@ public class EpochState {
         return BigInteger.valueOf(Instant.now().toEpochMilli()).divide(slotDuration);
     }
 
+    // epochIndex * epochLength + genesisSlot = epochStartSlotNumber
+    // The formula is the same as below but different variable is isolated, and we
+    // leverage the fact that epochStartSlotNumber is achieved when
+    // (currentSlotNumber - genesisSlotNumber) / epochLength results in whole number
     public BigInteger getCurrentEpochStartSlotNumer() {
         return getCurrentEpochIndex().multiply(epochLength).add(genesisSlotNumber);
     }
 
+    // (currentSlotNumber - genesisSlotNumber) / epochLength = epochIndex
+    // Dividing BigIntegers results in rounding down when the result is not a whole number,
+    // which is the intended behavior for calculating epochIndex.
     public BigInteger getCurrentEpochIndex() {
         return getCurrentSlotNumber().subtract(genesisSlotNumber).divide(epochLength);
     }

--- a/src/test/java/com/limechain/babe/AuthorshipTest.java
+++ b/src/test/java/com/limechain/babe/AuthorshipTest.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AuthorshipTest {
 
-
     @Test
     void testCalculatePrimaryThreshold()
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {


### PR DESCRIPTION
# Description

- Created the BabeService class to handle block production.
- Implemented the ExecuteEpochLottery method, which iterates from the current epoch's start slot number to the current epoch's end slot number. It checks if a BabePreDigest can be created; if so, the slot and PreDigest are added to a map, which will later be used to create blocks for claimed slots.
- Only the current epoch’s start slot is fetched from the epoch state, while the end slot is calculated on the fly to avoid fetching the start of one epoch and the end of the next (probably this will never happen)
- Refactored EpochState: the epoch index field was removed, as it can be easily derived from the genesis slot. Now, the epoch index, epoch start slot number, and epoch end slot number are all derived from the genesis slot. Note that the genesis slot is not initialized at the moment, but this will be implemented soon.
- EpochState is now related only to the current epoch and is unsuitable for handling previous epochs. This is because calculations for the epoch index and epoch start slot number are based on the current slot number, and getter methods will provide the current epoch index and current epoch start slot number.

Fixes: https://github.com/LimeChain/Fruzhin/issues/594