### PR TITLE
Increment Nabu version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 
     // Nabu
 //    implementation("com.github.LimeChain:nabu:master-SNAPSHOT") // Uncomment for "most-recent on the master branch"
-    implementation("com.github.LimeChain:nabu:0.7.8")
+    implementation("com.github.LimeChain:nabu:0.7.9")
 
     //JSON-RPC
     implementation("com.github.LimeChain:jsonrpc4j:1.7.0")


### PR DESCRIPTION
# Description

After spring-boot version update, Fruzhin stopped working because of the ```gson``` version in the ```nabu``` project. The ```jedis``` dependency in ```nabu``` has as sub-dependency ```gson```, so I updated ```jedis``` from 4.3.0 to 5.2.0, increasing indirectly the ```gson``` version to 2.11.0. The created tag 0.7.9 is then used in Fruzhin.