### PR TITLE
fix: Fix block authorship verification

### DIFF
--- a/src/main/java/com/limechain/babe/Authorship.java
+++ b/src/main/java/com/limechain/babe/Authorship.java
@@ -179,9 +179,9 @@ public class Authorship {
         );
     }
 
-    private static Integer getSecondarySlotAuthor(byte[] randomness,
-                                                  BigInteger slotNumber,
-                                                  List<Authority> authorities) {
+    public static Integer getSecondarySlotAuthor(byte[] randomness,
+                                                 BigInteger slotNumber,
+                                                 List<Authority> authorities) {
         if (authorities.isEmpty()) return null;
 
         byte[] concat = ByteArrayUtils.concatenate(randomness, slotNumber.toByteArray());

--- a/src/main/java/com/limechain/exception/misc/AuthorshipVerificationException.java
+++ b/src/main/java/com/limechain/exception/misc/AuthorshipVerificationException.java
@@ -1,0 +1,7 @@
+package com.limechain.exception.misc;
+
+public class AuthorshipVerificationException extends RuntimeException {
+    public AuthorshipVerificationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/limechain/network/protocol/warp/DigestHelper.java
+++ b/src/main/java/com/limechain/network/protocol/warp/DigestHelper.java
@@ -43,7 +43,7 @@ public class DigestHelper {
 
     public static HeaderDigest buildSealHeaderDigest(BlockHeader blockHeader, Schnorrkel.KeyPair keyPair) {
         byte[] signedMessage = Sr25519Utils.signMessage(
-                keyPair.getPublicKey(), keyPair.getSecretKey(), blockHeader.getHashBytes());
+                keyPair.getPublicKey(), keyPair.getSecretKey(), blockHeader.getBlake2bHash(true));
         HeaderDigest sealHeaderDigest = new HeaderDigest();
         sealHeaderDigest.setType(DigestType.SEAL);
         sealHeaderDigest.setId(ConsensusEngine.BABE);

--- a/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/BlockHeader.java
@@ -34,11 +34,14 @@ public class BlockHeader {
     }
 
     public Hash256 getHash() {
-        return new Hash256(getHashBytes());
+        return new Hash256(getBlake2bHash(true));
     }
 
-    public byte[] getHashBytes() {
-        byte[] scaleEncoded = ScaleUtils.Encode.encode(BlockHeaderScaleWriter.getInstance(), this);
+    public byte[] getBlake2bHash(boolean sealed) {
+        byte[] scaleEncoded = ScaleUtils.Encode.encode(sealed
+                        ? BlockHeaderScaleWriter.getInstance()
+                        : BlockHeaderScaleWriter.getInstance()::writeUnsealed,
+                this);
         return HashUtils.hashWithBlake2b(scaleEncoded);
     }
 }

--- a/src/main/java/com/limechain/storage/block/BlockHandler.java
+++ b/src/main/java/com/limechain/storage/block/BlockHandler.java
@@ -53,13 +53,10 @@ public class BlockHandler {
 
     public synchronized void handleBlockHeader(Instant arrivalTime, BlockHeader header, PeerId excluding) {
         try {
-            if (epochState.isInitialized() && !verifier.verifyAuthorship(header,
+            if (epochState.isInitialized() && !verifier.isAuthorshipValid(header,
                     epochState.getCurrentEpochData(),
                     epochState.getCurrentEpochDescriptor(),
-                    epochState.getCurrentEpochIndex(),
-                    epochState.getCurrentSlotNumber())) {
-                log.fine("Block No: " + header.getBlockNumber() + " with hash: " + header.getHash()
-                        + " cannot be verified.");
+                    epochState.getCurrentEpochIndex())) {
                 return;
             }
 
@@ -94,7 +91,7 @@ public class BlockHandler {
                             block.getHeader(), block.getHeader().getHash().equals(blockState.bestBlockHash())),
                     excluding);
         } catch (Exception e) {
-            log.warning("Error while importing announced block: " + e.getMessage());
+            log.warning("Error while importing announced block: " + e);
         }
     }
 

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -1,14 +1,15 @@
 package com.limechain.sync.fullsync;
 
 import com.google.protobuf.ByteString;
-import com.limechain.babe.state.EpochState;
 import com.limechain.babe.BabeService;
 import com.limechain.babe.coordinator.SlotCoordinator;
+import com.limechain.babe.state.EpochState;
 import com.limechain.config.HostConfig;
 import com.limechain.exception.storage.BlockNodeNotFoundException;
 import com.limechain.exception.sync.BlockExecutionException;
 import com.limechain.network.Network;
 import com.limechain.network.PeerMessageCoordinator;
+import com.limechain.network.PeerRequester;
 import com.limechain.network.protocol.blockannounce.NodeRole;
 import com.limechain.network.protocol.sync.BlockRequestField;
 import com.limechain.network.protocol.sync.pb.SyncMessage;
@@ -16,7 +17,6 @@ import com.limechain.network.protocol.warp.dto.Block;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.network.protocol.warp.dto.DigestType;
 import com.limechain.network.protocol.warp.dto.HeaderDigest;
-import com.limechain.network.PeerRequester;
 import com.limechain.rpc.server.AppBean;
 import com.limechain.runtime.Runtime;
 import com.limechain.runtime.RuntimeBuilder;

--- a/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
+++ b/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
@@ -26,10 +26,16 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 class BlockProductionVerifierTest {
 

--- a/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
+++ b/src/test/java/com/limechain/babe/BlockProductionVerifierTest.java
@@ -1,9 +1,11 @@
 package com.limechain.babe;
 
 import com.limechain.babe.predigest.BabePreDigest;
+import com.limechain.babe.predigest.PreDigestType;
 import com.limechain.babe.state.EpochData;
 import com.limechain.babe.state.EpochDescriptor;
 import com.limechain.chain.lightsyncstate.Authority;
+import com.limechain.exception.misc.AuthorshipVerificationException;
 import com.limechain.network.protocol.warp.DigestHelper;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.network.protocol.warp.dto.DigestType;
@@ -24,8 +26,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -57,7 +58,6 @@ class BlockProductionVerifierTest {
     private final byte[] randomness = new byte[]{0x01, 0x02, 0x03};
     private final byte[] vrfOutput = new byte[]{0x06};
     private final byte[] vrfProof = new byte[]{0x07};
-    private final BigInteger slotNumber = BigInteger.TEN;
 
     @BeforeEach
     void setUp() {
@@ -65,7 +65,7 @@ class BlockProductionVerifierTest {
     }
 
     @Test
-    void testVerifyAuthorship_ValidCase() {
+    void testIsAuthorship_Valid_ValidCase() {
         try (MockedStatic<DigestHelper> mockedDigestHelper = mockStatic(DigestHelper.class);
              MockedStatic<Sr25519Utils> mockedSr25519 = mockStatic(Sr25519Utils.class);
              MockedStatic<Schnorrkel> mockedSchnorrkel = mockStatic(Schnorrkel.class);
@@ -81,7 +81,7 @@ class BlockProductionVerifierTest {
 
             HeaderDigest[] headerDigests = new HeaderDigest[]{sealDigest};
             when(blockHeader.getDigest()).thenReturn(headerDigests);
-            when(blockHeader.getHashBytes()).thenReturn(new byte[]{0x01, 0x02, 0x03});
+            when(blockHeader.getBlake2bHash(true)).thenReturn(new byte[]{0x01, 0x02, 0x03});
 
             when(sealDigest.getType()).thenReturn(DigestType.SEAL);
             when(sealDigest.getMessage()).thenReturn(new byte[]{0x04, 0x05});
@@ -89,6 +89,9 @@ class BlockProductionVerifierTest {
             mockedDigestHelper.when(() -> DigestHelper.getBabePreRuntimeDigest(headerDigests))
                     .thenReturn(Optional.of(babePreDigest));
 
+
+            when(babePreDigest.getType()).thenReturn(PreDigestType.BABE_PRIMARY);
+            when(babePreDigest.getSlotNumber()).thenReturn(BigInteger.TEN);
             when(babePreDigest.getAuthorityIndex()).thenReturn(0L);
             when(babePreDigest.getVrfOutput()).thenReturn(vrfOutput);
             when(babePreDigest.getVrfProof()).thenReturn(vrfProof);
@@ -106,7 +109,7 @@ class BlockProductionVerifierTest {
 
             mockedSr25519.when(() -> Sr25519Utils.verifySignature(any())).thenReturn(true);
 
-            boolean result = verifierSpy.verifyAuthorship(blockHeader, currentEpochData, epochDescriptor, epochIndex, slotNumber);
+            boolean result = verifierSpy.isAuthorshipValid(blockHeader, currentEpochData, epochDescriptor, epochIndex);
 
             assertTrue(result);
 
@@ -117,7 +120,7 @@ class BlockProductionVerifierTest {
     }
 
     @Test
-    void testVerifyAuthorship_NotSlotWinner() {
+    void testIsAuthorship_Valid_NotSlotWinner() {
         try (MockedStatic<DigestHelper> mockedDigestHelper = mockStatic(DigestHelper.class);
              MockedStatic<Sr25519Utils> mockedSr25519 = mockStatic(Sr25519Utils.class);
              MockedStatic<Schnorrkel> mockedSchnorrkel = mockStatic(Schnorrkel.class);
@@ -133,7 +136,7 @@ class BlockProductionVerifierTest {
 
             HeaderDigest[] headerDigests = new HeaderDigest[]{sealDigest};
             when(blockHeader.getDigest()).thenReturn(headerDigests);
-            when(blockHeader.getHashBytes()).thenReturn(new byte[]{0x01, 0x02, 0x03});
+            when(blockHeader.getBlake2bHash(false)).thenReturn(new byte[]{0x01, 0x02, 0x03});
 
             when(sealDigest.getType()).thenReturn(DigestType.SEAL);
             when(sealDigest.getMessage()).thenReturn(new byte[]{0x04, 0x05});
@@ -141,6 +144,8 @@ class BlockProductionVerifierTest {
             mockedDigestHelper.when(() -> DigestHelper.getBabePreRuntimeDigest(headerDigests))
                     .thenReturn(Optional.of(babePreDigest));
 
+            when(babePreDigest.getType()).thenReturn(PreDigestType.BABE_PRIMARY);
+            when(babePreDigest.getSlotNumber()).thenReturn(BigInteger.TEN);
             when(babePreDigest.getAuthorityIndex()).thenReturn(0L);
             when(babePreDigest.getVrfOutput()).thenReturn(vrfOutput);
             when(babePreDigest.getVrfProof()).thenReturn(vrfProof);
@@ -158,11 +163,10 @@ class BlockProductionVerifierTest {
 
             mockedSr25519.when(() -> Sr25519Utils.verifySignature(any())).thenReturn(true);
 
-            boolean result = verifierSpy.verifyAuthorship(blockHeader, currentEpochData, epochDescriptor, epochIndex, slotNumber);
+            boolean result = verifierSpy.isAuthorshipValid(blockHeader, currentEpochData, epochDescriptor, epochIndex);
 
             assertFalse(result);
 
-            mockedSr25519.verify(() -> Sr25519Utils.verifySignature(any()), times(1));
             mockedDigestHelper.verify(() -> DigestHelper.getBabePreRuntimeDigest(headerDigests), times(1));
             mockedVrfOutputAndProof.verify(() -> VrfOutputAndProof.wrap(vrfOutput, vrfProof), times(1));
         }
@@ -170,13 +174,16 @@ class BlockProductionVerifierTest {
 
 
     @Test
-    void testVerifyAuthorship_InvalidSealDigest() {
+    void testIsAuthorship_Valid_InvalidDigest() {
         HeaderDigest[] headerDigests = new HeaderDigest[]{sealDigest};
         when(blockHeader.getDigest()).thenReturn(headerDigests);
         when(sealDigest.getType()).thenReturn(DigestType.PRE_RUNTIME);
 
-        boolean result = blockProductionVerifier.verifyAuthorship(blockHeader, currentEpochData, epochDescriptor, BigInteger.ONE, BigInteger.TEN);
-        assertFalse(result);
+        assertThrows(AuthorshipVerificationException.class, () -> blockProductionVerifier.isAuthorshipValid(blockHeader,
+                currentEpochData,
+                epochDescriptor,
+                BigInteger.ONE)
+        );
     }
 }
 


### PR DESCRIPTION
# Description

The current implementation only supported verifying a primary block. This PR implements verification for primary, secondary VRF and secondary plain blocks.