### PR TITLE
fix: Fix failing light sync snapshot workflow.

### DIFF
--- a/.github/workflows/update-light-snapshot.yml
+++ b/.github/workflows/update-light-snapshot.yml
@@ -39,7 +39,7 @@ jobs:
       - id: get-chain-id  # Reads the `id` field in the newly-downloaded chain spec
         run: echo "id=`jq -r .id ./chain_spec.json`" >> $GITHUB_OUTPUT
       - if: ${{ steps.get-chain-id.outputs.id == '' }}
-        uses: actions/upload-artifact@V4
+        uses: actions/upload-artifact@v4
         with:
           name: failed-response-${{ github.run_id }}
           path: |
@@ -49,7 +49,7 @@ jobs:
           output=./repo/genesis/${{ steps.get-chain-id.outputs.id }}.json
           jq --slurpfile downloaded ./chain_spec.json '.lightSyncState = $downloaded[0].lightSyncState' "$output" > "$tmp"
           mv "$tmp" "$output"
-      - uses: actions/upload-artifact@V4
+      - uses: actions/upload-artifact@v4
         with:
           name: chain-spec-${{ steps.get-chain-id.outputs.id }}
           # Note that passing `repo/**` maintains paths under `repo`. This is a bit of magic by the upload-artifact action.
@@ -66,7 +66,7 @@ jobs:
         with:
           path: repo
           ref: dev
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # Since we're not passing a name, this automatically downloads *all* artifacts
           # Unfortunately, this creates intermediary directories.

--- a/.github/workflows/update-light-snapshot.yml
+++ b/.github/workflows/update-light-snapshot.yml
@@ -39,7 +39,7 @@ jobs:
       - id: get-chain-id  # Reads the `id` field in the newly-downloaded chain spec
         run: echo "id=`jq -r .id ./chain_spec.json`" >> $GITHUB_OUTPUT
       - if: ${{ steps.get-chain-id.outputs.id == '' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@V4
         with:
           name: failed-response-${{ github.run_id }}
           path: |
@@ -49,7 +49,7 @@ jobs:
           output=./repo/genesis/${{ steps.get-chain-id.outputs.id }}.json
           jq --slurpfile downloaded ./chain_spec.json '.lightSyncState = $downloaded[0].lightSyncState' "$output" > "$tmp"
           mv "$tmp" "$output"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@V4
         with:
           name: chain-spec-${{ steps.get-chain-id.outputs.id }}
           # Note that passing `repo/**` maintains paths under `repo`. This is a bit of magic by the upload-artifact action.


### PR DESCRIPTION
# Description

Update deprecated `actions/upload-artifact` and  `actions/download-artifact` v3 actions.