### PR TITLE
399 Attempt to finalize at round

### DIFF
--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -54,7 +54,7 @@ public class GrandpaService {
             BlockHeader header = blockState.getHeader(bestFinalCandidate.getBlockHash());
             blockState.setFinalizedHash(header, grandpaRound.getRoundNumber(), grandpaSetState.getSetId());
 
-            if (grandpaSetState.isCommitMessageInArchive(bestFinalCandidate)) {
+            if (!grandpaSetState.isCommitMessageInArchive(bestFinalCandidate)) {
                 //TODO: broadcast
             }
         }

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -48,10 +48,7 @@ public class GrandpaService {
         long totalVoters = grandpaSetState.getAuthorities().size();
         long threshold = (2 * totalVoters) / 3;
 
-        // L - last finalized block
-        // E - best final candidate
-        // The spec defines E >= L, but here E > L ensures E is new and not already received.
-        if (bestFinalCandidate.getBlockNumber().compareTo(lastFinalizedBlockNumber) > 0 &&
+        if (bestFinalCandidate.getBlockNumber().compareTo(lastFinalizedBlockNumber) >= 0 &&
                 bestFinalCandidateVotesCount > threshold) {
 
             BlockHeader header = blockState.getHeader(bestFinalCandidate.getBlockHash());

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -54,7 +54,9 @@ public class GrandpaService {
             BlockHeader header = blockState.getHeader(bestFinalCandidate.getBlockHash());
             blockState.setFinalizedHash(header, grandpaRound.getRoundNumber(), grandpaSetState.getSetId());
 
-            //TODO: broadcast
+            if (grandpaSetState.isCommitMessageInArchive(bestFinalCandidate)) {
+                //TODO: broadcast
+            }
         }
     }
 

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -265,7 +265,6 @@ public class GrandpaService {
         return currentVote;
     }
 
-
     /**
      * Selects the block with the most votes from the provided map of blocks.
      * If multiple blocks have the same number of votes, it returns the one with the highest block number.
@@ -485,7 +484,7 @@ public class GrandpaService {
      * 1. As the primary validator, broadcasting a commit message for the best candidate block of the previous round.
      * 2. During attempt-to-finalize, broadcasting a commit message for the best candidate block of the current round.
      */
-    public void broadcastCommitMessage(GrandpaRound grandpaRound) {
+    private void broadcastCommitMessage(GrandpaRound grandpaRound) {
         Vote bestCandidate = findBestFinalCandidate(grandpaRound);
         PreCommit[] precommits = transformToCompactJustificationFormat(grandpaRound.getPreCommits());
 

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -76,8 +76,6 @@ public class GrandpaService {
             return false;
         }
 
-        grandpaRound.setPreVotedBlock(preVoteCandidate);
-
         if (!isCompletable(grandpaRound)) {
             return false;
         }
@@ -86,8 +84,6 @@ public class GrandpaService {
         if (bestFinalCandidate == null) {
             return false;
         }
-
-        grandpaRound.setBestFinalCandidate(bestFinalCandidate);
 
         var prevGrandpaRound = grandpaRound.getPrevious();
         if (prevGrandpaRound == null) {
@@ -201,6 +197,8 @@ public class GrandpaService {
             }
         }
 
+        grandpaRound.setBestFinalCandidate(bestFinalCandidate);
+
         return bestFinalCandidate;
     }
 
@@ -224,7 +222,10 @@ public class GrandpaService {
             throw new GhostExecutionException("GHOST not found");
         }
 
-        return selectBlockWithMostVotes(blocks);
+        Vote grandpaGhost = selectBlockWithMostVotes(blocks);
+        grandpaRound.setPreVotedBlock(grandpaGhost);
+
+        return grandpaGhost;
     }
 
     /**

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -35,9 +35,6 @@ public class GrandpaService {
         BigInteger lastFinalizedBlockNumber = blockState.getHighestFinalizedNumber();
 
         Vote bestFinalCandidate = grandpaRound.getBestFinalCandidate();
-        if (bestFinalCandidate == null) {
-            return;
-        }
 
         var bestFinalCandidateVotesCount = BigInteger.valueOf(
                 getObservedVotesForBlock(grandpaRound, bestFinalCandidate.getBlockHash(), Subround.PRECOMMIT)
@@ -67,7 +64,7 @@ public class GrandpaService {
      */
     private boolean isFinalizable(GrandpaRound grandpaRound) {
 
-        Vote preVoteCandidate = getGrandpaGhost(grandpaRound);
+        Vote preVoteCandidate = findGrandpaGhost(grandpaRound);
         if (preVoteCandidate == null) {
             return false;
         }
@@ -76,7 +73,7 @@ public class GrandpaService {
             return false;
         }
 
-        Vote bestFinalCandidate = getBestFinalCandidate(grandpaRound);
+        Vote bestFinalCandidate = findBestFinalCandidate(grandpaRound);
         if (bestFinalCandidate == null) {
             return false;
         }
@@ -150,9 +147,9 @@ public class GrandpaService {
      *
      * @return the best final candidate block
      */
-    public Vote getBestFinalCandidate(GrandpaRound grandpaRound) {
+    public Vote findBestFinalCandidate(GrandpaRound grandpaRound) {
 
-        Vote preVoteCandidate = getGrandpaGhost(grandpaRound);
+        Vote preVoteCandidate = findGrandpaGhost(grandpaRound);
 
         if (grandpaRound.getRoundNumber().equals(BigInteger.ZERO)) {
             return preVoteCandidate;
@@ -213,7 +210,7 @@ public class GrandpaService {
      *
      * @return GRANDPA GHOST block as a vote
      */
-    public Vote getGrandpaGhost(GrandpaRound grandpaRound) {
+    public Vote findGrandpaGhost(GrandpaRound grandpaRound) {
         var threshold = grandpaSetState.getThreshold();
 
         if (grandpaRound.getRoundNumber().equals(BigInteger.ZERO)) {
@@ -241,12 +238,13 @@ public class GrandpaService {
      *
      * @return the best pre-voted block
      */
-    public Vote getBestPreVoteCandidate(GrandpaRound grandpaRound) {
+    public Vote findBestPreVoteCandidate(GrandpaRound grandpaRound) {
+
         Vote previousBestFinalCandidate = grandpaRound.getPrevious() != null
                 ? grandpaRound.getPrevious().getBestFinalCandidate()
                 : new Vote(null, BigInteger.ZERO);
-        Vote currentVote = getGrandpaGhost(grandpaRound);
 
+        Vote currentVote = findGrandpaGhost(grandpaRound);
         SignedVote primaryVote = grandpaRound.getPrimaryVote();
 
         if (primaryVote != null) {

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -217,7 +217,7 @@ public class GrandpaService {
      *
      * @return GRANDPA GHOST block as a vote
      */
-    public Vote findGrandpaGhost(GrandpaRound grandpaRound) {
+    private Vote findGrandpaGhost(GrandpaRound grandpaRound) {
         var threshold = grandpaSetState.getThreshold();
 
         if (grandpaRound.getRoundNumber().equals(BigInteger.ZERO)) {
@@ -245,7 +245,7 @@ public class GrandpaService {
      *
      * @return the best pre-voted block
      */
-    public Vote findBestPreVoteCandidate(GrandpaRound grandpaRound) {
+    private Vote findBestPreVoteCandidate(GrandpaRound grandpaRound) {
 
         Vote previousBestFinalCandidate = grandpaRound.getPrevious() != null
                 ? grandpaRound.getPrevious().getBestFinalCandidate()

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -55,7 +55,7 @@ public class GrandpaService {
             BlockHeader header = blockState.getHeader(bestFinalCandidate.getBlockHash());
             blockState.setFinalizedHash(header, grandpaRound.getRoundNumber(), grandpaSetState.getSetId());
 
-            if (!grandpaSetState.isCommitMessageInArchive(bestFinalCandidate)) {
+            if (!grandpaRound.isCommitMessageInArchive(bestFinalCandidate)) {
                 broadcastCommitMessage(grandpaRound);
             }
         }

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -154,7 +154,7 @@ public class GrandpaService {
      *
      * @return the best final candidate block
      */
-    public Vote findBestFinalCandidate(GrandpaRound grandpaRound) {
+    private Vote findBestFinalCandidate(GrandpaRound grandpaRound) {
 
         Vote preVoteCandidate = findGrandpaGhost(grandpaRound);
 

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -56,7 +56,7 @@ public class GrandpaService {
             blockState.setFinalizedHash(header, grandpaRound.getRoundNumber(), grandpaSetState.getSetId());
 
             if (!grandpaSetState.isCommitMessageInArchive(bestFinalCandidate)) {
-                //TODO: broadcast
+                broadcastCommitMessage(grandpaRound);
             }
         }
     }
@@ -486,7 +486,7 @@ public class GrandpaService {
      * 2. During attempt-to-finalize, broadcasting a commit message for the best candidate block of the current round.
      */
     public void broadcastCommitMessage(GrandpaRound grandpaRound) {
-        Vote bestCandidate = getBestFinalCandidate(grandpaRound);
+        Vote bestCandidate = findBestFinalCandidate(grandpaRound);
         PreCommit[] precommits = transformToCompactJustificationFormat(grandpaRound.getPreCommits());
 
         CommitMessage commitMessage = new CommitMessage();

--- a/src/main/java/com/limechain/grandpa/state/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaRound.java
@@ -2,6 +2,7 @@ package com.limechain.grandpa.state;
 
 import com.limechain.exception.grandpa.GrandpaGenericException;
 import com.limechain.network.protocol.grandpa.messages.catchup.res.SignedVote;
+import com.limechain.network.protocol.grandpa.messages.commit.CommitMessage;
 import com.limechain.network.protocol.grandpa.messages.commit.Vote;
 import io.emeraldpay.polkaj.types.Hash256;
 import lombok.Getter;
@@ -9,6 +10,8 @@ import lombok.Setter;
 
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,6 +33,8 @@ public class GrandpaRound implements Serializable {
     private Map<Hash256, Set<SignedVote>> pvEquivocations = new ConcurrentHashMap<>();
     private Map<Hash256, Set<SignedVote>> pcEquivocations = new ConcurrentHashMap<>();
 
+    private List<CommitMessage> commitMessagesArchive = new ArrayList<>();
+
     public Vote getPreVotedBlock() {
         if (preVotedBlock == null) throw new GrandpaGenericException("Pre-voted block has not been set");
         return preVotedBlock;
@@ -50,5 +55,14 @@ public class GrandpaRound implements Serializable {
         return this.pcEquivocations.values().stream()
                 .mapToInt(Set::size)
                 .sum();
+    }
+
+    public void addCommitMessageToArchive(CommitMessage message) {
+        commitMessagesArchive.add(message);
+    }
+
+    public boolean isCommitMessageInArchive(Vote vote) {
+        return commitMessagesArchive.stream()
+                .anyMatch(cm -> cm.getVote().equals(vote));
     }
 }

--- a/src/main/java/com/limechain/grandpa/state/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaRound.java
@@ -1,5 +1,6 @@
 package com.limechain.grandpa.state;
 
+import com.limechain.exception.grandpa.GrandpaGenericException;
 import com.limechain.network.protocol.grandpa.messages.catchup.res.SignedVote;
 import com.limechain.network.protocol.grandpa.messages.commit.Vote;
 import io.emeraldpay.polkaj.types.Hash256;
@@ -28,6 +29,16 @@ public class GrandpaRound implements Serializable {
 
     private Map<Hash256, Set<SignedVote>> pvEquivocations = new ConcurrentHashMap<>();
     private Map<Hash256, Set<SignedVote>> pcEquivocations = new ConcurrentHashMap<>();
+
+    public Vote getPreVotedBlock() {
+        if (preVotedBlock == null) throw new GrandpaGenericException("Pre-voted block has not been set");
+        return preVotedBlock;
+    }
+
+    public Vote getBestFinalCandidate() {
+        if (bestFinalCandidate == null) throw new GrandpaGenericException("Best final candidate has not been set");
+        return bestFinalCandidate;
+    }
 
     public long getPvEquivocationsCount() {
         return this.pvEquivocations.values().stream()

--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -258,6 +258,6 @@ public class GrandpaSetState {
 
     public boolean isCommitMessageInArchive(Vote vote) {
         return commitMessagesArchive.get(setId).stream()
-                .noneMatch(cm -> cm.getVote().equals(vote));
+                .anyMatch(cm -> cm.getVote().equals(vote));
     }
 }

--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -13,6 +13,8 @@ import com.limechain.rpc.server.AppBean;
 import com.limechain.storage.DBConstants;
 import com.limechain.storage.KVRepository;
 import com.limechain.storage.StateUtil;
+import com.limechain.storage.crypto.KeyStore;
+import com.limechain.storage.crypto.KeyType;
 import com.limechain.sync.warpsync.dto.AuthoritySetChange;
 import com.limechain.sync.warpsync.dto.ForcedAuthoritySetChange;
 import com.limechain.sync.warpsync.dto.ScheduledAuthoritySetChange;
@@ -50,11 +52,14 @@ public class GrandpaSetState {
     private BigInteger setId;
     private RoundCache roundCache;
 
+    private KeyStore keyStore;
+
     private final PriorityQueue<AuthoritySetChange> authoritySetChanges = new PriorityQueue<>(AuthoritySetChange.getComparator());
 
     public void initialize() {
         loadPersistedState();
         roundCache = AppBean.getBean(RoundCache.class);
+        keyStore = AppBean.getBean(KeyStore.class);
     }
 
     /**
@@ -228,6 +233,11 @@ public class GrandpaSetState {
             }
             default -> throw new GrandpaGenericException("Unknown subround: " + subround);
         }
+    }
+
+    public boolean participatesAsVoter() {
+        return authorities.stream()
+                .anyMatch(a -> keyStore.getKeyPair(KeyType.GRANDPA, a.getPublicKey()).isPresent());
     }
 
 }

--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -4,7 +4,6 @@ import com.limechain.chain.lightsyncstate.Authority;
 import com.limechain.chain.lightsyncstate.LightSyncState;
 import com.limechain.exception.grandpa.GrandpaGenericException;
 import com.limechain.network.protocol.grandpa.messages.catchup.res.SignedVote;
-import com.limechain.network.protocol.grandpa.messages.commit.CommitMessage;
 import com.limechain.network.protocol.grandpa.messages.commit.Vote;
 import com.limechain.network.protocol.grandpa.messages.consensus.GrandpaConsensusMessage;
 import com.limechain.network.protocol.grandpa.messages.vote.SignedMessage;
@@ -26,10 +25,8 @@ import lombok.Setter;
 import lombok.extern.java.Log;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;

--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -249,6 +249,8 @@ public class GrandpaSetState {
         commitMessages.add(message);
     }
 
+    // Removes commit messages two SetIds behind the current one,
+    // keeping only those received in the current and previous set.
     public void cleanCommitMessagesArchive() {
         commitMessagesArchive.remove(setId.subtract(BigInteger.TWO));
     }

--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -56,7 +56,6 @@ public class GrandpaSetState {
     private final KeyStore keyStore;
     private final KVRepository<String, Object> repository;
 
-    private final Map<BigInteger, List<CommitMessage>> commitMessagesArchive = new HashMap<>();
     private final PriorityQueue<AuthoritySetChange> authoritySetChanges =
             new PriorityQueue<>(AuthoritySetChange.getComparator());
 
@@ -153,8 +152,6 @@ public class GrandpaSetState {
         roundCache.addRound(setId, grandpaRound);
         this.authorities = authorities;
 
-        cleanCommitMessagesArchive();
-
         log.log(Level.INFO, "Successfully transitioned to authority set id: " + setId);
     }
 
@@ -241,22 +238,5 @@ public class GrandpaSetState {
     public boolean participatesAsVoter() {
         return authorities.stream()
                 .anyMatch(a -> keyStore.getKeyPair(KeyType.GRANDPA, a.getPublicKey()).isPresent());
-    }
-
-    public void addCommitMessageToArchive(CommitMessage message) {
-        commitMessagesArchive.putIfAbsent(setId, new ArrayList<>());
-        List<CommitMessage> commitMessages = commitMessagesArchive.get(setId);
-        commitMessages.add(message);
-    }
-
-    // Removes commit messages two SetIds behind the current one,
-    // keeping only those received in the current and previous set.
-    public void cleanCommitMessagesArchive() {
-        commitMessagesArchive.remove(setId.subtract(BigInteger.TWO));
-    }
-
-    public boolean isCommitMessageInArchive(Vote vote) {
-        return commitMessagesArchive.get(setId).stream()
-                .anyMatch(cm -> cm.getVote().equals(vote));
     }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -152,7 +152,10 @@ public class GrandpaEngine {
     private void handleCommitMessage(byte[] message, PeerId peerId) {
         ScaleCodecReader reader = new ScaleCodecReader(message);
         CommitMessage commitMessage = reader.read(CommitMessageScaleReader.getInstance());
-        warpSyncState.syncCommit(commitMessage, peerId);
+
+        if (!grandpaSetState.participatesAsVoter()) {
+            warpSyncState.syncCommit(commitMessage, peerId);
+        }
     }
 
     private void handleCatchupRequestMessage(byte[] message, PeerId peerId) {

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -152,10 +152,7 @@ public class GrandpaEngine {
     private void handleCommitMessage(byte[] message, PeerId peerId) {
         ScaleCodecReader reader = new ScaleCodecReader(message);
         CommitMessage commitMessage = reader.read(CommitMessageScaleReader.getInstance());
-
-        if (!grandpaSetState.participatesAsVoter()) {
-            warpSyncState.syncCommit(commitMessage, peerId);
-        }
+        warpSyncState.syncCommit(commitMessage, peerId);
     }
 
     private void handleCatchupRequestMessage(byte[] message, PeerId peerId) {

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
@@ -143,7 +143,9 @@ public class WarpSyncState {
             return;
         }
 
-        grandpaSetState.addCommitMessageToArchive(commitMessage);
+        grandpaSetState.getRoundCache()
+                .getRound(commitMessage.getSetId(), commitMessage.getRoundNumber())
+                .addCommitMessageToArchive(commitMessage);
 
         if (warpSyncFinished && !grandpaSetState.participatesAsVoter()) {
             updateState(commitMessage);

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
@@ -143,7 +143,9 @@ public class WarpSyncState {
             return;
         }
 
-        if (warpSyncFinished) {
+        grandpaSetState.addCommitMessageToArchive(commitMessage);
+
+        if (warpSyncFinished && !grandpaSetState.participatesAsVoter()) {
             updateState(commitMessage);
         }
     }

--- a/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
+++ b/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
@@ -791,7 +791,7 @@ class GrandpaServiceTest {
     }
 
     @Test
-    void testBroadcastCommitMessageWhenPrimaryValidator() {
+    void testBroadcastCommitMessageWhenPrimaryValidator() throws Exception {
         Hash256 authorityPublicKey = new Hash256(THREES_ARRAY);
         Map<Hash256, SignedVote> signedVotes = new HashMap<>();
         Vote vote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(123L));
@@ -807,7 +807,10 @@ class GrandpaServiceTest {
         when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
         when(grandpaSetState.getSetId()).thenReturn(BigInteger.valueOf(42L));
 
-        grandpaService.broadcastCommitMessage(previousRound);
+        Method method = GrandpaService.class.getDeclaredMethod("broadcastCommitMessage", GrandpaRound.class);
+        method.setAccessible(true);
+
+        method.invoke(grandpaService, previousRound);
 
         ArgumentCaptor<CommitMessage> commitMessageCaptor = ArgumentCaptor.forClass(CommitMessage.class);
         verify(peerMessageCoordinator).sendCommitMessageToPeers(commitMessageCaptor.capture());

--- a/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
+++ b/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
@@ -69,7 +69,7 @@ class GrandpaServiceTest {
     }
 
     @Test
-    void testGetBestFinalCandidateWithoutPreCommits() {
+    void testFindBestFinalCandidateWithoutPreCommits() {
         Vote firstVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
         Vote secondVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
 
@@ -94,14 +94,14 @@ class GrandpaServiceTest {
         when(blockState.isDescendantOf(firstVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(secondVote.getBlockHash(), secondVote.getBlockHash())).thenReturn(true);
 
-        Vote result = grandpaService.getBestFinalCandidate(grandpaRound);
+        Vote result = grandpaService.findBestFinalCandidate(grandpaRound);
 
         assertNotNull(result);
         assertEquals(firstVote.getBlockHash(), result.getBlockHash());
     }
 
     @Test
-    void testGetBestFinalCandidateWithPreCommitBlockNumberBiggerThatPreVoteBlockNumber() {
+    void testFindBestFinalCandidateWithPreCommitBlockNumberBiggerThatPreVoteBlockNumber() {
         Vote firstVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
         Vote secondVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(4));
         Vote thirdVote = new Vote(new Hash256(TWOS_ARRAY), BigInteger.valueOf(5));
@@ -134,14 +134,14 @@ class GrandpaServiceTest {
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), thirdVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
 
-        Vote result = grandpaService.getBestFinalCandidate(grandpaRound);
+        Vote result = grandpaService.findBestFinalCandidate(grandpaRound);
 
         assertNotNull(result);
         assertEquals(thirdVote.getBlockHash(), result.getBlockHash());
     }
 
     @Test
-    void testGetBestFinalCandidateWithPreCommitBlockNumberLessThatPreVoteBlockNumber() {
+    void testFindBestFinalCandidateWithPreCommitBlockNumberLessThatPreVoteBlockNumber() {
         Vote firstVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
         Vote secondVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(4));
         Vote thirdVote = new Vote(new Hash256(TWOS_ARRAY), BigInteger.valueOf(5));
@@ -175,26 +175,26 @@ class GrandpaServiceTest {
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), blockHeader.getHash())).thenReturn(true);
 
-        Vote result = grandpaService.getBestFinalCandidate(grandpaRound);
+        Vote result = grandpaService.findBestFinalCandidate(grandpaRound);
 
         assertNotNull(result);
         assertEquals(blockHeader.getHash(), result.getBlockHash());
     }
 
     @Test
-    void testGetBestFinalCandidateWhereRoundNumberIsZero() {
+    void testFindBestFinalCandidateWhereRoundNumberIsZero() {
         BlockHeader blockHeader = createBlockHeader();
 
         when(grandpaRound.getRoundNumber()).thenReturn(BigInteger.valueOf(0));
         when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
 
-        var result = grandpaService.getBestFinalCandidate(grandpaRound);
+        var result = grandpaService.findBestFinalCandidate(grandpaRound);
         assertEquals(blockHeader.getHash(), result.getBlockHash());
         assertEquals(blockHeader.getBlockNumber(), result.getBlockNumber());
     }
 
     @Test
-    void testGetBestPreVoteCandidate_WithSignedMessage() {
+    void testFindBestPreVoteCandidate_WithSignedMessage() {
         Vote currentVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
         Hash256 currentVoteAuthorityHash = new Hash256(ONES_ARRAY);
         SignedVote currentSignedVote = new SignedVote(currentVote, Hash512.empty(), currentVoteAuthorityHash);
@@ -225,7 +225,7 @@ class GrandpaServiceTest {
         when(signedMessage.getBlockNumber()).thenReturn(BigInteger.valueOf(4));
         when(signedMessage.getBlockHash()).thenReturn(new Hash256(TWOS_ARRAY));
 
-        Vote result = grandpaService.getBestPreVoteCandidate(grandpaRound);
+        Vote result = grandpaService.findBestPreVoteCandidate(grandpaRound);
 
 
         assertNotNull(result);
@@ -234,7 +234,7 @@ class GrandpaServiceTest {
     }
 
     @Test
-    void testGetBestPreVoteCandidate_WithoutSignedMessage() {
+    void testFindBestPreVoteCandidate_WithoutSignedMessage() {
         Vote currentVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
         Hash256 currentVoteAuthorityHash = new Hash256(ONES_ARRAY);
         SignedVote currentSignedVote = new SignedVote(currentVote, Hash512.empty(), currentVoteAuthorityHash);
@@ -257,7 +257,7 @@ class GrandpaServiceTest {
         when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
         when(blockState.isDescendantOf(currentVote.getBlockHash(), currentVote.getBlockHash())).thenReturn(true);
 
-        Vote result = grandpaService.getBestPreVoteCandidate(grandpaRound);
+        Vote result = grandpaService.findBestPreVoteCandidate(grandpaRound);
 
         assertNotNull(result);
         assertEquals(currentVote.getBlockHash(), result.getBlockHash());
@@ -265,7 +265,7 @@ class GrandpaServiceTest {
     }
 
     @Test
-    void testGetBestPreVoteCandidate_WithSignedMessageAndBlockNumberLessThanCurrentVote() {
+    void testFindBestPreVoteCandidate_WithSignedMessageAndBlockNumberLessThanCurrentVote() {
         Vote currentVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(4));
         Hash256 currentVoteAuthorityHash = new Hash256(ONES_ARRAY);
         SignedVote currentSignedVote = new SignedVote(currentVote, Hash512.empty(), currentVoteAuthorityHash);
@@ -291,7 +291,7 @@ class GrandpaServiceTest {
         when(signedMessage.getBlockNumber()).thenReturn(BigInteger.valueOf(3));
         when(signedMessage.getBlockHash()).thenReturn(new Hash256(TWOS_ARRAY));
 
-        Vote result = grandpaService.getBestPreVoteCandidate(grandpaRound);
+        Vote result = grandpaService.findBestPreVoteCandidate(grandpaRound);
 
         assertNotNull(result);
         assertEquals(currentVote.getBlockHash(), result.getBlockHash());
@@ -299,27 +299,27 @@ class GrandpaServiceTest {
     }
 
     @Test
-    void testGetGrandpaGHOSTWhereNoBlocksPassThreshold() {
+    void testFindGrandpaGHOSTWhereNoBlocksPassThreshold() {
         when(grandpaSetState.getThreshold()).thenReturn(BigInteger.valueOf(10));
         when(grandpaRound.getRoundNumber()).thenReturn(BigInteger.valueOf(1));
         when(grandpaRound.getPreVotes()).thenReturn(Map.of());
-        assertThrows(GhostExecutionException.class, () -> grandpaService.getGrandpaGhost(grandpaRound));
+        assertThrows(GhostExecutionException.class, () -> grandpaService.findGrandpaGhost(grandpaRound));
     }
 
     @Test
-    void testGetGrandpaGHOSTWhereRoundNumberIsZero() {
+    void testFindGrandpaGHOSTWhereRoundNumberIsZero() {
         BlockHeader blockHeader = createBlockHeader();
 
         when(grandpaRound.getRoundNumber()).thenReturn(BigInteger.valueOf(0));
         when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
 
-        var result = grandpaService.getGrandpaGhost(grandpaRound);
+        var result = grandpaService.findGrandpaGhost(grandpaRound);
         assertEquals(blockHeader.getHash(), result.getBlockHash());
         assertEquals(blockHeader.getBlockNumber(), result.getBlockNumber());
     }
 
     @Test
-    void testGetGrandpaGHOSTWithBlockPassingThreshold() {
+    void testFindGrandpaGHOSTWithBlockPassingThreshold() {
         Vote firstVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
         Vote secondVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
 
@@ -343,7 +343,7 @@ class GrandpaServiceTest {
         when(blockState.isDescendantOf(firstVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(secondVote.getBlockHash(), secondVote.getBlockHash())).thenReturn(true);
 
-        Vote result = grandpaService.getGrandpaGhost(grandpaRound);
+        Vote result = grandpaService.findGrandpaGhost(grandpaRound);
         assertNotNull(result);
         assertEquals(firstVote.getBlockHash(), result.getBlockHash());
     }

--- a/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
+++ b/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
@@ -254,6 +254,11 @@ class GrandpaServiceTest {
                 currentVoteAuthorityHash, currentSignedVote
         ));
 
+        Vote bfc = new Vote(new Hash256(THREES_ARRAY), BigInteger.ONE);
+        GrandpaRound previousRound = new GrandpaRound();
+        previousRound.setBestFinalCandidate(bfc);
+        when(grandpaRound.getPrevious()).thenReturn(previousRound);
+
         when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
         when(blockState.isDescendantOf(currentVote.getBlockHash(), currentVote.getBlockHash())).thenReturn(true);
 
@@ -285,6 +290,11 @@ class GrandpaServiceTest {
         when(grandpaRound.getPreVotes()).thenReturn(Map.of(
                 currentVoteAuthorityHash, currentSignedVote
         ));
+
+        Vote bfc = new Vote(new Hash256(THREES_ARRAY), BigInteger.ONE);
+        GrandpaRound previousRound = new GrandpaRound();
+        previousRound.setBestFinalCandidate(bfc);
+        when(grandpaRound.getPrevious()).thenReturn(previousRound);
 
         when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
         when(blockState.isDescendantOf(currentVote.getBlockHash(), currentVote.getBlockHash())).thenReturn(true);

--- a/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
+++ b/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
@@ -77,7 +77,7 @@ class GrandpaServiceTest {
     }
 
     @Test
-    void testFindBestFinalCandidateWithoutPreCommits() {
+    void testFindBestFinalCandidateWithoutPreCommits() throws Exception {
         Vote firstVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
         Vote secondVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
 
@@ -102,14 +102,18 @@ class GrandpaServiceTest {
         when(blockState.isDescendantOf(firstVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(secondVote.getBlockHash(), secondVote.getBlockHash())).thenReturn(true);
 
-        Vote result = grandpaService.findBestFinalCandidate(grandpaRound);
+        // Call the private method via reflection
+        Method method = GrandpaService.class.getDeclaredMethod("findBestFinalCandidate", GrandpaRound.class);
+        method.setAccessible(true);
+
+        Vote result = (Vote) method.invoke(grandpaService, grandpaRound);
 
         assertNotNull(result);
         assertEquals(firstVote.getBlockHash(), result.getBlockHash());
     }
 
     @Test
-    void testFindBestFinalCandidateWithPreCommitBlockNumberBiggerThatPreVoteBlockNumber() {
+    void testFindBestFinalCandidateWithPreCommitBlockNumberBiggerThatPreVoteBlockNumber() throws Exception {
         Vote firstVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
         Vote secondVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(4));
         Vote thirdVote = new Vote(new Hash256(TWOS_ARRAY), BigInteger.valueOf(5));
@@ -142,14 +146,19 @@ class GrandpaServiceTest {
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), thirdVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
 
-        Vote result = grandpaService.findBestFinalCandidate(grandpaRound);
+        // Call the private method via reflection
+        Method method = GrandpaService.class.getDeclaredMethod("findBestFinalCandidate", GrandpaRound.class);
+        method.setAccessible(true);
+
+        Vote result = (Vote) method.invoke(grandpaService, grandpaRound);
+
 
         assertNotNull(result);
         assertEquals(thirdVote.getBlockHash(), result.getBlockHash());
     }
 
     @Test
-    void testFindBestFinalCandidateWithPreCommitBlockNumberLessThatPreVoteBlockNumber() {
+    void testFindBestFinalCandidateWithPreCommitBlockNumberLessThatPreVoteBlockNumber() throws Exception {
         Vote firstVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(3));
         Vote secondVote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(4));
         Vote thirdVote = new Vote(new Hash256(TWOS_ARRAY), BigInteger.valueOf(5));
@@ -183,20 +192,30 @@ class GrandpaServiceTest {
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), blockHeader.getHash())).thenReturn(true);
 
-        Vote result = grandpaService.findBestFinalCandidate(grandpaRound);
+        // Call the private method via reflection
+        Method method = GrandpaService.class.getDeclaredMethod("findBestFinalCandidate", GrandpaRound.class);
+        method.setAccessible(true);
+
+        Vote result = (Vote) method.invoke(grandpaService, grandpaRound);
+
 
         assertNotNull(result);
         assertEquals(blockHeader.getHash(), result.getBlockHash());
     }
 
     @Test
-    void testFindBestFinalCandidateWhereRoundNumberIsZero() {
+    void testFindBestFinalCandidateWhereRoundNumberIsZero() throws Exception {
         BlockHeader blockHeader = createBlockHeader();
 
         when(grandpaRound.getRoundNumber()).thenReturn(BigInteger.valueOf(0));
         when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
 
-        var result = grandpaService.findBestFinalCandidate(grandpaRound);
+        // Call the private method via reflection
+        Method method = GrandpaService.class.getDeclaredMethod("findBestFinalCandidate", GrandpaRound.class);
+        method.setAccessible(true);
+
+        Vote result = (Vote) method.invoke(grandpaService, grandpaRound);
+
         assertEquals(blockHeader.getHash(), result.getBlockHash());
         assertEquals(blockHeader.getBlockNumber(), result.getBlockNumber());
     }
@@ -234,7 +253,6 @@ class GrandpaServiceTest {
         when(signedMessage.getBlockHash()).thenReturn(new Hash256(TWOS_ARRAY));
 
         Vote result = grandpaService.findBestPreVoteCandidate(grandpaRound);
-
 
         assertNotNull(result);
         assertEquals(new Hash256(TWOS_ARRAY), result.getBlockHash());


### PR DESCRIPTION
# Description

- Implement Attempt-To-Finalize-At-Round by the polkadot spec definition -> https://spec.polkadot.network/sect-finality#algo-attempt-to%E2%80%93finalize
- Rename ```getBestFinalCandidate```, ```getGrandpaGhost``` and ```getBestPreVoteCandidate``` to ```findBestFinalCandidate```, ```findGrandpaGhost``` and ```findBestPreVoteCandidate``` in the ```GrandpaService``` in order not to have different names from the ```GrandpaRound``` getters
- The ```GrandpaGhost``` and ```BestFinalCandidate``` fields of the ```GrandpaRound``` object are now being set directly in the methods ```findGrandpaGhost()``` and ```findBestFinalCandidate()```, rather than in ```isFinalizable()``` 
- Add ```commitMessagesArchive```, a map of ```SetId``` as a key, and a list of commit messages as value. On every new set start the commit messages for (setId - 2) are deleted because they will probably never be used again.
- Updating the last finalized block from commit messages is now executed only when we (as a node) aren't part of the voters set.
- Make all methods in GrandpaService private

Fixes: https://github.com/LimeChain/Fruzhin/issues/399
