### PR TITLE
feat: Implement broadcasting commit messages and added unit tests.

### DIFF
--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -229,5 +229,4 @@ public class GrandpaSetState {
             default -> throw new GrandpaGenericException("Unknown subround: " + subround);
         }
     }
-
 }

--- a/src/main/java/com/limechain/network/PeerMessageCoordinator.java
+++ b/src/main/java/com/limechain/network/PeerMessageCoordinator.java
@@ -4,6 +4,8 @@ import com.limechain.network.kad.KademliaService;
 import com.limechain.network.protocol.blockannounce.NodeRole;
 import com.limechain.network.protocol.blockannounce.messages.BlockAnnounceMessage;
 import com.limechain.network.protocol.blockannounce.scale.BlockAnnounceMessageScaleWriter;
+import com.limechain.network.protocol.grandpa.messages.commit.CommitMessage;
+import com.limechain.network.protocol.grandpa.messages.commit.CommitMessageScaleWriter;
 import com.limechain.network.protocol.transaction.scale.TransactionWriter;
 import com.limechain.transaction.dto.Extrinsic;
 import com.limechain.transaction.dto.ExtrinsicArray;
@@ -98,5 +100,14 @@ public class PeerMessageCoordinator {
 
     public void sendNeighbourMessageToPeer(PeerId peerId) {
         network.getGrandpaService().sendNeighbourMessage(network.getHost(), peerId);
+    }
+
+    public void sendCommitMessageToPeers(CommitMessage commitMessage) {
+        byte[] scaleMessage = ScaleUtils.Encode.encode(new CommitMessageScaleWriter(), commitMessage);
+        sendMessageToActivePeers(peerId -> {
+            asyncExecutor.executeAndForget(() -> network.getGrandpaService().sendCommitMessage(
+                    network.getHost(), peerId, scaleMessage
+            ));
+        });
     }
 }

--- a/src/main/java/com/limechain/network/PeerMessageCoordinator.java
+++ b/src/main/java/com/limechain/network/PeerMessageCoordinator.java
@@ -103,7 +103,7 @@ public class PeerMessageCoordinator {
     }
 
     public void sendCommitMessageToPeers(CommitMessage commitMessage) {
-        byte[] scaleMessage = ScaleUtils.Encode.encode(new CommitMessageScaleWriter(), commitMessage);
+        byte[] scaleMessage = ScaleUtils.Encode.encode(CommitMessageScaleWriter.getInstance(), commitMessage);
         sendMessageToActivePeers(peerId -> {
             asyncExecutor.executeAndForget(() -> network.getGrandpaService().sendCommitMessage(
                     network.getHost(), peerId, scaleMessage

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaController.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaController.java
@@ -26,4 +26,11 @@ public class GrandpaController {
     public void sendNeighbourMessage() {
         engine.writeNeighbourMessage(stream, stream.remotePeerId());
     }
+
+    /**
+     * Sends a commit message over the controller stream.
+     */
+    public void sendCommitMessage(byte[] encodedCommitMessage) {
+        engine.writeCommitMessage(stream, encodedCommitMessage);
+    }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -210,7 +210,7 @@ public class GrandpaEngine {
      * @param encodedCommitMessage scale encoded CommitMessage object
      */
     public void writeCommitMessage(Stream stream, byte[] encodedCommitMessage) {
-        log.log(Level.FINE, "Sending neighbour message to peer " + stream.remotePeerId());
+        log.log(Level.FINE, "Sending commit message to peer " + stream.remotePeerId());
         stream.writeAndFlush(encodedCommitMessage);
     }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -1,6 +1,7 @@
 package com.limechain.network.protocol.grandpa;
 
 import com.limechain.exception.scale.ScaleEncodingException;
+import com.limechain.grandpa.GrandpaService;
 import com.limechain.grandpa.state.GrandpaSetState;
 import com.limechain.network.ConnectionManager;
 import com.limechain.network.protocol.blockannounce.messages.BlockAnnounceHandshakeBuilder;
@@ -200,5 +201,16 @@ public class GrandpaEngine {
 
         log.log(Level.FINE, "Sending neighbour message to peer " + peerId);
         stream.writeAndFlush(buf.toByteArray());
+    }
+
+    /**
+     * Send our GRANDPA commit message from {@link GrandpaService} on a given <b>responder</b> stream.
+     *
+     * @param stream               <b>responder</b> stream to write the message to
+     * @param encodedCommitMessage scale encoded CommitMessage object
+     */
+    public void writeCommitMessage(Stream stream, byte[] encodedCommitMessage) {
+        log.log(Level.FINE, "Sending neighbour message to peer " + stream.remotePeerId());
+        stream.writeAndFlush(encodedCommitMessage);
     }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaService.java
@@ -37,6 +37,23 @@ public class GrandpaService extends NetworkService<Grandpa> {
                 );
     }
 
+    /**
+     * Sends a commit message to a peer. If there is no initiator stream opened with the peer,
+     * sends a handshake instead.
+     *
+     * @param us                   our host object
+     * @param peerId               message receiver
+     * @param encodedCommitMessage scale encoded representation of the CommitMessage object
+     */
+    public void sendCommitMessage(Host us, PeerId peerId, byte[] encodedCommitMessage) {
+        Optional.ofNullable(connectionManager.getPeerInfo(peerId))
+                .map(p -> p.getGrandpaStreams().getInitiator())
+                .ifPresentOrElse(
+                        stream -> new GrandpaController(stream).sendCommitMessage(encodedCommitMessage),
+                        () -> sendHandshake(us, peerId)
+                );
+    }
+
     private void sendNeighbourMessage(Stream stream) {
         GrandpaController controller = new GrandpaController(stream);
         controller.sendNeighbourMessage();

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/commit/CommitMessageScaleWriter.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/commit/CommitMessageScaleWriter.java
@@ -13,7 +13,7 @@ public class CommitMessageScaleWriter implements ScaleWriter<CommitMessage> {
     private final VoteScaleWriter voteScaleWriter;
     private final CompactJustificationScaleWriter compactJustificationScaleWriter;
 
-    private CommitMessageScaleWriter() {
+    public CommitMessageScaleWriter() {
         uint64Writer = new UInt64Writer();
         voteScaleWriter = VoteScaleWriter.getInstance();
         compactJustificationScaleWriter = CompactJustificationScaleWriter.getInstance();

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/commit/CommitMessageScaleWriter.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/commit/CommitMessageScaleWriter.java
@@ -13,7 +13,7 @@ public class CommitMessageScaleWriter implements ScaleWriter<CommitMessage> {
     private final VoteScaleWriter voteScaleWriter;
     private final CompactJustificationScaleWriter compactJustificationScaleWriter;
 
-    public CommitMessageScaleWriter() {
+    private CommitMessageScaleWriter() {
         uint64Writer = new UInt64Writer();
         voteScaleWriter = VoteScaleWriter.getInstance();
         compactJustificationScaleWriter = CompactJustificationScaleWriter.getInstance();

--- a/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
+++ b/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
@@ -20,9 +20,9 @@ import io.emeraldpay.polkaj.types.Hash256;
 import io.emeraldpay.polkaj.types.Hash512;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -37,12 +37,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
-@Disabled
 class GrandpaServiceTest {
 
     private static final byte[] ZEROS_ARRAY = new byte[32];
@@ -733,7 +732,7 @@ class GrandpaServiceTest {
     }
 
     @Test
-    void testPrimaryBroadcastCommitMessage() {
+    void testBroadcastCommitMessageWhenPrimaryValidator() {
         Hash256 authorityPublicKey = new Hash256(THREES_ARRAY);
         Map<Hash256, SignedVote> signedVotes = new HashMap<>();
         Vote vote = new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(123L));
@@ -745,12 +744,11 @@ class GrandpaServiceTest {
         previousRound.setPreCommits(signedVotes);
         BlockHeader blockHeader = createBlockHeader();
 
-        when(grandpaRound.getPrevious()).thenReturn(previousRound);
         when(grandpaSetState.getThreshold()).thenReturn(BigInteger.ONE);
         when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
         when(grandpaSetState.getSetId()).thenReturn(BigInteger.valueOf(42L));
 
-        grandpaService.broadcastCommitMessage(grandpaRound);
+        grandpaService.broadcastCommitMessage(previousRound);
 
         ArgumentCaptor<CommitMessage> commitMessageCaptor = ArgumentCaptor.forClass(CommitMessage.class);
         verify(peerMessageCoordinator).sendCommitMessageToPeers(commitMessageCaptor.capture());

--- a/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
+++ b/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
@@ -19,6 +19,7 @@ import com.limechain.storage.block.BlockState;
 import io.emeraldpay.polkaj.types.Hash256;
 import io.emeraldpay.polkaj.types.Hash512;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Disabled
 class GrandpaServiceTest {
 
     private static final byte[] ZEROS_ARRAY = new byte[32];
@@ -60,7 +62,7 @@ class GrandpaServiceTest {
         grandpaSetState = mock(GrandpaSetState.class);
         blockState = mock(BlockState.class);
         peerMessageCoordinator = mock(PeerMessageCoordinator.class);
-        grandpaService = new GrandpaService(grandpaSetState, blockState, peerMessageCoordinator);
+        grandpaService = new GrandpaService(grandpaSetState, peerMessageCoordinator);
         grandpaRound = mock(GrandpaRound.class);
     }
 
@@ -737,7 +739,7 @@ class GrandpaServiceTest {
         when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
         when(grandpaSetState.getSetId()).thenReturn(BigInteger.valueOf(42L));
 
-        grandpaService.primaryBroadcastCommitMessage(grandpaRound);
+        grandpaService.broadcastCommitMessage(grandpaRound);
 
         ArgumentCaptor<CommitMessage> commitMessageCaptor = ArgumentCaptor.forClass(CommitMessage.class);
         verify(peerMessageCoordinator).sendCommitMessageToPeers(commitMessageCaptor.capture());

--- a/src/test/java/com/limechain/network/protocol/grandpa/GrandpaControllerTest.java
+++ b/src/test/java/com/limechain/network/protocol/grandpa/GrandpaControllerTest.java
@@ -25,19 +25,27 @@ class GrandpaControllerTest {
 
     @BeforeEach
     void setup() {
-        when(stream.remotePeerId()).thenReturn(peerId);
         grandpaController.engine = engine;
     }
 
     @Test
     void sendHandshake() {
+        when(stream.remotePeerId()).thenReturn(peerId);
         grandpaController.sendHandshake();
         verify(engine).writeHandshakeToStream(stream, peerId);
     }
 
     @Test
     void sendNeighbourMessage() {
+        when(stream.remotePeerId()).thenReturn(peerId);
         grandpaController.sendNeighbourMessage();
         verify(engine).writeNeighbourMessage(stream, peerId);
+    }
+
+    @Test
+    void sendCommitMessage() {
+        byte[] encodedCommitMessage = {1, 0, 0, 0, 2, 0, 1, 1, 1, 1, 0, 0, 0, 1, 2, 0};
+        grandpaController.sendCommitMessage(encodedCommitMessage);
+        verify(engine).writeCommitMessage(stream, encodedCommitMessage);
     }
 }

--- a/src/test/java/com/limechain/network/protocol/grandpa/GrandpaEngineTest.java
+++ b/src/test/java/com/limechain/network/protocol/grandpa/GrandpaEngineTest.java
@@ -33,7 +33,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.math.BigInteger;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unused")
 @ExtendWith(MockitoExtension.class)
@@ -56,6 +62,9 @@ class GrandpaEngineTest {
     private final NeighbourMessage neighbourMessage =
             new NeighbourMessage(1, BigInteger.ONE, BigInteger.TWO, BigInteger.TEN);
     private final byte[] encodedNeighbourMessage
+            = new byte[]{2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0};
+
+    private final byte[] encodedCommitMessage
             = new byte[]{2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0};
 
     @Test
@@ -285,5 +294,11 @@ class GrandpaEngineTest {
 
             verify(stream).writeAndFlush(encodedNeighbourMessage);
         }
+    }
+
+    @Test
+    void writeCommitMessage() {
+        grandpaEngine.writeCommitMessage(stream, encodedCommitMessage);
+        verify(stream).writeAndFlush(encodedCommitMessage);
     }
 }

--- a/src/test/java/com/limechain/network/protocol/grandpa/GrandpaServiceTest.java
+++ b/src/test/java/com/limechain/network/protocol/grandpa/GrandpaServiceTest.java
@@ -18,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,6 +31,8 @@ class GrandpaServiceTest {
     @Mock
     private ProtocolStreams protocolStreams;
     @Mock
+    private Stream stream;
+    @Mock
     private Host host;
     @Mock
     private PeerId peerId;
@@ -39,6 +40,10 @@ class GrandpaServiceTest {
     private ConnectionManager connectionManager;
     @Mock
     private Grandpa protocol;
+    @Mock
+    private AddressBook addressBook;
+    @Mock
+    private GrandpaController grandpaController;
 
     private final byte[] encodedCommitMessage
             = new byte[]{2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0};
@@ -51,8 +56,6 @@ class GrandpaServiceTest {
 
     @Test
     void sendNeighbourMessageWhenNotConnectionShouldSendHandshake() {
-        AddressBook addressBook = mock(AddressBook.class);
-        GrandpaController grandpaController = mock(GrandpaController.class);
         when(connectionManager.getPeerInfo(peerId)).thenReturn(peerInfo);
         when(peerInfo.getGrandpaStreams()).thenReturn(protocolStreams);
         when(protocolStreams.getInitiator()).thenReturn(null);
@@ -66,9 +69,6 @@ class GrandpaServiceTest {
 
     @Test
     void sendNeighbourMessageWhenExistingConnection() {
-        PeerInfo peerInfo = mock(PeerInfo.class);
-        ProtocolStreams protocolStreams = mock(ProtocolStreams.class);
-        Stream stream = mock(Stream.class);
         when(connectionManager.getPeerInfo(peerId)).thenReturn(peerInfo);
         when(peerInfo.getGrandpaStreams()).thenReturn(protocolStreams);
         when(protocolStreams.getInitiator()).thenReturn(stream);
@@ -84,8 +84,6 @@ class GrandpaServiceTest {
 
     @Test
     void sendCommitMessageWhenNotConnectionShouldSendHandshake() {
-        AddressBook addressBook = mock(AddressBook.class);
-        GrandpaController grandpaController = mock(GrandpaController.class);
         when(connectionManager.getPeerInfo(peerId)).thenReturn(peerInfo);
         when(peerInfo.getGrandpaStreams()).thenReturn(protocolStreams);
         when(protocolStreams.getInitiator()).thenReturn(null);
@@ -99,9 +97,6 @@ class GrandpaServiceTest {
 
     @Test
     void sendCommitMessageWhenExistingConnection() {
-        PeerInfo peerInfo = mock(PeerInfo.class);
-        ProtocolStreams protocolStreams = mock(ProtocolStreams.class);
-        Stream stream = mock(Stream.class);
         when(connectionManager.getPeerInfo(peerId)).thenReturn(peerInfo);
         when(peerInfo.getGrandpaStreams()).thenReturn(protocolStreams);
         when(protocolStreams.getInitiator()).thenReturn(stream);


### PR DESCRIPTION
# Description
Implement broadcasting commit messages. The logic is being used in Play Grandpa Round when we are the primary validator in the current round. A commit message is constructed, based on the best final candidate determined from the previous round. Commit message is broadcasted to network peers.

Fixes #693 >