### PR TITLE
402 catchup request sending

### DIFF
--- a/src/main/java/com/limechain/network/PeerMessageCoordinator.java
+++ b/src/main/java/com/limechain/network/PeerMessageCoordinator.java
@@ -68,7 +68,7 @@ public class PeerMessageCoordinator {
      * those specified in the provided set. The excluded peers are typically the ones that
      * originally sent the transaction to our node.
      *
-     * @param extrinsic    the transaction data to encode and propagate to peers.
+     * @param extrinsic     the transaction data to encode and propagate to peers.
      * @param peersToIgnore a set of peer IDs that should not receive the transaction
      */
     public void sendTransactionMessageExcludingPeer(Extrinsic extrinsic, Set<PeerId> peersToIgnore) {
@@ -109,5 +109,9 @@ public class PeerMessageCoordinator {
                     network.getHost(), peerId, scaleMessage
             ));
         });
+    }
+
+    public void sendCatchUpRequestToPeer(PeerId peerId) {
+        network.getGrandpaService().sendCatchUpRequest(network.getHost(), peerId);
     }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaController.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaController.java
@@ -33,4 +33,8 @@ public class GrandpaController {
     public void sendCommitMessage(byte[] encodedCommitMessage) {
         engine.writeCommitMessage(stream, encodedCommitMessage);
     }
+
+    public void sendCatchUpRequest() {
+        engine.writeCatchUpRequest(stream, stream.remotePeerId());
+    }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaController.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaController.java
@@ -34,6 +34,9 @@ public class GrandpaController {
         engine.writeCommitMessage(stream, encodedCommitMessage);
     }
 
+    /**
+     * Sends a catch-up request message over the controller stream.
+     */
     public void sendCatchUpRequest() {
         engine.writeCatchUpRequest(stream, stream.remotePeerId());
     }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -144,8 +144,7 @@ public class GrandpaEngine {
         new Thread(() -> warpSyncState.syncNeighbourMessage(neighbourMessage, peerId)).start();
 
         // If peer has the same voter set id
-        BigInteger currentSetId = grandpaSetState.getSetId();
-        if (neighbourMessage.getSetId().equals(currentSetId)) {
+        if (neighbourMessage.getSetId().equals(grandpaSetState.getSetId())) {
             sendCatchUpRequest(neighbourMessage, peerId, stream);
         }
     }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaService.java
@@ -67,4 +67,18 @@ public class GrandpaService extends NetworkService<Grandpa> {
             log.warning("Failed to send Grandpa handshake to " + peerId);
         }
     }
+
+    public void sendCatchUpRequest(Host us, PeerId peerId) {
+        Optional.ofNullable(connectionManager.getPeerInfo(peerId))
+                .map(p -> p.getGrandpaStreams().getInitiator())
+                .ifPresentOrElse(
+                        this::sendCatchUpRequest,
+                        () -> sendHandshake(us, peerId)
+                );
+    }
+
+    private void sendCatchUpRequest(Stream stream) {
+        GrandpaController controller = new GrandpaController(stream);
+        controller.sendCatchUpRequest();
+    }
 }

--- a/src/main/java/com/limechain/network/protocol/message/ProtocolMessageBuilder.java
+++ b/src/main/java/com/limechain/network/protocol/message/ProtocolMessageBuilder.java
@@ -35,7 +35,9 @@ public class ProtocolMessageBuilder {
         );
     }
 
-    public CatchUpReqMessage buildCatchUpRequestMessage(GrandpaSetState grandpaSetState) {
+    public CatchUpReqMessage buildCatchUpRequestMessage() {
+        GrandpaSetState grandpaSetState = AppBean.getBean(GrandpaSetState.class);
+
         BigInteger setId = grandpaSetState.getSetId();
         BigInteger roundNumber = grandpaSetState.getRoundCache().getLatestRoundNumber(setId);
 

--- a/src/main/java/com/limechain/network/protocol/message/ProtocolMessageBuilder.java
+++ b/src/main/java/com/limechain/network/protocol/message/ProtocolMessageBuilder.java
@@ -2,6 +2,7 @@ package com.limechain.network.protocol.message;
 
 import com.limechain.grandpa.state.GrandpaSetState;
 import com.limechain.network.protocol.blockannounce.messages.BlockAnnounceMessage;
+import com.limechain.network.protocol.grandpa.messages.catchup.req.CatchUpReqMessage;
 import com.limechain.network.protocol.grandpa.messages.neighbour.NeighbourMessage;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.rpc.server.AppBean;
@@ -31,6 +32,16 @@ public class ProtocolMessageBuilder {
         return new BlockAnnounceMessage(
                 blockHeader,
                 isBestBlock
+        );
+    }
+
+    public CatchUpReqMessage buildCatchUpRequestMessage(GrandpaSetState grandpaSetState) {
+        BigInteger setId = grandpaSetState.getSetId();
+        BigInteger roundNumber = grandpaSetState.getRoundCache().getLatestRoundNumber(setId);
+
+        return new CatchUpReqMessage(
+                roundNumber,
+                setId
         );
     }
 }


### PR DESCRIPTION
# Description
Implemented logic for sending catchup requests.

**When sending Catch-Up Requests?**

When a neighbor message is received, the following conditions must be checked to determine whether to issue a catch-up request:
**1. Peer Node setID Validation**
       Ensure the setID of the peer node matches the setID of the current round in our node. If they do not match, ignore the 
       peer.

**2. Round Number Validation**
        **Per spec:** Check if the roundNumber of the neighbor is greater than the current roundNumber of our node.

Fixes #402 >