### PR TITLE
Disable Authoriry

### DIFF
--- a/src/main/java/com/limechain/babe/consensus/BabeConsensusMessage.java
+++ b/src/main/java/com/limechain/babe/consensus/BabeConsensusMessage.java
@@ -4,10 +4,12 @@ import com.limechain.babe.state.EpochData;
 import com.limechain.babe.state.EpochDescriptor;
 import lombok.Data;
 
+import java.math.BigInteger;
+
 @Data
 public class BabeConsensusMessage {
     private EpochData nextEpochData;
-    private long disabledAuthority;
+    private BigInteger disabledAuthority;
     private EpochDescriptor nextEpochDescriptor;
     private BabeConsensusMessageFormat format;
 }

--- a/src/main/java/com/limechain/babe/consensus/scale/BabeConsensusMessageReader.java
+++ b/src/main/java/com/limechain/babe/consensus/scale/BabeConsensusMessageReader.java
@@ -25,19 +25,28 @@ public class BabeConsensusMessageReader implements ScaleReader<BabeConsensusMess
         BabeConsensusMessage babeConsensusMessage = new BabeConsensusMessage();
         BabeConsensusMessageFormat format = BabeConsensusMessageFormat.fromFormat(reader.readByte());
         babeConsensusMessage.setFormat(format);
+
         switch (format) {
             case NEXT_EPOCH_DATA -> {
                 List<Authority> authorities = reader.read(new ListReader<>(new AuthorityReader()));
                 byte[] randomness = reader.readUint256();
                 babeConsensusMessage.setNextEpochData(new EpochData(authorities, randomness));
             }
-            case DISABLED_AUTHORITY -> babeConsensusMessage.setDisabledAuthority(reader.readUint32());
+
+            case DISABLED_AUTHORITY ->
+                    babeConsensusMessage.setDisabledAuthority(BigInteger.valueOf(reader.readUint32()));
+
             case NEXT_EPOCH_DESCRIPTOR -> {
-                Pair<BigInteger, BigInteger> constant = new PairReader<>(new UInt64Reader(), new UInt64Reader()).read(reader);
-                BabeEpoch.BabeAllowedSlots secondarySlot = new EnumReader<>(BabeEpoch.BabeAllowedSlots.values()).read(reader);
+                Pair<BigInteger, BigInteger> constant = new PairReader<>(new UInt64Reader(), new UInt64Reader())
+                        .read(reader);
+
+                BabeEpoch.BabeAllowedSlots secondarySlot = new EnumReader<>(BabeEpoch.BabeAllowedSlots.values())
+                        .read(reader);
+
                 babeConsensusMessage.setNextEpochDescriptor(new EpochDescriptor(constant, secondarySlot));
             }
         }
+
         return babeConsensusMessage;
     }
 }

--- a/src/main/java/com/limechain/babe/state/EpochState.java
+++ b/src/main/java/com/limechain/babe/state/EpochState.java
@@ -19,7 +19,7 @@ public class EpochState {
 
     private boolean isInitialized = false;
 
-    private long disabledAuthority;
+    private BigInteger disabledAuthority;
     private BigInteger slotDuration;
     private BigInteger epochLength;
     private BigInteger genesisSlotNumber;

--- a/src/main/java/com/limechain/grandpa/state/RoundState.java
+++ b/src/main/java/com/limechain/grandpa/state/RoundState.java
@@ -41,6 +41,7 @@ public class RoundState {
     private final KVRepository<String, Object> repository;
 
     private List<Authority> authorities;
+    private BigInteger disabledAuthority;
     private BigInteger setId;
     private BigInteger roundNumber;
 
@@ -190,7 +191,7 @@ public class RoundState {
             ));
             //TODO: Implement later
             case GRANDPA_ON_DISABLED -> {
-                log.log(Level.SEVERE, "'ON DISABLED' grandpa message not implemented");
+                disabledAuthority = consensusMessage.getDisabledAuthority();
             }
             case GRANDPA_PAUSE -> {
                 log.log(Level.SEVERE, "'PAUSE' grandpa message not implemented");

--- a/src/test/java/com/limechain/network/protocol/warp/DigestHelperTest.java
+++ b/src/test/java/com/limechain/network/protocol/warp/DigestHelperTest.java
@@ -42,7 +42,7 @@ class DigestHelperTest {
 
         var result = optResult.get();
         assertEquals(BabeConsensusMessageFormat.DISABLED_AUTHORITY, result.getFormat());
-        assertEquals(0, result.getDisabledAuthority());
+        assertEquals(BigInteger.ZERO, result.getDisabledAuthority());
         assertNull(result.getNextEpochData());
         assertNull(result.getNextEpochDescriptor());
     }


### PR DESCRIPTION
# Description

- The responsibility for handling disabled authorities and restricting them from block production or voting, lies within the runtime, not in the host implementation.
- Disabling authorities should not affect threshold calculations or any other computations related to authorities and their weights, as the disabled authorities remain part of the validator set.
- In the past, some blocks were produced by disabled authorities before runtime handling was properly implemented. However, this is no longer the case, as the runtime now handles this scenario.
- Information source: https://app.element.io/#/room/#polkadot-implementers:web3.foundation/$5bXTpPOld-h93QVOZhBVsVzdGcQR5ZyAWu3Di0QsJVU

- Conclusion: The runtime ensures that disabled authorities cannot participate in consensus processes.
- Our responsibility is only to receive and store ```disabled authority``` value



Fixes: https://github.com/LimeChain/Fruzhin/issues/405