### PR TITLE
feat: Revert state storage updates for runtime calls...

### DIFF
--- a/src/main/java/com/limechain/trie/MemoryTrieAccessor.java
+++ b/src/main/java/com/limechain/trie/MemoryTrieAccessor.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract sealed class MemoryTrieAccessor extends TrieAccessor
-    permits BlockTrieAccessor, MemoryChildTrieAccessor {
+         permits BlockTrieAccessor, MemoryChildTrieAccessor {
 
     private final TrieStructure<NodeData> initialTrie;
     private List<TrieNodeIndex> updates;
@@ -59,8 +59,8 @@ public abstract sealed class MemoryTrieAccessor extends TrieAccessor
 
         for (Nibble nibble : Nibbles.ALL) {
             nodeHandle.getChild(nibble)
-                .map(NodeHandle::getNodeIndex)
-                .ifPresent(childIndex -> initialTrie.deleteNodesRecursively(childIndex, limit, deleted));
+                    .map(NodeHandle::getNodeIndex)
+                    .ifPresent(childIndex -> initialTrie.deleteNodesRecursively(childIndex, limit, deleted));
         }
 
         if (limit != null && deleted.get() >= limit) {
@@ -79,8 +79,8 @@ public abstract sealed class MemoryTrieAccessor extends TrieAccessor
     @Override
     public Optional<byte[]> findStorageValue(Nibbles key) {
         return initialTrie.existingNode(key)
-            .map(NodeHandle::getUserData)
-            .map(NodeData::getValue);
+                .map(NodeHandle::getUserData)
+                .map(NodeData::getValue);
     }
 
     @Override
@@ -128,19 +128,30 @@ public abstract sealed class MemoryTrieAccessor extends TrieAccessor
         return new MemoryChildTrieAccessor(trieStorage, this, trieKey, merkleRoot);
     }
 
+    @Override
+    public void prepareBackup() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void backup() {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Retrieves the Merkle root hash of the trie with the specified state version.
      *
      * @param version The state version.
      * @return The Merkle root hash.
      */
+    @Override
     public byte[] getMerkleRoot(StateVersion version) {
         updates = TrieStructureFactory.recalculateMerkleValues(initialTrie, version, HashUtils::hashWithBlake2b);
 
         mainTrieRoot = initialTrie.getRootNode()
-            .map(NodeHandle::getUserData)
-            .map(NodeData::getMerkleValue)
-            .orElseThrow();
+                .map(NodeHandle::getUserData)
+                .map(NodeData::getMerkleValue)
+                .orElseThrow();
 
         return mainTrieRoot;
     }

--- a/src/main/java/com/limechain/trie/TrieAccessor.java
+++ b/src/main/java/com/limechain/trie/TrieAccessor.java
@@ -26,7 +26,7 @@ public abstract sealed class TrieAccessor permits MemoryTrieAccessor, DiskTrieAc
     protected byte[] mainTrieRoot;
     @Setter
     protected StateVersion currentStateVersion;
-    // True if
+    // Runtime instance sets this to false only when executing `Core_execute_block`.
     @Setter
     protected boolean shouldBackup;
 

--- a/src/test/java/com/limechain/sync/fullsync/BlockExecutorTest.java
+++ b/src/test/java/com/limechain/sync/fullsync/BlockExecutorTest.java
@@ -14,6 +14,7 @@ import com.limechain.runtime.version.StateVersion;
 import com.limechain.storage.KVRepository;
 import com.limechain.storage.trie.TrieStorage;
 import com.limechain.trie.BlockTrieAccessor;
+import com.limechain.trie.DiskTrieAccessor;
 import com.limechain.trie.TrieStructureFactory;
 import com.limechain.utils.StringUtils;
 import com.limechain.utils.scale.ScaleUtils;
@@ -46,7 +47,7 @@ class BlockExecutorTest {
         trieStorage.insertTrieStorage(genesisTrie); // populate with the genesis trie
 
         final byte[] genesisStateRoot = genesisTrie.getRootNode().get().getUserData().getMerkleValue();
-        BlockTrieAccessor trieAccessor = new BlockTrieAccessor(trieStorage, genesisStateRoot); // instantiate a block trie accessor with the trieStorage specified for the genesis block
+        DiskTrieAccessor trieAccessor = new DiskTrieAccessor(trieStorage, genesisStateRoot); // instantiate a block trie accessor with the trieStorage specified for the genesis block
         trieAccessor.setCurrentStateVersion(StateVersion.V0);
 
         // Package all dependencies into the expected configuration for the runtime builder


### PR DESCRIPTION
# Description
Runtime now reverts all state storage changes originating from a runtime call different from `Core_execute_block`. This is needed when validating transactions. The runtime updates state storage when checking if a provided transaction is valid.