### PR TITLE
680: Persist and Fetch GRANDPA Data with Refactoring from Previous Class

### DIFF
--- a/src/main/java/com/limechain/grandpa/state/RoundState.java
+++ b/src/main/java/com/limechain/grandpa/state/RoundState.java
@@ -6,6 +6,7 @@ import com.limechain.network.protocol.grandpa.messages.catchup.res.SignedVote;
 import com.limechain.network.protocol.grandpa.messages.commit.Vote;
 import com.limechain.storage.DBConstants;
 import com.limechain.storage.KVRepository;
+import com.limechain.storage.StateUtil;
 import io.libp2p.core.crypto.PubKey;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
@@ -18,10 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static com.limechain.storage.StateUtil.generateAuthorityKey;
-import static com.limechain.storage.StateUtil.generatePrecommitsKey;
-import static com.limechain.storage.StateUtil.generatePrevotesKey;
 
 /**
  * Represents the state information for the current round and authorities that are needed
@@ -76,11 +73,11 @@ public class RoundState {
     }
 
     public void saveGrandpaAuthorities() {
-        repository.save(generateAuthorityKey(DBConstants.AUTHORITY_SET, setId), authorities);
+        repository.save(StateUtil.generateAuthorityKey(DBConstants.AUTHORITY_SET, setId), authorities);
     }
 
     public Authority[] fetchGrandpaAuthorities() {
-        return repository.find(generateAuthorityKey(DBConstants.AUTHORITY_SET, setId), new Authority[0]);
+        return repository.find(StateUtil.generateAuthorityKey(DBConstants.AUTHORITY_SET, setId), new Authority[0]);
     }
 
     public void saveAuthoritySetId() {
@@ -100,20 +97,20 @@ public class RoundState {
     }
 
     public void savePrevotes() {
-        repository.save(generatePrevotesKey(DBConstants.GRANDPA_PREVOTES, roundNumber, setId), prevotes);
+        repository.save(StateUtil.generatePrevotesKey(DBConstants.GRANDPA_PREVOTES, roundNumber, setId), prevotes);
     }
 
     public Map<PubKey, Vote> fetchPrevotes() {
-        return repository.find(generatePrevotesKey(DBConstants.GRANDPA_PREVOTES, roundNumber, setId),
+        return repository.find(StateUtil.generatePrevotesKey(DBConstants.GRANDPA_PREVOTES, roundNumber, setId),
                 Collections.emptyMap());
     }
 
     public void savePrecommits() {
-        repository.save(generatePrecommitsKey(DBConstants.GRANDPA_PRECOMMITS, roundNumber, setId), precommits);
+        repository.save(StateUtil.generatePrecommitsKey(DBConstants.GRANDPA_PRECOMMITS, roundNumber, setId), precommits);
     }
 
     public Map<PubKey, Vote> fetchPrecommits() {
-        return repository.find(generatePrecommitsKey(DBConstants.GRANDPA_PRECOMMITS, roundNumber, setId),
+        return repository.find(StateUtil.generatePrecommitsKey(DBConstants.GRANDPA_PRECOMMITS, roundNumber, setId),
                 Collections.emptyMap());
     }
 

--- a/src/main/java/com/limechain/grandpa/state/RoundState.java
+++ b/src/main/java/com/limechain/grandpa/state/RoundState.java
@@ -11,7 +11,6 @@ import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -20,7 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.limechain.storage.StateUtil.*;
+import static com.limechain.storage.StateUtil.generateAuthorityKey;
+import static com.limechain.storage.StateUtil.generatePrecommitsKey;
+import static com.limechain.storage.StateUtil.generatePrevotesKey;
 
 /**
  * Represents the state information for the current round and authorities that are needed
@@ -64,7 +65,9 @@ public class RoundState {
     }
 
     private BigInteger getAuthoritiesTotalWeight() {
-        return authorities.stream().map(Authority::getWeight).reduce(BigInteger.ZERO, BigInteger::add);
+        return authorities.stream()
+                .map(Authority::getWeight)
+                .reduce(BigInteger.ZERO, BigInteger::add);
     }
 
     public BigInteger derivePrimary() {
@@ -76,7 +79,7 @@ public class RoundState {
         repository.save(generateAuthorityKey(DBConstants.AUTHORITY_SET, setId), authorities);
     }
 
-    public Authority[] fetchGrandpaVoters() {
+    public Authority[] fetchGrandpaAuthorities() {
         return repository.find(generateAuthorityKey(DBConstants.AUTHORITY_SET, setId), new Authority[0]);
     }
 
@@ -92,7 +95,7 @@ public class RoundState {
         repository.save(DBConstants.LATEST_ROUND, roundNumber);
     }
 
-    public BigInteger fetchLatestRoundNumber() {
+    public BigInteger fetchLatestRound() {
         return repository.find(DBConstants.LATEST_ROUND, BigInteger.ONE);
     }
 
@@ -115,9 +118,9 @@ public class RoundState {
     }
 
     private void loadPersistedState() {
-        this.authorities = Arrays.asList(fetchGrandpaVoters());
+        this.authorities = Arrays.asList(fetchGrandpaAuthorities());
         this.setId = fetchAuthoritiesSetId();
-        this.roundNumber = fetchLatestRoundNumber();
+        this.roundNumber = fetchLatestRound();
         this.precommits = fetchPrecommits();
         this.prevotes = fetchPrevotes();
     }
@@ -130,7 +133,7 @@ public class RoundState {
         savePrevotes();
     }
 
-    public BigInteger incrementAuthoritiesSetId() {
+    public BigInteger incrementSetId() {
         this.setId = setId.add(BigInteger.ONE);
         return setId;
     }

--- a/src/main/java/com/limechain/grandpa/state/RoundState.java
+++ b/src/main/java/com/limechain/grandpa/state/RoundState.java
@@ -73,7 +73,6 @@ public class RoundState {
         return roundNumber.remainder(authoritiesCount);
     }
 
-
     public void saveGrandpaAuthorities() {
         repository.save(generateAuthorityKey(DBConstants.AUTHORITY_SET, setId), authorities);
     }
@@ -131,7 +130,6 @@ public class RoundState {
         savePrecommits();
         savePrevotes();
     }
-
 
     public BigInteger incrementAuthoritiesSetId() {
         this.setId = setId.add(BigInteger.ONE);

--- a/src/main/java/com/limechain/grandpa/state/RoundState.java
+++ b/src/main/java/com/limechain/grandpa/state/RoundState.java
@@ -29,7 +29,6 @@ import static com.limechain.storage.StateUtil.*;
  */
 @Getter
 @Setter //TODO: remove it when initialize() method is implemented
-@Component
 @RequiredArgsConstructor
 public class RoundState {
 

--- a/src/main/java/com/limechain/grandpa/state/RoundState.java
+++ b/src/main/java/com/limechain/grandpa/state/RoundState.java
@@ -3,15 +3,21 @@ package com.limechain.grandpa.state;
 import com.limechain.chain.lightsyncstate.Authority;
 import com.limechain.network.protocol.grandpa.messages.catchup.res.SignedVote;
 import com.limechain.network.protocol.grandpa.messages.commit.Vote;
+import com.limechain.storage.DBConstants;
+import com.limechain.storage.KVRepository;
 import io.libp2p.core.crypto.PubKey;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static com.limechain.storage.StateUtil.*;
 
 /**
  * Represents the state information for the current round and authorities that are needed
@@ -21,9 +27,11 @@ import java.util.concurrent.ConcurrentHashMap;
 @Getter
 @Setter //TODO: remove it when initialize() method is implemented
 @Component
+@RequiredArgsConstructor
 public class RoundState {
 
     private static final BigInteger THRESHOLD_DENOMINATOR = BigInteger.valueOf(3);
+    private final KVRepository<String, Object> repository;
 
     private List<Authority> voters;
     private BigInteger setId;
@@ -48,13 +56,55 @@ public class RoundState {
     }
 
     private BigInteger getAuthoritiesTotalWeight() {
-        return voters.stream()
-                .map(Authority::getWeight)
-                .reduce(BigInteger.ZERO, BigInteger::add);
+        return voters.stream().map(Authority::getWeight).reduce(BigInteger.ZERO, BigInteger::add);
     }
 
     public BigInteger derivePrimary() {
         var votersCount = BigInteger.valueOf(voters.size());
         return roundNumber.remainder(votersCount);
     }
+
+
+    public void saveGrandpaVoters() {
+        repository.save(generateAuthorityKey(DBConstants.AUTHORITY_SET, setId), voters);
+    }
+
+    public Authority[] fetchGrandpaVoters() {
+        return repository.find(generateAuthorityKey(DBConstants.AUTHORITY_SET, setId), new Authority[0]);
+    }
+
+    public void saveAuthoritySetId() {
+        repository.save(DBConstants.SET_ID, setId);
+    }
+
+    public BigInteger fetchAuthoritiesSetId() {
+        return repository.find(DBConstants.SET_ID, BigInteger.ONE);
+    }
+
+    public void saveLatestRound() {
+        repository.save(DBConstants.LATEST_ROUND, roundNumber);
+    }
+
+    public BigInteger fetchLatestRound() {
+        return repository.find(DBConstants.LATEST_ROUND, BigInteger.ONE);
+    }
+
+    public void savePrevotes() {
+        repository.save(generatePrevotesKey(DBConstants.GRANDPA_PREVOTES, roundNumber, setId), prevotes);
+    }
+
+    public List<Map<PubKey, Vote>> fetchPrevotes() {
+        return repository.find(generatePrevotesKey(DBConstants.GRANDPA_PREVOTES, roundNumber, setId),
+                Collections.emptyList());
+    }
+
+    public void savePrecommits() {
+        repository.save(generatePrecommitsKey(DBConstants.GRANDPA_PRECOMMITS, roundNumber, setId), precommits);
+    }
+
+    public List<Map<PubKey, Vote>> fetchPrecommits() {
+        return repository.find(generatePrecommitsKey(DBConstants.GRANDPA_PRECOMMITS, roundNumber, setId),
+                Collections.emptyList());
+    }
+
 }

--- a/src/main/java/com/limechain/network/protocol/message/ProtocolMessageBuilder.java
+++ b/src/main/java/com/limechain/network/protocol/message/ProtocolMessageBuilder.java
@@ -1,5 +1,6 @@
 package com.limechain.network.protocol.message;
 
+import com.limechain.grandpa.state.RoundState;
 import com.limechain.network.protocol.blockannounce.messages.BlockAnnounceMessage;
 import com.limechain.network.protocol.grandpa.messages.neighbour.NeighbourMessage;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
@@ -13,11 +14,12 @@ public class ProtocolMessageBuilder {
 
     public NeighbourMessage buildNeighbourMessage() {
         SyncState syncState = AppBean.getBean(SyncState.class);
+        RoundState roundState = AppBean.getBean(RoundState.class);
 
         return new NeighbourMessage(
                 NEIGHBOUR_MESSAGE_VERSION,
-                syncState.getLatestRound(),
-                syncState.getSetId(),
+                roundState.getRoundNumber(),
+                roundState.getSetId(),
                 syncState.getLastFinalizedBlockNumber()
         );
     }

--- a/src/main/java/com/limechain/rpc/config/CommonConfig.java
+++ b/src/main/java/com/limechain/rpc/config/CommonConfig.java
@@ -7,6 +7,7 @@ import com.limechain.cli.CliArguments;
 import com.limechain.config.HostConfig;
 import com.limechain.config.SystemInfo;
 import com.limechain.constants.GenesisBlockHash;
+import com.limechain.grandpa.state.RoundState;
 import com.limechain.network.Network;
 import com.limechain.network.PeerMessageCoordinator;
 import com.limechain.network.PeerRequester;
@@ -87,18 +88,24 @@ public class CommonConfig {
     }
 
     @Bean
+    public RoundState roundState(KVRepository<String, Object> repository) {
+        return new RoundState(repository);
+    }
+
+    @Bean
     public WarpSyncState warpSyncState(SyncState syncState,
+                                       RoundState roundState,
                                        KVRepository<String, Object> repository,
                                        RuntimeBuilder runtimeBuilder,
                                        PeerRequester requester,
                                        PeerMessageCoordinator messageCoordinator) {
-        return new WarpSyncState(syncState, repository, runtimeBuilder, requester, messageCoordinator);
+        return new WarpSyncState(syncState, repository, runtimeBuilder, requester, messageCoordinator, roundState);
     }
 
     @Bean
     public WarpSyncMachine warpSyncMachine(Network network, ChainService chainService, SyncState syncState,
-                                           WarpSyncState warpSyncState) {
-        return new WarpSyncMachine(network, chainService, syncState, warpSyncState);
+                                           WarpSyncState warpSyncState, RoundState roundState) {
+        return new WarpSyncMachine(network, chainService, syncState, warpSyncState, roundState);
     }
 
     @Bean

--- a/src/main/java/com/limechain/storage/DBConstants.java
+++ b/src/main/java/com/limechain/storage/DBConstants.java
@@ -6,8 +6,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DBConstants {
     /**
-    * Key for storing the privateKey for nabu
-    *  */
+     * Key for storing the privateKey for nabu
+     */
     public static final String PEER_ID = "nodePeerId";
     /**
      * Key under which the genesis chain spec is stored
@@ -29,12 +29,16 @@ public class DBConstants {
      */
     public static final String HIGHEST_ROUND_AND_SET_ID_KEY = "hrs";
 
+
     // SyncState keys
     public static final String LAST_FINALIZED_BLOCK_NUMBER = "ss::lastFinalizedBlockNumber";
     public static final String LAST_FINALIZED_BLOCK_HASH = "ss::lastFinalizedBlockHash";
-    public static final String AUTHORITY_SET = "ss::authoritySet";
-    public static final String LATEST_ROUND = "ss::latestRound";
     public static final String STATE_ROOT = "ss::stateRoot";
-    public static final String SET_ID = "ss::setId";
-    // SyncState keys
+
+    // GrandpaState keys
+    public static final String AUTHORITY_SET = "gs::authoritySet";
+    public static final String LATEST_ROUND = "gs::latestRound";
+    public static final String SET_ID = "gs::setId";
+    public static final String GRANDPA_PREVOTES = "gs:grandpaPrevotes";
+    public static final String GRANDPA_PRECOMMITS = "gs:grandpaPrecommits";
 }

--- a/src/main/java/com/limechain/storage/DBConstants.java
+++ b/src/main/java/com/limechain/storage/DBConstants.java
@@ -29,7 +29,6 @@ public class DBConstants {
      */
     public static final String HIGHEST_ROUND_AND_SET_ID_KEY = "hrs";
 
-
     // SyncState keys
     public static final String LAST_FINALIZED_BLOCK_NUMBER = "ss::lastFinalizedBlockNumber";
     public static final String LAST_FINALIZED_BLOCK_HASH = "ss::lastFinalizedBlockHash";

--- a/src/main/java/com/limechain/storage/DBRepository.java
+++ b/src/main/java/com/limechain/storage/DBRepository.java
@@ -127,6 +127,12 @@ public class DBRepository implements KVRepository<String, Object> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public <T> T find(String key, T defaultValue) {
+        return (T) find(key).orElse(defaultValue);
+    }
+
+    @Override
     public synchronized List<byte[]> findKeysByPrefix(String prefixSeek, int limit) {
         return findByPrefix(prefixSeek, (long) limit)
             .stream()

--- a/src/main/java/com/limechain/storage/KVRepository.java
+++ b/src/main/java/com/limechain/storage/KVRepository.java
@@ -35,6 +35,17 @@ public interface KVRepository<K, V> {
      */
     Optional<V> find(K key);
 
+
+    /**
+     * Generic method to fetch a value from the repository with a default fallback if no result is being found.
+     *
+     * @param key          The key to fetch from the repository.
+     * @param defaultValue The default value to return if the key is not found.
+     * @param <T>          The type of the value being fetched.
+     * @return The fetched value or the default if not present.
+     */
+    <T> T find(String key, T defaultValue);
+
     /**
      * Deletes a key-value pair from the DB
      *

--- a/src/main/java/com/limechain/storage/StateUtil.java
+++ b/src/main/java/com/limechain/storage/StateUtil.java
@@ -1,11 +1,11 @@
 package com.limechain.storage;
 
-import lombok.NoArgsConstructor;
+import lombok.experimental.UtilityClass;
 
 import java.math.BigInteger;
 
-@NoArgsConstructor
-public final class StateUtil {
+@UtilityClass
+public class StateUtil {
 
     /**
      * Prepares a concatenated key by appending all suffixes to the base key.

--- a/src/main/java/com/limechain/storage/StateUtil.java
+++ b/src/main/java/com/limechain/storage/StateUtil.java
@@ -16,7 +16,7 @@ public class StateUtil {
      * @param suffixes additional parts to be appended to the key.
      * @return the concatenated key as a single {String}.
      */
-    private static String prepareKey(String key, String... suffixes) {
+    private String prepareKey(String key, String... suffixes) {
         StringBuilder sb = new StringBuilder(key);
         for (String suffix : suffixes) {
             sb.append(suffix);
@@ -25,15 +25,15 @@ public class StateUtil {
         return sb.toString();
     }
 
-    public static String generateAuthorityKey(String authorityKey, BigInteger setId) {
+    public String generateAuthorityKey(String authorityKey, BigInteger setId) {
         return prepareKey(authorityKey, setId.toString());
     }
 
-    public static String generatePrevotesKey(String grandpaPrevotes, BigInteger roundNumber, BigInteger setId) {
+    public String generatePrevotesKey(String grandpaPrevotes, BigInteger roundNumber, BigInteger setId) {
         return prepareKey(grandpaPrevotes, roundNumber.toString(), setId.toString());
     }
 
-    public static String generatePrecommitsKey(String precommitsKey, BigInteger roundNumber, BigInteger setId) {
+    public String generatePrecommitsKey(String precommitsKey, BigInteger roundNumber, BigInteger setId) {
         return prepareKey(precommitsKey, roundNumber.toString(), setId.toString());
     }
 

--- a/src/main/java/com/limechain/storage/StateUtil.java
+++ b/src/main/java/com/limechain/storage/StateUtil.java
@@ -1,0 +1,40 @@
+package com.limechain.storage;
+
+import lombok.NoArgsConstructor;
+
+import java.math.BigInteger;
+
+@NoArgsConstructor
+public final class StateUtil {
+
+    /**
+     * Prepares a concatenated key by appending all suffixes to the base key.
+     * This method builds a key string by appending the provided suffixes sequentially
+     * to the base key using a {StringBuilder}.
+     *
+     * @param key      the base(main) part of the key.
+     * @param suffixes additional parts to be appended to the key.
+     * @return the concatenated key as a single {String}.
+     */
+    private static String prepareKey(String key, String... suffixes) {
+        StringBuilder sb = new StringBuilder(key);
+        for (String suffix : suffixes) {
+            sb.append(suffix);
+        }
+
+        return sb.toString();
+    }
+
+    public static String generateAuthorityKey(String authorityKey, BigInteger setId) {
+        return prepareKey(authorityKey, setId.toString());
+    }
+
+    public static String generatePrevotesKey(String grandpaPrevotes, BigInteger roundNumber, BigInteger setId) {
+        return prepareKey(grandpaPrevotes, roundNumber.toString(), setId.toString());
+    }
+
+    public static String generatePrecommitsKey(String precommitsKey, BigInteger roundNumber, BigInteger setId) {
+        return prepareKey(precommitsKey, roundNumber.toString(), setId.toString());
+    }
+
+}

--- a/src/main/java/com/limechain/storage/block/SyncState.java
+++ b/src/main/java/com/limechain/storage/block/SyncState.java
@@ -27,11 +27,7 @@ public class SyncState {
     private final BigInteger startingBlock;
     private final Hash256 genesisBlockHash;
     private Hash256 lastFinalizedBlockHash;
-    @Setter
-    private Authority[] authoritySet;
-    private BigInteger latestRound;
     private Hash256 stateRoot;
-    private BigInteger setId;
 
     public SyncState(GenesisBlockHash genesisBlockHashCalculator, KVRepository<String, Object> repository) {
         this.genesisBlockHashCalculator = genesisBlockHashCalculator;
@@ -46,21 +42,15 @@ public class SyncState {
         this.lastFinalizedBlockNumber = repository.find(DBConstants.LAST_FINALIZED_BLOCK_NUMBER, BigInteger.ZERO);
         this.lastFinalizedBlockHash = new Hash256(
                 repository.find(DBConstants.LAST_FINALIZED_BLOCK_HASH, genesisBlockHash.getBytes()));
- //       this.authoritySet = (Authority[]) repository.find(DBConstants.AUTHORITY_SET).orElse(new Authority[0]);
- //       this.latestRound = (BigInteger) repository.find(DBConstants.LATEST_ROUND).orElse(BigInteger.ONE);
         byte[] stateRootBytes = repository.find(DBConstants.STATE_ROOT, null);
         this.stateRoot = stateRootBytes != null ? new Hash256(stateRootBytes) : genesisBlockHashCalculator
                 .getGenesisBlockHeader().getStateRoot();
- //       this.setId = (BigInteger) repository.find(DBConstants.SET_ID).orElse(BigInteger.ZERO);
     }
 
     public void persistState() {
         repository.save(DBConstants.LAST_FINALIZED_BLOCK_NUMBER, lastFinalizedBlockNumber);
         repository.save(DBConstants.LAST_FINALIZED_BLOCK_HASH, lastFinalizedBlockHash.getBytes());
-        repository.save(DBConstants.AUTHORITY_SET, authoritySet);
-        repository.save(DBConstants.LATEST_ROUND, latestRound);
         repository.save(DBConstants.STATE_ROOT, stateRoot.getBytes());
-        repository.save(DBConstants.SET_ID, setId);
     }
 
     public void finalizeHeader(BlockHeader header) {
@@ -97,18 +87,7 @@ public class SyncState {
         return true;
     }
 
-    public BigInteger incrementSetId() {
-        this.setId = this.setId.add(BigInteger.ONE);
-        return setId;
-    }
-
-    public void resetRound() {
-        this.latestRound = BigInteger.ONE;
-    }
-
     public void setLightSyncState(LightSyncState initState) {
-        this.setId = initState.getGrandpaAuthoritySet().getSetId();
-        setAuthoritySet(initState.getGrandpaAuthoritySet().getCurrentAuthorities());
         finalizeHeader(initState.getFinalizedBlockHeader());
     }
 

--- a/src/main/java/com/limechain/storage/block/SyncState.java
+++ b/src/main/java/com/limechain/storage/block/SyncState.java
@@ -43,16 +43,15 @@ public class SyncState {
     }
 
     private void loadPersistedState() {
-        this.lastFinalizedBlockNumber =
-                (BigInteger) repository.find(DBConstants.LAST_FINALIZED_BLOCK_NUMBER).orElse(BigInteger.ZERO);
+        this.lastFinalizedBlockNumber = repository.find(DBConstants.LAST_FINALIZED_BLOCK_NUMBER, BigInteger.ZERO);
         this.lastFinalizedBlockHash = new Hash256(
-                (byte[]) repository.find(DBConstants.LAST_FINALIZED_BLOCK_HASH).orElse(genesisBlockHash.getBytes()));
-        this.authoritySet = (Authority[]) repository.find(DBConstants.AUTHORITY_SET).orElse(new Authority[0]);
-        this.latestRound = (BigInteger) repository.find(DBConstants.LATEST_ROUND).orElse(BigInteger.ONE);
-        byte[] stateRootBytes = (byte[]) repository.find(DBConstants.STATE_ROOT).orElse(null);
+                repository.find(DBConstants.LAST_FINALIZED_BLOCK_HASH, genesisBlockHash.getBytes()));
+ //       this.authoritySet = (Authority[]) repository.find(DBConstants.AUTHORITY_SET).orElse(new Authority[0]);
+ //       this.latestRound = (BigInteger) repository.find(DBConstants.LATEST_ROUND).orElse(BigInteger.ONE);
+        byte[] stateRootBytes = repository.find(DBConstants.STATE_ROOT, null);
         this.stateRoot = stateRootBytes != null ? new Hash256(stateRootBytes) : genesisBlockHashCalculator
                 .getGenesisBlockHeader().getStateRoot();
-        this.setId = (BigInteger) repository.find(DBConstants.SET_ID).orElse(BigInteger.ZERO);
+ //       this.setId = (BigInteger) repository.find(DBConstants.SET_ID).orElse(BigInteger.ZERO);
     }
 
     public void persistState() {

--- a/src/main/java/com/limechain/sync/JustificationVerifier.java
+++ b/src/main/java/com/limechain/sync/JustificationVerifier.java
@@ -1,6 +1,7 @@
 package com.limechain.sync;
 
 import com.limechain.chain.lightsyncstate.Authority;
+import com.limechain.grandpa.state.RoundState;
 import com.limechain.network.protocol.warp.dto.Precommit;
 import com.limechain.rpc.server.AppBean;
 import com.limechain.runtime.hostapi.dto.Key;
@@ -27,9 +28,9 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JustificationVerifier {
     public static boolean verify(Precommit[] precommits, BigInteger round) {
-        SyncState syncState = AppBean.getBean(SyncState.class);
-        Authority[] authorities = syncState.getAuthoritySet();
-        BigInteger authoritiesSetId = syncState.getSetId();
+        RoundState roundState = AppBean.getBean(RoundState.class);
+        Authority[] authorities = roundState.getAuthorities().toArray(new Authority[0]);
+        BigInteger authoritiesSetId = roundState.getSetId();
 
         // Implementation from: https://github.com/smol-dot/smoldot
         // lib/src/finality/justification/verify.rs

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
@@ -18,7 +18,11 @@ import lombok.extern.java.Log;
 import org.javatuples.Pair;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
@@ -18,11 +18,7 @@ import lombok.extern.java.Log;
 import org.javatuples.Pair;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.PriorityQueue;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -44,7 +40,11 @@ public class WarpSyncMachine {
     private final RoundState roundState;
     private final List<Runnable> onFinishCallbacks;
 
-    public WarpSyncMachine(Network network, ChainService chainService, SyncState syncState, WarpSyncState warpSyncState, RoundState roundState) {
+    public WarpSyncMachine(Network network,
+                           ChainService chainService,
+                           SyncState syncState,
+                           WarpSyncState warpSyncState,
+                           RoundState roundState) {
         this.networkService = network;
         this.chainService = chainService;
         this.syncState = syncState;
@@ -72,7 +72,7 @@ public class WarpSyncMachine {
         if (this.chainService.getChainSpec().getLightSyncState() != null) {
             LightSyncState initState = LightSyncState.decode(this.chainService.getChainSpec().getLightSyncState());
             if (this.syncState.getLastFinalizedBlockNumber()
-                        .compareTo(initState.getFinalizedBlockHeader().getBlockNumber()) < 0) {
+                    .compareTo(initState.getFinalizedBlockHeader().getBlockNumber()) < 0) {
                 this.syncState.setLightSyncState(initState);
                 this.roundState.setLightSyncState(initState);
             }

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
@@ -87,7 +87,8 @@ public class WarpSyncState {
                          PeerRequester requester,
                          PeerMessageCoordinator messageCoordinator,
                          RoundState roundState) {
-        this(syncState, roundState,
+        this(syncState,
+                roundState,
                 db,
                 runtimeBuilder,
                 new HashSet<>(),
@@ -312,7 +313,7 @@ public class WarpSyncState {
         boolean updated = false;
         while (data != null) {
             if (data.getValue0().compareTo(syncState.getLastFinalizedBlockNumber()) < 1) {
-                authoritiesSetId = roundState.incrementAuthoritiesSetId();
+                authoritiesSetId = roundState.incrementSetId();
                 roundState.resetRound();
                 roundState.setAuthorities(Arrays.asList(data.getValue1()));
                 scheduledAuthorityChanges.poll();

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
@@ -85,7 +85,8 @@ public class WarpSyncState {
                          KVRepository<String, Object> db,
                          RuntimeBuilder runtimeBuilder,
                          PeerRequester requester,
-                         PeerMessageCoordinator messageCoordinator, RoundState roundState) {
+                         PeerMessageCoordinator messageCoordinator,
+                         RoundState roundState) {
         this(syncState, roundState,
                 db,
                 runtimeBuilder,

--- a/src/test/java/com/limechain/grandpa/state/RoundStateTest.java
+++ b/src/test/java/com/limechain/grandpa/state/RoundStateTest.java
@@ -31,7 +31,7 @@ class RoundStateTest {
         Authority authority9 = new Authority(Ed25519Utils.generateKeyPair().publicKey().bytes(), BigInteger.ONE);
         Authority authority10 = new Authority(Ed25519Utils.generateKeyPair().publicKey().bytes(), BigInteger.ONE);
 
-        roundState.setVoters(
+        roundState.setAuthorities(
                 List.of(
                         authority1, authority2, authority3, authority4, authority5,
                         authority6, authority7, authority8, authority9, authority10
@@ -50,7 +50,7 @@ class RoundStateTest {
         Authority authority2 = new Authority(Ed25519Utils.generateKeyPair().publicKey().bytes(), BigInteger.ONE);
         Authority authority3 = new Authority(Ed25519Utils.generateKeyPair().publicKey().bytes(), BigInteger.ONE);
 
-        roundState.setVoters(List.of(
+        roundState.setAuthorities(List.of(
                 authority1, authority2, authority3
         ));
 

--- a/src/test/java/com/limechain/sync/fullsync/InMemoryDB.java
+++ b/src/test/java/com/limechain/sync/fullsync/InMemoryDB.java
@@ -31,6 +31,12 @@ class InMemoryDB implements KVRepository<String, Object> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public <T> T find(String key, T defaultValue) {
+        return (T) find(key).orElse(defaultValue);
+    }
+
+    @Override
     public boolean delete(String key) {
         storage.remove(key);
         return true;


### PR DESCRIPTION
### Description

- Added new methods to persist and fetch GRANDPA-related data in the database.
- Refactored the code to eliminate duplicate data by moving relevant fields from SyncState to RoundState (Grandpa state).
- Refactored WarpSyncMachine.java and WarpSyncState.java to accommodate these changes.

**P.S. As part of my task, I conducted research to identify where these persisting and fetching methods are utilized in the current implementation and explored potential use cases for them in upcoming tasks.**

**Hereby, I place what I have found:**
Method: saveAuthorities()
Should be seen in:
* func newGrandpaStateFromGenesis()
* func applyScheduledChanges()
* func applyForcedChanges()
* func setNextChange()

Method: loadAuthorities()
Should be seen in:
* func updateAuthorities(): Updates the GRANDPA voter set, increments the setID, and resets the round numbers.
* func verifyBlockJustification(): Verifies the finality justification for a block and returns the SCALE-encoded justification with any extra bytes removed.

Method: saveCurrentSetID()
Should be seen in:
* func newGrandpaStateFromGenesis(): Returns a new GrandpaState given the GRANDPA genesis authorities.
* func incrementSetID(): Increments the set ID.
* func rewind(): Rewinds the chain to the given block number. If the number of blocks exceeds the chain height, it rewinds to genesis.

Method: loadCurrentSetID()
Should be seen in:
* func applyForcedChanges(): Checks for scheduled forced changes relative to the imported block and applies them (or does nothing if none are found).
* func setNextChange(): Sets the next authority change at the given block number (the last block in the current set, not part of the next set).
* func incrementSetID(): Increments the set ID.
* func getSetIDByBlockNumber(): Returns the set ID for a given block number.
* func rewind(): Rewinds the chain to the given block number. If the number of blocks exceeds the chain height, it rewinds to genesis.
* func newService(): Returns a new GRANDPA Service instance.
* func updateAuthorities(): Updates the GRANDPA voter set, increments the setID, and resets the round numbers.
* func reportEquivocation(): Handles equivocation reports.

Method: saveLatestRound()
Should be seen in:
* func newGrandpaStateFromGenesis(): Returns a new GrandpaState given the GRANDPA genesis authorities.
* func initiateRound(): Initiates a new round in GRANDPA.
* func finalise(): Finalizes the round by setting the best final candidate for this round.

Method: loadLatestRound()
Should be seen in:
* func newService(): Returns a new GRANDPA Service instance.
* func reportEquivocation(): Handles equivocation reports.

Method: savePrevotes()
Should be seen in:
* func finalise(): Finalizes the round by setting the best final candidate for this round.
* func handleCatchUpResponse(): Handles responses during the catch-up process.

Method: loadPrevotes()
Should be seen in:
* func newCatchUpResponse(): Handles the creation of a new catch-up response.

Method: savePrecommits()
Should be seen in:
* func finalise(): Finalizes the round.
* func handleCommitMessage(): Processes commit messages in GRANDPA.
* func handleCatchUpResponse(): Handles responses during the catch-up process.

Method: loadPrecommits()
Should be seen in:
* func newCommitMessage(): Handles the creation of a new commit message.
* func newCatchUpResponse(): Handles the creation of a new catch-up response.

Fixes #680