### PR TITLE
Implement Genesis Slot Number Retrieval

### DIFF
--- a/src/main/java/com/limechain/babe/state/EpochState.java
+++ b/src/main/java/com/limechain/babe/state/EpochState.java
@@ -53,10 +53,11 @@ public class EpochState {
     public void setGenesisSlotNumber(BigInteger retrievedGenesisSlotNumber) {
         if (retrievedGenesisSlotNumber != null) {
             this.genesisSlotNumber = retrievedGenesisSlotNumber;
+        } else {
+            // If retrieved genesis slot number is null, then there are no executed
+            // blocks on the chain and current slot number should be the genesis
+            this.genesisSlotNumber = getCurrentSlotNumber();
         }
-        // If retrieved genesis slot number is null, then there are no executed
-        // blocks on the chain and current slot number should be the genesis
-        this.genesisSlotNumber = getCurrentSlotNumber();
     }
 
     public BigInteger getCurrentSlotNumber() {

--- a/src/main/java/com/limechain/babe/state/EpochState.java
+++ b/src/main/java/com/limechain/babe/state/EpochState.java
@@ -18,23 +18,29 @@ import java.time.Instant;
 @Getter
 @Component
 public class EpochState {
+
+    private boolean isInitialized = false;
+
+    private long disabledAuthority;
     private BigInteger slotDuration;
     private BigInteger epochLength;
+    private BigInteger genesisSlotNumber;
+
     private EpochData currentEpochData;
     private EpochDescriptor currentEpochDescriptor;
+
     private EpochData nextEpochData;
     private EpochDescriptor nextEpochDescriptor;
-    private long disabledAuthority;
-    private BigInteger genesisSlotNumber;
 
     public void initialize(BabeApiConfiguration babeApiConfiguration) {
         this.slotDuration = babeApiConfiguration.getSlotDuration();
         this.epochLength = babeApiConfiguration.getEpochLength();
         this.currentEpochData = new EpochData(babeApiConfiguration.getAuthorities(), babeApiConfiguration.getRandomness());
         this.currentEpochDescriptor = new EpochDescriptor(babeApiConfiguration.getConstant(), babeApiConfiguration.getAllowedSlots());
+        this.isInitialized = true;
     }
 
-    //TODO: This will be fixed in https://github.com/LimeChain/Fruzhin/issues/593
+    //TODO: Call this form the BlockImporter class when it it created!
     public void updateNextEpochBlockConfig(byte[] message) {
         BabeConsensusMessage babeConsensusMessage = ScaleUtils.Decode.decode(message, new BabeConsensusMessageReader());
         switch (babeConsensusMessage.getFormat()) {
@@ -42,6 +48,15 @@ public class EpochState {
             case DISABLED_AUTHORITY -> this.disabledAuthority = babeConsensusMessage.getDisabledAuthority();
             case NEXT_EPOCH_DESCRIPTOR -> this.nextEpochDescriptor = babeConsensusMessage.getNextEpochDescriptor();
         }
+    }
+
+    public void setGenesisSlotNumber(BigInteger retrievedGenesisSlotNumber) {
+        if (retrievedGenesisSlotNumber != null) {
+            this.genesisSlotNumber = retrievedGenesisSlotNumber;
+        }
+        // If retrieved genesis slot number is null, then there are no executed
+        // blocks on the chain and current slot number should be the genesis
+        this.genesisSlotNumber = getCurrentSlotNumber();
     }
 
     public BigInteger getCurrentSlotNumber() {

--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
@@ -91,8 +91,6 @@ public class BlockAnnounceEngine {
         if (BlockState.getInstance().isInitialized()) {
             BlockState.getInstance().addBlockToBlockTree(announce.getHeader());
         }
-        //TODO: This will be fixed in https://github.com/LimeChain/Fruzhin/issues/593
-//        digestHelper.handleHeaderDigests(announce.getHeader().getDigest());
     }
 
     public void writeHandshakeToStream(Stream stream, PeerId peerId) {

--- a/src/main/java/com/limechain/rpc/config/CommonConfig.java
+++ b/src/main/java/com/limechain/rpc/config/CommonConfig.java
@@ -95,8 +95,8 @@ public class CommonConfig {
     }
 
     @Bean
-    public FullSyncMachine fullSyncMachine(Network network, SyncState syncState) {
-        return new FullSyncMachine(network, syncState);
+    public FullSyncMachine fullSyncMachine(HostConfig hostConfig, Network network, SyncState syncState) {
+        return new FullSyncMachine(hostConfig, network, syncState);
     }
 
     @Bean

--- a/src/main/java/com/limechain/runtime/Runtime.java
+++ b/src/main/java/com/limechain/runtime/Runtime.java
@@ -69,24 +69,20 @@ public class Runtime {
         return context.getSharedMemory().readData(responsePtrSize);
     }
 
+    private Optional<byte[]> findStorageValue(Nibbles key) {
+        return this.context.trieAccessor.findStorageValue(key);
+    }
+
+    public BigInteger getGenesisSlotNumber() {
+        var optGenesisSlotBytes = this.findStorageValue(RuntimeStorageKey.GENESIS_SLOT.getKey());
+        return optGenesisSlotBytes.map(LittleEndianUtils::fromLittleEndianByteArray).orElse(null);
+    }
+
     /**
      * @return the {@link BabeApiConfiguration}.
      */
     public BabeApiConfiguration callBabeApiConfiguration() {
         return ScaleUtils.Decode.decode(this.call(RuntimeEndpoint.BABE_API_CONFIGURATION), new BabeApiConfigurationReader());
-    }
-
-    public Optional<byte[]> findStorageValue(Nibbles key) {
-        return this.context.trieAccessor.findStorageValue(key);
-    }
-
-    public BigInteger retrieveGenesisSlot() {
-        var optGenesisSlotBytes = this.findStorageValue(
-                Nibbles.fromHexString("0x1cb6f36e027abb2091cfb5110ab5087f678711d15ebbceba5cd0cea158e6675a")
-        );
-
-        return optGenesisSlotBytes.map(LittleEndianUtils::fromLittleEndianByteArray).orElse(null);
-
     }
 
     /**

--- a/src/main/java/com/limechain/runtime/Runtime.java
+++ b/src/main/java/com/limechain/runtime/Runtime.java
@@ -74,7 +74,7 @@ public class Runtime {
     }
 
     public BigInteger getGenesisSlotNumber() {
-        var optGenesisSlotBytes = this.findStorageValue(RuntimeStorageKey.GENESIS_SLOT.getKey());
+        var optGenesisSlotBytes = this.findStorageValue(RuntimeStorageKey.GENESIS_SLOT.getNibbles());
         return optGenesisSlotBytes.map(LittleEndianUtils::fromLittleEndianByteArray).orElse(null);
     }
 

--- a/src/main/java/com/limechain/runtime/Runtime.java
+++ b/src/main/java/com/limechain/runtime/Runtime.java
@@ -10,6 +10,8 @@ import com.limechain.runtime.version.RuntimeVersion;
 import com.limechain.runtime.version.scale.RuntimeVersionReader;
 import com.limechain.sync.fullsync.inherents.InherentData;
 import com.limechain.sync.fullsync.inherents.scale.InherentDataWriter;
+import com.limechain.trie.structure.nibble.Nibbles;
+import com.limechain.utils.LittleEndianUtils;
 import com.limechain.utils.scale.ScaleUtils;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -20,6 +22,8 @@ import org.jetbrains.annotations.Nullable;
 import org.wasmer.Instance;
 import org.wasmer.Module;
 
+import java.math.BigInteger;
+import java.util.Optional;
 import java.util.logging.Level;
 
 @Log
@@ -70,6 +74,19 @@ public class Runtime {
      */
     public BabeApiConfiguration callBabeApiConfiguration() {
         return ScaleUtils.Decode.decode(this.call(RuntimeEndpoint.BABE_API_CONFIGURATION), new BabeApiConfigurationReader());
+    }
+
+    public Optional<byte[]> findStorageValue(Nibbles key) {
+        return this.context.trieAccessor.findStorageValue(key);
+    }
+
+    public BigInteger retrieveGenesisSlot() {
+        var optGenesisSlotBytes = this.findStorageValue(
+                Nibbles.fromHexString("0x1cb6f36e027abb2091cfb5110ab5087f678711d15ebbceba5cd0cea158e6675a")
+        );
+
+        return optGenesisSlotBytes.map(LittleEndianUtils::fromLittleEndianByteArray).orElse(null);
+
     }
 
     /**

--- a/src/main/java/com/limechain/runtime/RuntimeStorageKey.java
+++ b/src/main/java/com/limechain/runtime/RuntimeStorageKey.java
@@ -4,6 +4,7 @@ import com.limechain.trie.structure.nibble.Nibbles;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+// all available keys can be found here: https://www.shawntabrizi.com/substrate-known-keys/
 @Getter
 @AllArgsConstructor
 public enum RuntimeStorageKey {

--- a/src/main/java/com/limechain/runtime/RuntimeStorageKey.java
+++ b/src/main/java/com/limechain/runtime/RuntimeStorageKey.java
@@ -4,11 +4,16 @@ import com.limechain.trie.structure.nibble.Nibbles;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-// all available keys can be found here: https://www.shawntabrizi.com/substrate-known-keys/
+// All available keys can be found here: https://www.shawntabrizi.com/substrate-known-keys/
+// Keys are encoded using 'xxHash' algorithm, and we use directly the encoded value
 @Getter
 @AllArgsConstructor
 public enum RuntimeStorageKey {
-    GENESIS_SLOT(Nibbles.fromHexString("0x1cb6f36e027abb2091cfb5110ab5087f678711d15ebbceba5cd0cea158e6675a"));
+    GENESIS_SLOT("0x1cb6f36e027abb2091cfb5110ab5087f678711d15ebbceba5cd0cea158e6675a");
 
-    private final Nibbles key;
+    private final String encodedKey;
+
+    public Nibbles getNibbles() {
+        return Nibbles.fromHexString(this.getEncodedKey());
+    }
 }

--- a/src/main/java/com/limechain/runtime/RuntimeStorageKey.java
+++ b/src/main/java/com/limechain/runtime/RuntimeStorageKey.java
@@ -1,0 +1,13 @@
+package com.limechain.runtime;
+
+import com.limechain.trie.structure.nibble.Nibbles;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RuntimeStorageKey {
+    GENESIS_SLOT(Nibbles.fromHexString("0x1cb6f36e027abb2091cfb5110ab5087f678711d15ebbceba5cd0cea158e6675a"));
+
+    private final Nibbles key;
+}

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -119,7 +119,7 @@ public class FullSyncMachine {
 
     private void initializeEpochState() {
         epochState.initialize(runtime.callBabeApiConfiguration());
-        epochState.setGenesisSlotNumber(runtime.retrieveGenesisSlot());
+        epochState.setGenesisSlotNumber(runtime.getGenesisSlotNumber());
     }
 
     private TrieStructure<NodeData> loadStateAtBlockFromPeer(Hash256 lastFinalizedBlockHash) {

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -1,9 +1,11 @@
 package com.limechain.sync.fullsync;
 
 import com.google.protobuf.ByteString;
+import com.limechain.config.HostConfig;
 import com.limechain.exception.storage.BlockNodeNotFoundException;
 import com.limechain.exception.sync.BlockExecutionException;
 import com.limechain.network.Network;
+import com.limechain.network.protocol.blockannounce.NodeRole;
 import com.limechain.network.protocol.sync.BlockRequestDto;
 import com.limechain.network.protocol.sync.pb.SyncMessage;
 import com.limechain.network.protocol.warp.dto.Block;
@@ -15,7 +17,6 @@ import com.limechain.network.protocol.warp.dto.HeaderDigest;
 import com.limechain.network.protocol.warp.scale.reader.BlockHeaderReader;
 import com.limechain.rpc.server.AppBean;
 import com.limechain.runtime.Runtime;
-import com.limechain.babe.api.BabeApiConfiguration;
 import com.limechain.babe.state.EpochState;
 import com.limechain.runtime.builder.RuntimeBuilder;
 import com.limechain.runtime.version.StateVersion;
@@ -51,6 +52,8 @@ import java.util.Map;
 @Getter
 @Log
 public class FullSyncMachine {
+
+    private final HostConfig hostConfig;
     private final Network networkService;
     private final SyncState syncState;
     private final BlockState blockState = BlockState.getInstance();
@@ -59,7 +62,8 @@ public class FullSyncMachine {
     private final EpochState epochState = AppBean.getBean(EpochState.class);
     private Runtime runtime = null;
 
-    public FullSyncMachine(final Network networkService, final SyncState syncState) {
+    public FullSyncMachine(HostConfig hostConfig, Network networkService, SyncState syncState) {
+        this.hostConfig = hostConfig;
         this.networkService = networkService;
         this.syncState = syncState;
     }
@@ -81,8 +85,6 @@ public class FullSyncMachine {
 
         runtime = buildRuntimeFromState(trieAccessor);
         StateVersion runtimeStateVersion = runtime.getVersion().getStateVersion();
-        BabeApiConfiguration babeApiConfiguration = runtime.callBabeApiConfiguration();
-        epochState.initialize(babeApiConfiguration);
         trieAccessor.setCurrentStateVersion(runtimeStateVersion);
 
         byte[] calculatedMerkleRoot = trieAccessor.getMerkleRoot(runtimeStateVersion);
@@ -108,7 +110,16 @@ public class FullSyncMachine {
             receivedBlocks = requestBlocks(startNumber, blocksToFetch);
         }
 
+        if (NodeRole.AUTHORING.equals(hostConfig.getNodeRole())) {
+            initializeEpochState();
+        }
+
         blockState.setFullSyncFinished(true);
+    }
+
+    private void initializeEpochState() {
+        epochState.initialize(runtime.callBabeApiConfiguration());
+        epochState.setGenesisSlotNumber(runtime.retrieveGenesisSlot());
     }
 
     private TrieStructure<NodeData> loadStateAtBlockFromPeer(Hash256 lastFinalizedBlockHash) {


### PR DESCRIPTION
# Description

- Add a method to call Runtime Storage and retrieve the genesis slot number.
- Add a method to set the genesis slot number in EpochState. The provided value may be null, indicating that the chain has no executed blocks, in which case the current slot number is used as the genesis slot number.
- Add an isInitialized flag to EpochState, which is set to TRUE only when the goal is to run an authoring node.

Fixes: https://github.com/LimeChain/Fruzhin/issues/593