### PR TITLE
Refactor startNewSet method and persist Round/Set state

### DIFF
--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -55,7 +55,7 @@ public class GrandpaService {
             BlockHeader header = blockState.getHeader(bestFinalCandidate.getBlockHash());
             blockState.setFinalizedHash(header, grandpaRound.getRoundNumber(), grandpaSetState.getSetId());
 
-            // Persisting into the database when the round is finished
+            // Persisting round and set data into the database when a block is finalized
             grandpaSetState.persistState();
 
             if (!grandpaRound.isCommitMessageInArchive(bestFinalCandidate)) {

--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -156,6 +156,7 @@ public class GrandpaSetState {
         initGrandpaRound.setBestFinalCandidate(lastFinalizedBlock);
 
         roundCache.addRound(setId, initGrandpaRound);
+        // Persisting of the round happens when a block is finalized and for round ZERO we should do it manually
         persistState();
 
         GrandpaRound grandpaRound = new GrandpaRound();

--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -12,6 +12,7 @@ import com.limechain.network.protocol.grandpa.messages.vote.VoteMessage;
 import com.limechain.storage.DBConstants;
 import com.limechain.storage.KVRepository;
 import com.limechain.storage.StateUtil;
+import com.limechain.storage.block.BlockState;
 import com.limechain.storage.crypto.KeyStore;
 import com.limechain.storage.crypto.KeyType;
 import com.limechain.sync.warpsync.dto.AuthoritySetChange;
@@ -49,6 +50,7 @@ public class GrandpaSetState {
     private BigInteger disabledAuthority;
     private BigInteger setId;
 
+    private final BlockState blockState = BlockState.getInstance();
     private final RoundCache roundCache;
     private final KeyStore keyStore;
     private final KVRepository<String, Object> repository;
@@ -144,10 +146,22 @@ public class GrandpaSetState {
 
     public void startNewSet(List<Authority> authorities) {
         this.setId = setId.add(BigInteger.ONE);
-        GrandpaRound grandpaRound = new GrandpaRound();
-        grandpaRound.setRoundNumber(BigInteger.ZERO);
-        roundCache.addRound(setId, grandpaRound);
         this.authorities = authorities;
+
+        var lastFinalizedBlock = blockState.getLastFinalizedBlockAsVote();
+
+        GrandpaRound initGrandpaRound = new GrandpaRound();
+        initGrandpaRound.setRoundNumber(BigInteger.ZERO);
+        initGrandpaRound.setPreVotedBlock(lastFinalizedBlock);
+        initGrandpaRound.setBestFinalCandidate(lastFinalizedBlock);
+
+        roundCache.addRound(setId, initGrandpaRound);
+        persistState();
+
+        GrandpaRound grandpaRound = new GrandpaRound();
+        grandpaRound.setRoundNumber(BigInteger.ONE);
+
+        roundCache.addRound(setId, grandpaRound);
 
         log.log(Level.INFO, "Successfully transitioned to authority set id: " + setId);
     }

--- a/src/main/java/com/limechain/storage/block/BlockState.java
+++ b/src/main/java/com/limechain/storage/block/BlockState.java
@@ -7,6 +7,7 @@ import com.limechain.exception.storage.BlockStorageGenericException;
 import com.limechain.exception.storage.HeaderNotFoundException;
 import com.limechain.exception.storage.LowerThanRootException;
 import com.limechain.exception.storage.RoundAndSetIdNotFoundException;
+import com.limechain.network.protocol.grandpa.messages.commit.Vote;
 import com.limechain.network.protocol.warp.dto.Block;
 import com.limechain.network.protocol.warp.dto.BlockBody;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
@@ -891,6 +892,15 @@ public class BlockState {
         }
 
         return helper.bytesToRoundAndSetId(data);
+    }
+
+    public Vote getLastFinalizedBlockAsVote() {
+        var lastFinalizedBlockHeader = getHighestFinalizedHeader();
+
+        return new Vote(
+                lastFinalizedBlockHeader.getHash(),
+                lastFinalizedBlockHeader.getBlockNumber()
+        );
     }
 
     /**

--- a/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
+++ b/src/test/java/com/limechain/grandpa/GrandpaServiceTest.java
@@ -99,7 +99,8 @@ class GrandpaServiceTest {
                 secondVoteAuthorityHash, secondSignedVote
         ));
 
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
         when(blockState.isDescendantOf(firstVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(secondVote.getBlockHash(), secondVote.getBlockHash())).thenReturn(true);
 
@@ -141,7 +142,8 @@ class GrandpaServiceTest {
                 thirdVoteAuthorityHash, thirdSignedVote
         ));
 
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
         when(blockState.isDescendantOf(firstVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(secondVote.getBlockHash(), secondVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), thirdVote.getBlockHash())).thenReturn(true);
@@ -186,7 +188,8 @@ class GrandpaServiceTest {
                 thirdVoteAuthorityHash, thirdSignedVote
         ));
 
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
         when(blockState.isDescendantOf(firstVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(secondVote.getBlockHash(), secondVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(thirdVote.getBlockHash(), thirdVote.getBlockHash())).thenReturn(true);
@@ -209,7 +212,8 @@ class GrandpaServiceTest {
         BlockHeader blockHeader = createBlockHeader();
 
         when(grandpaRound.getRoundNumber()).thenReturn(BigInteger.valueOf(0));
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
 
         // Call the private method via reflection
         Method method = GrandpaService.class.getDeclaredMethod("findBestFinalCandidate", GrandpaRound.class);
@@ -247,7 +251,8 @@ class GrandpaServiceTest {
         previousRound.setBestFinalCandidate(new Vote(new Hash256(ONES_ARRAY), BigInteger.valueOf(2)));
         when(grandpaRound.getPrevious()).thenReturn(previousRound);
 
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
         when(blockState.isDescendantOf(currentVote.getBlockHash(), currentVote.getBlockHash())).thenReturn(true);
         when(voteMessage.getMessage()).thenReturn(signedMessage);
         when(signedMessage.getBlockNumber()).thenReturn(BigInteger.valueOf(4));
@@ -290,7 +295,8 @@ class GrandpaServiceTest {
         previousRound.setBestFinalCandidate(bfc);
         when(grandpaRound.getPrevious()).thenReturn(previousRound);
 
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
         when(blockState.isDescendantOf(currentVote.getBlockHash(), currentVote.getBlockHash())).thenReturn(true);
 
         // Call the private method via reflection
@@ -331,7 +337,8 @@ class GrandpaServiceTest {
         previousRound.setBestFinalCandidate(bfc);
         when(grandpaRound.getPrevious()).thenReturn(previousRound);
 
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
         when(blockState.isDescendantOf(currentVote.getBlockHash(), currentVote.getBlockHash())).thenReturn(true);
         when(signedMessage.getBlockNumber()).thenReturn(BigInteger.valueOf(3));
         when(signedMessage.getBlockHash()).thenReturn(new Hash256(TWOS_ARRAY));
@@ -368,7 +375,8 @@ class GrandpaServiceTest {
         BlockHeader blockHeader = createBlockHeader();
 
         when(grandpaRound.getRoundNumber()).thenReturn(BigInteger.valueOf(0));
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
 
         // Call the private method via reflection
         Method method = GrandpaService.class.getDeclaredMethod("findGrandpaGhost", GrandpaRound.class);
@@ -401,7 +409,8 @@ class GrandpaServiceTest {
                 secondVoteAuthorityHash, secondSignedVote
         ));
 
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
         when(blockState.isDescendantOf(firstVote.getBlockHash(), firstVote.getBlockHash())).thenReturn(true);
         when(blockState.isDescendantOf(secondVote.getBlockHash(), secondVote.getBlockHash())).thenReturn(true);
 
@@ -760,7 +769,8 @@ class GrandpaServiceTest {
         blocks.put(new Hash256(TWOS_ARRAY), BigInteger.valueOf(4));
 
         BlockHeader blockHeader = createBlockHeader();
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
 
         Method method = GrandpaService.class.getDeclaredMethod("selectBlockWithMostVotes", Map.class);
         method.setAccessible(true);
@@ -778,7 +788,8 @@ class GrandpaServiceTest {
         blocks.put(new Hash256(ONES_ARRAY), BigInteger.valueOf(0));
 
         BlockHeader blockHeader = createBlockHeader();
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
 
         Method method = GrandpaService.class.getDeclaredMethod("selectBlockWithMostVotes", Map.class);
         method.setAccessible(true);
@@ -804,7 +815,8 @@ class GrandpaServiceTest {
         BlockHeader blockHeader = createBlockHeader();
 
         when(grandpaSetState.getThreshold()).thenReturn(BigInteger.ONE);
-        when(blockState.getHighestFinalizedHeader()).thenReturn(blockHeader);
+        when(blockState.getLastFinalizedBlockAsVote())
+                .thenReturn(new Vote(blockHeader.getHash(), blockHeader.getBlockNumber()));
         when(grandpaSetState.getSetId()).thenReturn(BigInteger.valueOf(42L));
 
         Method method = GrandpaService.class.getDeclaredMethod("broadcastCommitMessage", GrandpaRound.class);


### PR DESCRIPTION
# Description

- The ```startNewSet``` method initializes a round with number 0, where ```preVotedBlock``` and ```bestFinalCandidate``` are set to the ```lastFinalizedBlock```. This round is directly persisted, followed by the creation of round 1, which acts as functional start of the GRANDPA set.
- Each other round (except the round with the number 0) is persisted when the ```attemptToFinalizeAt``` method passes all of the checks for finalizing a block.

Fixes: https://github.com/LimeChain/Fruzhin/issues/712