### PR TITLE
Implemented Block equivocation without unit tests

### DIFF
--- a/src/main/java/com/limechain/babe/BlockProductionVerifier.java
+++ b/src/main/java/com/limechain/babe/BlockProductionVerifier.java
@@ -1,5 +1,9 @@
 package com.limechain.babe;
 
+import com.limechain.babe.api.BlockEquivocationProof;
+import com.limechain.babe.api.OpaqueKeyOwnershipProof;
+import com.limechain.babe.coordinator.SlotChangeEvent;
+import com.limechain.babe.coordinator.SlotChangeListener;
 import com.limechain.babe.predigest.BabePreDigest;
 import com.limechain.babe.state.EpochData;
 import com.limechain.babe.state.EpochDescriptor;
@@ -8,24 +12,36 @@ import com.limechain.network.protocol.warp.DigestHelper;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.network.protocol.warp.dto.DigestType;
 import com.limechain.network.protocol.warp.dto.HeaderDigest;
+import com.limechain.runtime.Runtime;
 import com.limechain.runtime.hostapi.dto.Key;
 import com.limechain.runtime.hostapi.dto.VerifySignature;
 import com.limechain.utils.LittleEndianUtils;
 import com.limechain.utils.Sr25519Utils;
+import com.limechain.utils.StringUtils;
 import io.emeraldpay.polkaj.merlin.TranscriptData;
 import io.emeraldpay.polkaj.schnorrkel.Schnorrkel;
 import io.emeraldpay.polkaj.schnorrkel.VrfOutputAndProof;
 import lombok.extern.java.Log;
+import org.apache.tomcat.util.buf.HexUtils;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 @Log
-public class BlockProductionVerifier {
+public class BlockProductionVerifier implements SlotChangeListener {
 
-    public boolean verifyAuthorship(BlockHeader blockHeader, EpochData currentEpochData, EpochDescriptor descriptor, BigInteger currentEpochIndex, BigInteger currentSlotNumber) {
+    private final Map<String, BlockHeader> currentSlotAuthorBlockMap = new ConcurrentHashMap<>();
+
+    public boolean verifyAuthorship(Runtime runtime,
+                                    BlockHeader blockHeader,
+                                    EpochData currentEpochData,
+                                    EpochDescriptor descriptor,
+                                    BigInteger currentEpochIndex,
+                                    BigInteger currentSlotNumber) {
         HeaderDigest[] headerDigests = blockHeader.getDigest();
         Optional<BabePreDigest> babePreDigest = DigestHelper.getBabePreRuntimeDigest(headerDigests);
         HeaderDigest sealDigest = headerDigests[headerDigests.length - 1];
@@ -39,19 +55,45 @@ public class BlockProductionVerifier {
         int authorityIndex = babePreDigest.map(BabePreDigest::getAuthorityIndex).map(Math::toIntExact).get();
         Authority verifyingAuthority = authorities.get(authorityIndex);
 
-        VrfOutputAndProof vrfOutputAndProof = VrfOutputAndProof.wrap(
-                babePreDigest.get().getVrfOutput(), babePreDigest.get().getVrfProof());
-        VerifySignature signature = new VerifySignature(
-                signatureData, blockHeader.getHashBytes(), verifyingAuthority.getPublicKey(), Key.SR25519);
+        if (!checkBlockEquivocation(verifyingAuthority, blockHeader, runtime, currentSlotNumber)) {
+            return false;
+        }
 
-        return Sr25519Utils.verifySignature(signature) &&
-                verifySlotWinner(authorityIndex,
-                        authorities,
-                        currentEpochIndex,
-                        randomness,
-                        descriptor,
-                        currentSlotNumber,
-                        vrfOutputAndProof);
+        VrfOutputAndProof vrfOutputAndProof = VrfOutputAndProof.wrap(babePreDigest.get().getVrfOutput(), babePreDigest.get().getVrfProof());
+        VerifySignature signature = new VerifySignature(signatureData, blockHeader.getHashBytes(), verifyingAuthority.getPublicKey(), Key.SR25519);
+
+        boolean isVerified = Sr25519Utils.verifySignature(signature) &&
+                verifySlotWinner(authorityIndex, authorities, currentEpochIndex, randomness, descriptor, currentSlotNumber, vrfOutputAndProof);
+
+        if (isVerified) {
+            currentSlotAuthorBlockMap.put(StringUtils.toHexWithPrefix(verifyingAuthority.getPublicKey()),blockHeader);
+        }
+
+        return isVerified;
+    }
+
+    private boolean checkBlockEquivocation(Authority authority,
+                                           BlockHeader blockHeader,
+                                           Runtime runtime,
+                                           BigInteger currentSlotNumber) {
+        String hexPublicKey = HexUtils.toHexString(authority.getPublicKey());
+        if (currentSlotAuthorBlockMap.containsKey(hexPublicKey)) {
+            BlockHeader firstBlockHeader = currentSlotAuthorBlockMap.get(hexPublicKey);
+            if (!firstBlockHeader.equals(blockHeader)) {
+                BlockEquivocationProof blockEquivocationProof = new BlockEquivocationProof();
+                blockEquivocationProof.setPublicKey(authority.getPublicKey());
+                blockEquivocationProof.setSlotNumber(currentSlotNumber);
+                blockEquivocationProof.setFirstBlockHeader(firstBlockHeader);
+                blockEquivocationProof.setSecondBlockHeader(blockHeader);
+
+                Optional<OpaqueKeyOwnershipProof> opaqueKeyOwnershipProof = runtime.generateKeyOwnershipProof(currentSlotNumber, authority.getPublicKey());
+                opaqueKeyOwnershipProof.ifPresentOrElse(
+                        key -> runtime.submitReportEquivocationUnsignedExtrinsic(blockEquivocationProof, key.getProof()),
+                        () -> log.warning(String.format("Unable to generate Opaque Key Ownership Proof for authority: %s", hexPublicKey)));
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean verifySlotWinner(int authorityIndex,
@@ -76,5 +118,10 @@ public class BlockProductionVerifier {
             log.log(Level.WARNING, "Block producer is not a winner of the slot");
         }
         return Schnorrkel.getInstance().vrfVerify(publicKey, transcript, vrfOutputAndProof) && isBelowThreshold;
+    }
+
+    @Override
+    public void slotChanged(SlotChangeEvent event) {
+        currentSlotAuthorBlockMap.clear();
     }
 }

--- a/src/main/java/com/limechain/babe/api/BlockEquivocationProof.java
+++ b/src/main/java/com/limechain/babe/api/BlockEquivocationProof.java
@@ -1,0 +1,14 @@
+package com.limechain.babe.api;
+
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import lombok.Data;
+
+import java.math.BigInteger;
+
+@Data
+public class BlockEquivocationProof {
+    byte[] publicKey;
+    BigInteger slotNumber;
+    BlockHeader firstBlockHeader;
+    BlockHeader secondBlockHeader;
+}

--- a/src/main/java/com/limechain/babe/api/BlockEquivocationProof.java
+++ b/src/main/java/com/limechain/babe/api/BlockEquivocationProof.java
@@ -7,8 +7,8 @@ import java.math.BigInteger;
 
 @Data
 public class BlockEquivocationProof {
-    byte[] publicKey;
-    BigInteger slotNumber;
-    BlockHeader firstBlockHeader;
-    BlockHeader secondBlockHeader;
+    private byte[] publicKey;
+    private BigInteger slotNumber;
+    private BlockHeader firstBlockHeader;
+    private BlockHeader secondBlockHeader;
 }

--- a/src/main/java/com/limechain/babe/api/OpaqueKeyOwnershipProof.java
+++ b/src/main/java/com/limechain/babe/api/OpaqueKeyOwnershipProof.java
@@ -1,0 +1,8 @@
+package com.limechain.babe.api;
+
+import lombok.Data;
+
+@Data
+public class OpaqueKeyOwnershipProof {
+    byte[] proof;
+}

--- a/src/main/java/com/limechain/babe/api/OpaqueKeyOwnershipProof.java
+++ b/src/main/java/com/limechain/babe/api/OpaqueKeyOwnershipProof.java
@@ -4,5 +4,5 @@ import lombok.Data;
 
 @Data
 public class OpaqueKeyOwnershipProof {
-    byte[] proof;
+    private byte[] proof;
 }

--- a/src/main/java/com/limechain/babe/api/scale/BlockEquivocationProofWriter.java
+++ b/src/main/java/com/limechain/babe/api/scale/BlockEquivocationProofWriter.java
@@ -1,0 +1,26 @@
+package com.limechain.babe.api.scale;
+
+import com.limechain.babe.api.BlockEquivocationProof;
+import com.limechain.network.protocol.blockannounce.scale.BlockHeaderScaleWriter;
+import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import io.emeraldpay.polkaj.scale.ScaleWriter;
+import io.emeraldpay.polkaj.scale.writer.UInt64Writer;
+
+import java.io.IOException;
+
+public class BlockEquivocationProofWriter implements ScaleWriter<BlockEquivocationProof> {
+
+    private final UInt64Writer uint64Writer;
+
+    public BlockEquivocationProofWriter() {
+        this.uint64Writer = new UInt64Writer();
+    }
+
+    @Override
+    public void write(ScaleCodecWriter writer, BlockEquivocationProof blockEquivocationProof) throws IOException {
+        writer.writeByteArray(blockEquivocationProof.getPublicKey());
+        uint64Writer.write(writer, blockEquivocationProof.getSlotNumber());
+        writer.write(BlockHeaderScaleWriter.getInstance(), blockEquivocationProof.getFirstBlockHeader());
+        writer.write(BlockHeaderScaleWriter.getInstance(), blockEquivocationProof.getSecondBlockHeader());
+    }
+}

--- a/src/main/java/com/limechain/babe/api/scale/OpaqueKeyOwnershipProofReader.java
+++ b/src/main/java/com/limechain/babe/api/scale/OpaqueKeyOwnershipProofReader.java
@@ -1,0 +1,15 @@
+package com.limechain.babe.api.scale;
+
+import com.limechain.babe.api.OpaqueKeyOwnershipProof;
+import io.emeraldpay.polkaj.scale.ScaleCodecReader;
+import io.emeraldpay.polkaj.scale.ScaleReader;
+
+public class OpaqueKeyOwnershipProofReader implements ScaleReader<OpaqueKeyOwnershipProof> {
+
+    @Override
+    public OpaqueKeyOwnershipProof read(ScaleCodecReader reader) {
+        OpaqueKeyOwnershipProof proof = new OpaqueKeyOwnershipProof();
+        proof.setProof(reader.readByteArray());
+        return proof;
+    }
+}

--- a/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Objects;
 
 @Setter
 @Getter
@@ -44,17 +43,5 @@ public class BlockHeader {
                         : BlockHeaderScaleWriter.getInstance()::writeUnsealed,
                 this);
         return HashUtils.hashWithBlake2b(scaleEncoded);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BlockHeader that)) return false;
-        return Objects.equals(parentHash, that.parentHash) && Objects.equals(blockNumber, that.blockNumber) && Objects.equals(stateRoot, that.stateRoot) && Objects.equals(extrinsicsRoot, that.extrinsicsRoot) && Objects.deepEquals(digest, that.digest);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(parentHash, blockNumber, stateRoot, extrinsicsRoot, Arrays.hashCode(digest));
     }
 }

--- a/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Objects;
 
 @Setter
 @Getter
@@ -43,5 +44,17 @@ public class BlockHeader {
                         : BlockHeaderScaleWriter.getInstance()::writeUnsealed,
                 this);
         return HashUtils.hashWithBlake2b(scaleEncoded);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BlockHeader that)) return false;
+        return Objects.equals(parentHash, that.parentHash) && Objects.equals(blockNumber, that.blockNumber) && Objects.equals(stateRoot, that.stateRoot) && Objects.equals(extrinsicsRoot, that.extrinsicsRoot) && Objects.deepEquals(digest, that.digest);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parentHash, blockNumber, stateRoot, extrinsicsRoot, Arrays.hashCode(digest));
     }
 }

--- a/src/main/java/com/limechain/runtime/Runtime.java
+++ b/src/main/java/com/limechain/runtime/Runtime.java
@@ -1,6 +1,8 @@
 package com.limechain.runtime;
 
 import com.limechain.babe.api.BabeApiConfiguration;
+import com.limechain.babe.api.BlockEquivocationProof;
+import com.limechain.babe.api.OpaqueKeyOwnershipProof;
 import com.limechain.network.protocol.warp.dto.Block;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.rpc.methods.author.dto.DecodedKey;
@@ -14,10 +16,15 @@ import com.limechain.transaction.dto.TransactionValidationResponse;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 
 public interface Runtime {
 
     BabeApiConfiguration getBabeApiConfiguration();
+
+    Optional<OpaqueKeyOwnershipProof> generateKeyOwnershipProof(BigInteger slotNumber, byte[] authorityPublicKey);
+
+    void submitReportEquivocationUnsignedExtrinsic(BlockEquivocationProof blockEquivocationProof, byte[] keyOwnershipProof);
 
     List<DecodedKey> decodeSessionKeys(String sessionKeys);
 

--- a/src/main/java/com/limechain/runtime/RuntimeEndpoint.java
+++ b/src/main/java/com/limechain/runtime/RuntimeEndpoint.java
@@ -16,6 +16,8 @@ public enum RuntimeEndpoint {
     CORE_EXECUTE_BLOCK("Core_execute_block"),
     CORE_INITIALIZE_BLOCK("Core_initialize_block"),
     BABE_API_CONFIGURATION("BabeApi_configuration"),
+    BABE_API_GENERATE_KEY_OWNERSHIP_PROOF("BabeApi_generate_key_ownership_proof"),
+    BABE_API_SUBMIT_REPORT_EQUIVOCATION_UNSIGNED_EXTRINSIC("BabeApi_submit_report_equivocation_unsigned_extrinsic"),
     BLOCKBUILDER_FINALIZE_BLOCK("BlockBuilder_finalize_block"),
     BLOCKBUILDER_CHECK_INHERENTS("BlockBuilder_check_inherents"),
     BLOCKBUILDER_APPLY_EXTRINISIC("BlockBuilder_apply_extrinsic"),

--- a/src/main/java/com/limechain/runtime/RuntimeImpl.java
+++ b/src/main/java/com/limechain/runtime/RuntimeImpl.java
@@ -74,7 +74,6 @@ public class RuntimeImpl implements Runtime {
     @Override
     public void submitReportEquivocationUnsignedExtrinsic(BlockEquivocationProof blockEquivocationProof,
                                                           byte[] keyOwnershipProof) {
-        // Key ownership needs to be encoded as a list (have its length encoded) as it is of varying size.
         try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
              ScaleCodecWriter scaleCodecWriter = new ScaleCodecWriter(buffer)) {
             new BlockEquivocationProofWriter().write(scaleCodecWriter, blockEquivocationProof);

--- a/src/main/java/com/limechain/runtime/RuntimeImpl.java
+++ b/src/main/java/com/limechain/runtime/RuntimeImpl.java
@@ -1,7 +1,11 @@
 package com.limechain.runtime;
 
 import com.limechain.babe.api.BabeApiConfiguration;
+import com.limechain.babe.api.BlockEquivocationProof;
+import com.limechain.babe.api.OpaqueKeyOwnershipProof;
 import com.limechain.babe.api.scale.BabeApiConfigurationReader;
+import com.limechain.babe.api.scale.BlockEquivocationProofWriter;
+import com.limechain.babe.api.scale.OpaqueKeyOwnershipProofReader;
 import com.limechain.network.protocol.blockannounce.scale.BlockHeaderScaleWriter;
 import com.limechain.network.protocol.transaction.scale.TransactionReader;
 import com.limechain.network.protocol.warp.dto.Block;
@@ -15,11 +19,7 @@ import com.limechain.runtime.version.RuntimeVersion;
 import com.limechain.runtime.version.scale.RuntimeVersionReader;
 import com.limechain.sync.fullsync.inherents.InherentData;
 import com.limechain.sync.fullsync.inherents.scale.InherentDataWriter;
-import com.limechain.transaction.dto.ApplyExtrinsicResult;
-import com.limechain.transaction.dto.Extrinsic;
-import com.limechain.transaction.dto.ExtrinsicArray;
-import com.limechain.transaction.dto.TransactionValidationRequest;
-import com.limechain.transaction.dto.TransactionValidationResponse;
+import com.limechain.transaction.dto.*;
 import com.limechain.trie.structure.nibble.Nibbles;
 import com.limechain.utils.ByteArrayUtils;
 import com.limechain.utils.LittleEndianUtils;
@@ -29,7 +29,9 @@ import com.limechain.utils.scale.readers.ApplyExtrinsicResultReader;
 import com.limechain.utils.scale.readers.TransactionValidationReader;
 import com.limechain.utils.scale.writers.BlockInherentsWriter;
 import com.limechain.utils.scale.writers.TransactionValidationWriter;
+import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import io.emeraldpay.polkaj.scale.writer.UInt64Writer;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.extern.java.Log;
@@ -55,6 +57,19 @@ public class RuntimeImpl implements Runtime {
     @Override
     public BabeApiConfiguration getBabeApiConfiguration() {
         return ScaleUtils.Decode.decode(call(RuntimeEndpoint.BABE_API_CONFIGURATION), new BabeApiConfigurationReader());
+    }
+
+    @Override
+    public Optional<OpaqueKeyOwnershipProof> generateKeyOwnershipProof(BigInteger slotNumber, byte[] authorityPublicKey) {
+        byte[] encodedProof = ArrayUtils.addAll(ScaleUtils.Encode.encode(new UInt64Writer(), slotNumber), authorityPublicKey);
+        byte[] encodedResponse = call(RuntimeEndpoint.BABE_API_GENERATE_KEY_OWNERSHIP_PROOF, encodedProof);
+        return new ScaleCodecReader(encodedResponse).readOptional(new OpaqueKeyOwnershipProofReader());
+    }
+
+    @Override
+    public void submitReportEquivocationUnsignedExtrinsic(BlockEquivocationProof blockEquivocationProof, byte[] keyOwnershipProof) {
+        byte[] encodedEquivocation = ArrayUtils.addAll(ScaleUtils.Encode.encode(new BlockEquivocationProofWriter(), blockEquivocationProof), keyOwnershipProof);
+        call(RuntimeEndpoint.BABE_API_SUBMIT_REPORT_EQUIVOCATION_UNSIGNED_EXTRINSIC, encodedEquivocation);
     }
 
     @Override

--- a/src/main/java/com/limechain/storage/block/BlockHandler.java
+++ b/src/main/java/com/limechain/storage/block/BlockHandler.java
@@ -53,7 +53,11 @@ public class BlockHandler {
 
     public synchronized void handleBlockHeader(Instant arrivalTime, BlockHeader header, PeerId excluding) {
         try {
-            if (epochState.isInitialized() && !verifier.isAuthorshipValid(header,
+            Runtime runtime = blockState.getRuntime(header.getParentHash());
+            Runtime newRuntime = builder.copyRuntime(runtime);
+
+            if (epochState.isInitialized() && !verifier.isAuthorshipValid(newRuntime,
+                    header,
                     epochState.getCurrentEpochData(),
                     epochState.getCurrentEpochDescriptor(),
                     epochState.getCurrentEpochIndex())) {
@@ -67,9 +71,6 @@ public class BlockHandler {
 
             CompletableFuture<List<Block>> responseFuture = requester.requestBlocks(
                     BlockRequestField.ALL, header.getHash(), 1);
-
-            Runtime runtime = blockState.getRuntime(header.getParentHash());
-            Runtime newRuntime = builder.copyRuntime(runtime);
 
             List<Block> blocks = responseFuture.join();
             while (blocks.isEmpty()) {

--- a/src/main/java/com/limechain/storage/block/BlockHandler.java
+++ b/src/main/java/com/limechain/storage/block/BlockHandler.java
@@ -53,7 +53,11 @@ public class BlockHandler {
 
     public synchronized void handleBlockHeader(Instant arrivalTime, BlockHeader header, PeerId excluding) {
         try {
-            if (epochState.isInitialized() && !verifier.verifyAuthorship(header,
+            Runtime runtime = blockState.getRuntime(header.getParentHash());
+            Runtime newRuntime = builder.copyRuntime(runtime);
+
+            if (epochState.isInitialized() && !verifier.verifyAuthorship(newRuntime,
+                    header,
                     epochState.getCurrentEpochData(),
                     epochState.getCurrentEpochDescriptor(),
                     epochState.getCurrentEpochIndex(),
@@ -70,9 +74,6 @@ public class BlockHandler {
 
             CompletableFuture<List<Block>> responseFuture = requester.requestBlocks(
                     BlockRequestField.ALL, header.getHash(), 1);
-
-            Runtime runtime = blockState.getRuntime(header.getParentHash());
-            Runtime newRuntime = builder.copyRuntime(runtime);
 
             List<Block> blocks = responseFuture.join();
             while (blocks.isEmpty()) {

--- a/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
+++ b/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
@@ -33,7 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 class BlockProductionVerifierTest {
 
@@ -170,19 +174,31 @@ class BlockProductionVerifierTest {
 
             mockedSr25519.when(() -> Sr25519Utils.verifySignature(any())).thenReturn(true);
 
-            BlockHeader firstBlockHeader = new BlockHeader();
-            firstBlockHeader.setDigest(headerDigests);
-            firstBlockHeader.setBlockNumber(BigInteger.ONE);
-            firstBlockHeader.setParentHash(new Hash256(new byte[32]));
-            firstBlockHeader.setExtrinsicsRoot(new Hash256(new byte[32]));
-            firstBlockHeader.setStateRoot(new Hash256(new byte[32]));
+            byte[] hash1 = new byte[]{
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                    0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+                    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+                    0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20
+            };
+            byte[] hash2 = new byte[]{
+                    0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+                    0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30,
+                    0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+                    0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F, 0x40
+            };
+            // First block header
+            BlockHeader firstBlockHeader = mock(BlockHeader.class);
+            when(firstBlockHeader.getDigest()).thenReturn(headerDigests);
+            when(firstBlockHeader.getBlockNumber()).thenReturn(BigInteger.ONE);
+            when(firstBlockHeader.getBlake2bHash(true)).thenReturn(new byte[]{0x01, 0x02, 0x03});
+            when(firstBlockHeader.getHash()).thenReturn(new Hash256(hash1));
 
-            BlockHeader secondBlockHeader = new BlockHeader();
-            secondBlockHeader.setDigest(headerDigests);
-            secondBlockHeader.setBlockNumber(BigInteger.TEN);
-            secondBlockHeader.setParentHash(new Hash256(new byte[32]));
-            secondBlockHeader.setExtrinsicsRoot(new Hash256(new byte[32]));
-            secondBlockHeader.setStateRoot(new Hash256(new byte[32]));
+            // Second block header
+            BlockHeader secondBlockHeader = mock(BlockHeader.class);
+            when(secondBlockHeader.getDigest()).thenReturn(headerDigests);
+            when(secondBlockHeader.getBlockNumber()).thenReturn(BigInteger.ONE); // Same block number to simulate equivocation
+            when(secondBlockHeader.getBlake2bHash(true)).thenReturn(new byte[]{0x01, 0x02, 0x03, 0x04});
+            when(secondBlockHeader.getHash()).thenReturn(new Hash256(hash2));
 
             verifierSpy.isAuthorshipValid(runtime, firstBlockHeader, currentEpochData, epochDescriptor, epochIndex);
             boolean result = verifierSpy.isAuthorshipValid(runtime, secondBlockHeader, currentEpochData, epochDescriptor, epochIndex);

--- a/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
+++ b/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
@@ -8,6 +8,7 @@ import com.limechain.network.protocol.warp.DigestHelper;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.network.protocol.warp.dto.DigestType;
 import com.limechain.network.protocol.warp.dto.HeaderDigest;
+import com.limechain.runtime.Runtime;
 import com.limechain.utils.Sr25519Utils;
 import io.emeraldpay.polkaj.merlin.TranscriptData;
 import io.emeraldpay.polkaj.schnorrkel.Schnorrkel;
@@ -52,6 +53,9 @@ class BlockProductionVerifierTest {
 
     @Mock
     private BabePreDigest babePreDigest;
+
+    @Mock
+    private Runtime runtime;
 
     private final BigInteger epochIndex = BigInteger.ONE;
     private final byte[] randomness = new byte[]{0x01, 0x02, 0x03};
@@ -106,7 +110,7 @@ class BlockProductionVerifierTest {
 
             mockedSr25519.when(() -> Sr25519Utils.verifySignature(any())).thenReturn(true);
 
-            boolean result = verifierSpy.verifyAuthorship(blockHeader, currentEpochData, epochDescriptor, epochIndex, slotNumber);
+            boolean result = verifierSpy.verifyAuthorship(runtime, blockHeader, currentEpochData, epochDescriptor, epochIndex, slotNumber);
 
             assertTrue(result);
 
@@ -158,7 +162,7 @@ class BlockProductionVerifierTest {
 
             mockedSr25519.when(() -> Sr25519Utils.verifySignature(any())).thenReturn(true);
 
-            boolean result = verifierSpy.verifyAuthorship(blockHeader, currentEpochData, epochDescriptor, epochIndex, slotNumber);
+            boolean result = verifierSpy.verifyAuthorship(runtime, blockHeader, currentEpochData, epochDescriptor, epochIndex, slotNumber);
 
             assertFalse(result);
 
@@ -175,7 +179,7 @@ class BlockProductionVerifierTest {
         when(blockHeader.getDigest()).thenReturn(headerDigests);
         when(sealDigest.getType()).thenReturn(DigestType.PRE_RUNTIME);
 
-        boolean result = blockProductionVerifier.verifyAuthorship(blockHeader, currentEpochData, epochDescriptor, BigInteger.ONE, BigInteger.TEN);
+        boolean result = blockProductionVerifier.verifyAuthorship(runtime, blockHeader, currentEpochData, epochDescriptor, BigInteger.ONE, BigInteger.TEN);
         assertFalse(result);
     }
 }

--- a/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
+++ b/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
@@ -6,6 +6,7 @@ import com.limechain.babe.state.EpochData;
 import com.limechain.babe.state.EpochDescriptor;
 import com.limechain.chain.lightsyncstate.Authority;
 import com.limechain.exception.misc.AuthorshipVerificationException;
+import com.limechain.runtime.Runtime;
 import com.limechain.network.protocol.warp.DigestHelper;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.network.protocol.warp.dto.DigestType;
@@ -14,6 +15,7 @@ import com.limechain.utils.Sr25519Utils;
 import io.emeraldpay.polkaj.merlin.TranscriptData;
 import io.emeraldpay.polkaj.schnorrkel.Schnorrkel;
 import io.emeraldpay.polkaj.schnorrkel.VrfOutputAndProof;
+import io.emeraldpay.polkaj.types.Hash256;
 import org.javatuples.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,11 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class BlockProductionVerifierTest {
 
@@ -59,6 +57,9 @@ class BlockProductionVerifierTest {
 
     @Mock
     private BabePreDigest babePreDigest;
+
+    @Mock
+    private Runtime runtime;
 
     private final BigInteger epochIndex = BigInteger.ONE;
     private final byte[] randomness = new byte[]{0x01, 0x02, 0x03};
@@ -115,13 +116,77 @@ class BlockProductionVerifierTest {
 
             mockedSr25519.when(() -> Sr25519Utils.verifySignature(any())).thenReturn(true);
 
-            boolean result = verifierSpy.isAuthorshipValid(blockHeader, currentEpochData, epochDescriptor, epochIndex);
+            boolean result = verifierSpy.isAuthorshipValid(runtime, blockHeader, currentEpochData, epochDescriptor, epochIndex);
 
             assertTrue(result);
 
             mockedSr25519.verify(() -> Sr25519Utils.verifySignature(any()), times(1));
             mockedDigestHelper.verify(() -> DigestHelper.getBabePreRuntimeDigest(headerDigests), times(1));
             mockedVrfOutputAndProof.verify(() -> VrfOutputAndProof.wrap(vrfOutput, vrfProof), times(1));
+        }
+    }
+
+    @Test
+    void testIsAuthorship_EquivocationCase() {
+        try (MockedStatic<DigestHelper> mockedDigestHelper = mockStatic(DigestHelper.class);
+             MockedStatic<Sr25519Utils> mockedSr25519 = mockStatic(Sr25519Utils.class);
+             MockedStatic<Schnorrkel> mockedSchnorrkel = mockStatic(Schnorrkel.class);
+             MockedStatic<VrfOutputAndProof> mockedVrfOutputAndProof = mockStatic(VrfOutputAndProof.class)) {
+            Schnorrkel schnorrkelMock = mock(Schnorrkel.class);
+            mockedSchnorrkel.when(Schnorrkel::getInstance).thenReturn(schnorrkelMock);
+            BlockProductionVerifier verifierSpy = spy(blockProductionVerifier);
+
+            when(schnorrkelMock.makeBytes(any(Schnorrkel.PublicKey.class), any(TranscriptData.class), eq(vrfOutputAndProof)))
+                    .thenReturn(new byte[32]);
+            when(schnorrkelMock.vrfVerify(any(Schnorrkel.PublicKey.class), any(TranscriptData.class), eq(vrfOutputAndProof)))
+                    .thenReturn(true);
+
+            HeaderDigest[] headerDigests = new HeaderDigest[]{sealDigest};
+            when(blockHeader.getDigest()).thenReturn(headerDigests);
+            when(blockHeader.getBlake2bHash(true)).thenReturn(new byte[]{0x01, 0x02, 0x03});
+
+            when(sealDigest.getType()).thenReturn(DigestType.SEAL);
+            when(sealDigest.getMessage()).thenReturn(new byte[]{0x04, 0x05});
+
+            mockedDigestHelper.when(() -> DigestHelper.getBabePreRuntimeDigest(headerDigests))
+                    .thenReturn(Optional.of(babePreDigest));
+
+            when(babePreDigest.getType()).thenReturn(PreDigestType.BABE_PRIMARY);
+            when(babePreDigest.getSlotNumber()).thenReturn(BigInteger.TEN);
+            when(babePreDigest.getAuthorityIndex()).thenReturn(0L);
+            when(babePreDigest.getVrfOutput()).thenReturn(vrfOutput);
+            when(babePreDigest.getVrfProof()).thenReturn(vrfProof);
+
+            mockedVrfOutputAndProof.when(() -> VrfOutputAndProof.wrap(vrfOutput, vrfProof))
+                    .thenReturn(vrfOutputAndProof);
+
+            when(currentEpochData.getRandomness()).thenReturn(randomness);
+            when(epochDescriptor.getConstant()).thenReturn(new Pair<>(BigInteger.valueOf(3), BigInteger.valueOf(4)));
+            List<Authority> authorities = List.of(
+                    new Authority(new byte[32], BigInteger.valueOf(1000)),
+                    new Authority(new byte[32], BigInteger.valueOf(500)),
+                    new Authority(new byte[32], BigInteger.valueOf(500)));
+            when(currentEpochData.getAuthorities()).thenReturn(authorities);
+
+            mockedSr25519.when(() -> Sr25519Utils.verifySignature(any())).thenReturn(true);
+
+            BlockHeader firstBlockHeader = new BlockHeader();
+            firstBlockHeader.setDigest(headerDigests);
+            firstBlockHeader.setBlockNumber(BigInteger.ONE);
+            firstBlockHeader.setParentHash(new Hash256(new byte[32]));
+            firstBlockHeader.setExtrinsicsRoot(new Hash256(new byte[32]));
+            firstBlockHeader.setStateRoot(new Hash256(new byte[32]));
+
+            BlockHeader secondBlockHeader = new BlockHeader();
+            secondBlockHeader.setDigest(headerDigests);
+            secondBlockHeader.setBlockNumber(BigInteger.TEN);
+            secondBlockHeader.setParentHash(new Hash256(new byte[32]));
+            secondBlockHeader.setExtrinsicsRoot(new Hash256(new byte[32]));
+            secondBlockHeader.setStateRoot(new Hash256(new byte[32]));
+
+            verifierSpy.isAuthorshipValid(runtime, firstBlockHeader, currentEpochData, epochDescriptor, epochIndex);
+            boolean result = verifierSpy.isAuthorshipValid(runtime, secondBlockHeader, currentEpochData, epochDescriptor, epochIndex);
+            assertFalse(result);
         }
     }
 
@@ -169,7 +234,7 @@ class BlockProductionVerifierTest {
 
             mockedSr25519.when(() -> Sr25519Utils.verifySignature(any())).thenReturn(true);
 
-            boolean result = verifierSpy.isAuthorshipValid(blockHeader, currentEpochData, epochDescriptor, epochIndex);
+            boolean result = verifierSpy.isAuthorshipValid(runtime, blockHeader, currentEpochData, epochDescriptor, epochIndex);
 
             assertFalse(result);
 
@@ -185,7 +250,7 @@ class BlockProductionVerifierTest {
         when(blockHeader.getDigest()).thenReturn(headerDigests);
         when(sealDigest.getType()).thenReturn(DigestType.PRE_RUNTIME);
 
-        assertThrows(AuthorshipVerificationException.class, () -> blockProductionVerifier.isAuthorshipValid(blockHeader,
+        assertThrows(AuthorshipVerificationException.class, () -> blockProductionVerifier.isAuthorshipValid(runtime, blockHeader,
                 currentEpochData,
                 epochDescriptor,
                 BigInteger.ONE)


### PR DESCRIPTION
Implemented Block equivocation via creating map per slot to keep information about produced blocks buy authorities in given slot.
## Checklist:
- [x] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.