### PR TITLE
733 catch up response receiving

### DIFF
--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -108,7 +108,7 @@ public class GrandpaService {
      *
      * @return if the current round is completable
      */
-    private boolean isCompletable(GrandpaRound grandpaRound) {
+    public boolean isCompletable(GrandpaRound grandpaRound) {
 
         Map<Vote, Long> votes = getDirectVotes(grandpaRound, SubRound.PRE_COMMIT);
         long votesCount = votes.values().stream()
@@ -157,7 +157,7 @@ public class GrandpaService {
      *
      * @return the best final candidate block
      */
-    private BlockHeader findBestFinalCandidate(GrandpaRound grandpaRound) {
+    public BlockHeader findBestFinalCandidate(GrandpaRound grandpaRound) {
         GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
         BlockState blockState = stateManager.getBlockState();
 

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -67,8 +67,8 @@ public class GrandpaRound implements Serializable {
     private Map<Hash256, SignedVote> preCommits = new ConcurrentHashMap<>();
     private SignedVote primaryVote;
 
-    private final Map<Hash256, Set<SignedVote>> pvEquivocations = new ConcurrentHashMap<>();
-    private final Map<Hash256, Set<SignedVote>> pcEquivocations = new ConcurrentHashMap<>();
+    private Map<Hash256, Set<SignedVote>> pvEquivocations = new ConcurrentHashMap<>();
+    private Map<Hash256, Set<SignedVote>> pcEquivocations = new ConcurrentHashMap<>();
 
     private final transient List<CommitMessage> commitMessagesArchive = new ArrayList<>();
 

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -77,8 +76,8 @@ public class GrandpaRound implements Serializable {
     private Map<Hash256, SignedVote> preCommits = new ConcurrentHashMap<>();
     private SignedVote primaryVote;
 
-    private Map<Hash256, Set<SignedVote>> pvEquivocations = new ConcurrentHashMap<>();
-    private Map<Hash256, Set<SignedVote>> pcEquivocations = new ConcurrentHashMap<>();
+    private Map<Hash256, List<SignedVote>> pvEquivocations = new ConcurrentHashMap<>();
+    private Map<Hash256, List<SignedVote>> pcEquivocations = new ConcurrentHashMap<>();
 
     private final transient List<CommitMessage> commitMessagesArchive = new ArrayList<>();
 
@@ -109,13 +108,13 @@ public class GrandpaRound implements Serializable {
 
     public long getPvEquivocationsCount() {
         return this.pvEquivocations.values().stream()
-                .mapToLong(Set::size)
+                .mapToLong(List::size)
                 .sum();
     }
 
     public long getPcEquivocationsCount() {
         return this.pcEquivocations.values().stream()
-                .mapToInt(Set::size)
+                .mapToInt(List::size)
                 .sum();
     }
 

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -175,8 +175,11 @@ public class GrandpaEngine {
     private void handleCatchupResponseMessage(byte[] message, PeerId peerId) {
         ScaleCodecReader reader = new ScaleCodecReader(message);
         CatchUpResMessage catchUpResMessage = reader.read(CatchUpResMessageScaleReader.getInstance());
-        //todo: handle catchup res message (authoring node responsibility)
         log.log(Level.INFO, "Received catch up response message from Peer " + peerId + "\n" + catchUpResMessage);
+
+        if (AbstractState.isActiveAuthority() && connectionManager.checkIfPeerIsAuthorNode(peerId)) {
+            //          grandpaMessageHandler.handleCatchUpResponse(peerId, catchUpResMessage, connectionManager::getPeerIds);
+        }
     }
 
     /**

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -178,7 +178,7 @@ public class GrandpaEngine {
         log.log(Level.INFO, "Received catch up response message from Peer " + peerId + "\n" + catchUpResMessage);
 
         if (AbstractState.isActiveAuthority() && connectionManager.checkIfPeerIsAuthorNode(peerId)) {
-            //          grandpaMessageHandler.handleCatchUpResponse(peerId, catchUpResMessage, connectionManager::getPeerIds);
+            grandpaMessageHandler.handleCatchUpResponse(peerId, catchUpResMessage, connectionManager::getPeerIds);
         }
     }
 

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -2,6 +2,7 @@ package com.limechain.network.protocol.grandpa;
 
 import com.limechain.chain.lightsyncstate.Authority;
 import com.limechain.exception.grandpa.GrandpaGenericException;
+import com.limechain.exception.sync.JustificationVerificationException;
 import com.limechain.grandpa.GrandpaService;
 import com.limechain.grandpa.round.GrandpaRound;
 import com.limechain.grandpa.round.RoundCache;
@@ -45,11 +46,18 @@ import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Log
@@ -324,113 +332,164 @@ public class GrandpaMessageHandler {
     private SignedVote[] getPreVoteJustification(GrandpaRound requestedRound) {
         BlockHeader estimate = requestedRound.getBestFinalCandidate();
         BlockState blockState = stateManager.getBlockState();
+        Hash256 estimateHash = estimate.getHash();
 
-        List<SignedVote> preVotes = requestedRound.getPreVotes().values().stream()
-                .filter(preVote ->
-                        blockState.isDescendantOf(estimate.getHash(), preVote.getVote().getBlockHash())
-                ).toList();
+        Predicate<SignedVote> isDescendant = vote ->
+                blockState.isDescendantOf(estimateHash, vote.getVote().getBlockHash());
 
-        List<SignedVote> pvEquivocations = requestedRound.getPvEquivocations().values().stream()
-                .flatMap(Set::stream)
-                .toList();
-
-        return Stream.concat(preVotes.stream(), pvEquivocations.stream()).toArray(SignedVote[]::new);
+        return Stream.concat(
+                        requestedRound.getPreVotes().values().stream(),
+                        requestedRound.getPvEquivocations().values().stream().flatMap(Set::stream)
+                )
+                .filter(isDescendant)
+                .toArray(SignedVote[]::new);
     }
 
     private SignedVote[] getPreCommitJustification(GrandpaRound requestedRound) {
         BlockHeader finalizedBlock = requestedRound.getFinalizedBlock();
-        BlockState blockState = stateManager.getBlockState();
         BigInteger totalWeight = BigInteger.ZERO;
         BigInteger threshold = stateManager.getGrandpaSetState().getThreshold();
 
         List<SignedVote> result = new ArrayList<>();
-        SignedVote[] preCommits = requestedRound.getPreCommits().values()
-                .toArray(SignedVote[]::new);
-        SignedVote[] pcEquivocations = requestedRound.getPcEquivocations().values()
-                .stream()
-                .flatMap(Set::stream)
-                .toArray(SignedVote[]::new);
 
-        for (SignedVote pcEquivocation : pcEquivocations) {
+        Stream<SignedVote> allPreCommits = Stream.concat(
+                requestedRound.getPcEquivocations().values().stream().flatMap(Set::stream),
+                requestedRound.getPreCommits().values().stream()
+        );
+
+        for (SignedVote vote : allPreCommits.toList()) {
             if (totalWeight.compareTo(threshold) >= 0)
                 break;
-            totalWeight = processVote(pcEquivocation, totalWeight, result);
+            totalWeight = validateAndProcessVote(vote, finalizedBlock, totalWeight, result);
         }
 
-        for (SignedVote preCommit : preCommits) {
-            if (totalWeight.compareTo(threshold) >= 0)
-                break;
-            if (finalizedBlock.getBlockNumber().compareTo(preCommit.getVote().getBlockNumber()) <= 0 &&
-                    blockState.isDescendantOf(finalizedBlock.getHash(), preCommit.getVote().getBlockHash())) {
-
-                totalWeight = processVote(preCommit, totalWeight, result);
-            }
-        }
         return result.toArray(SignedVote[]::new);
     }
 
+    private BigInteger validateAndProcessVote(SignedVote vote,
+                                              BlockHeader finalizedBlock,
+                                              BigInteger totalWeight,
+                                              List<SignedVote> result) {
+
+        BlockState blockState = stateManager.getBlockState();
+        if (finalizedBlock.getBlockNumber().compareTo(vote.getVote().getBlockNumber()) <= 0 &&
+                blockState.isDescendantOf(finalizedBlock.getHash(), vote.getVote().getBlockHash())) {
+
+            return processVote(vote, totalWeight, result);
+        }
+        return totalWeight;
+    }
+
     private BigInteger processVote(SignedVote vote, BigInteger totalWeight, List<SignedVote> result) {
-        Optional<BigInteger> voterWeight = getAuthorityWeight(vote.getAuthorityPublicKey());
-        if (voterWeight.isPresent() && voterWeight.get().compareTo(BigInteger.ZERO) > 0) {
-            totalWeight = totalWeight.add(voterWeight.get());
+        BigInteger voterWeight = getAuthorityWeight(vote.getAuthorityPublicKey()).orElse(BigInteger.ZERO);
+        if (voterWeight.compareTo(BigInteger.ZERO) > 0) {
+            totalWeight = totalWeight.add(voterWeight);
             result.add(vote);
         }
         return totalWeight;
     }
 
     private Optional<BigInteger> getAuthorityWeight(Hash256 authorityPublicKey) {
-        List<Authority> authorities = stateManager.getGrandpaSetState().getAuthorities();
-        return authorities.stream()
+        return stateManager.getGrandpaSetState().getAuthorities().stream()
                 .filter(authority -> new Hash256(authority.getPublicKey()).equals(authorityPublicKey))
-                .findFirst()
-                .map(Authority::getWeight);
+                .map(Authority::getWeight)
+                .findFirst();
     }
 
-//    public void handleCatchUpResponse(PeerId peerId,
-//                                      CatchUpResMessage catchUpResMessage,
-//                                      Supplier<Set<PeerId>> peerIds) {
-//
-//        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
-//        if (!peerIds.get().contains(peerId)) {
-//            throw new GrandpaGenericException("Receiving catching up response from a non-peer.");
-//        }
-//
-//        if (!catchUpResMessage.getSetId().equals(grandpaSetState.getSetId())) {
-//            throw new GrandpaGenericException("Catch up response has a different setId.");
-//        }
-//
-//        RoundCache roundCache = grandpaSetState.getRoundCache();
-//        BigInteger latestRoundNumber = roundCache.getLatestRoundNumber(grandpaSetState.getSetId());
-//        if (catchUpResMessage.getRound().compareTo(latestRoundNumber) <= 0) {
-//            throw new GrandpaGenericException("Catching up unto a round in the future.");
-//        }
-//
-//        //Todo: verify preCommits and preVotes
-//
-//        Map<Hash256, SignedVote> preVotes = Arrays.stream(catchUpResMessage.getPreVotes())
-//                .collect(Collectors.toMap(SignedVote::getAuthorityPublicKey, Function.identity()));
-//
-//        Map<Hash256, SignedVote> preCommits = Arrays.stream(catchUpResMessage.getPreCommits())
-//                .collect(Collectors.toMap(SignedVote::getAuthorityPublicKey, Function.identity()));
-//
-//        GrandpaRound grandpaRound = new GrandpaRound();
-//        grandpaRound.setRoundNumber(catchUpResMessage.getRound());
-//        grandpaRound.setPreVotes(preVotes);
-//        grandpaRound.setPreCommits(preCommits);
-//
-//        Vote preVoteCandidate = grandpaService.findGrandpaGhost(grandpaRound);
-//
-//        if (preVoteCandidate == null) {
-//            throw new GrandpaGenericException("Cannot determine a valid preVote block to catch up to.");
-//        }
-//
-//        grandpaRound.setPreVotedBlock(preVoteCandidate);
-//        grandpaRound.setPvEquivocations(new HashMap<>());
-//        grandpaRound.setPcEquivocations(new HashMap<>());
-//
-//        if (!grandpaService.isCompletable(grandpaRound)) {
-//            throw new GrandpaGenericException("Catch-up round is not completable.");
-//        }
-//
-//    }
+    /**
+     * Handles a catch-up response from a peer, validating pre-votes and pre-commits.
+     * Initializes a new round, determines the Grandpa Ghost and finalization estimate,
+     * checks round compatibility, and executes the Play-Grandpa-Round if valid.
+     *
+     * @param peerId            peer requesting catch-up message
+     * @param catchUpResMessage received catch-up response message
+     * @param peerIds           set of connected peer ids
+     */
+    public void handleCatchUpResponse(PeerId peerId,
+                                      CatchUpResMessage catchUpResMessage,
+                                      Supplier<Set<PeerId>> peerIds) {
+
+        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
+        if (!peerIds.get().contains(peerId)) {
+            throw new GrandpaGenericException("Receiving catching up response from a non-peer.");
+        }
+
+        if (!catchUpResMessage.getSetId().equals(grandpaSetState.getSetId())) {
+            throw new GrandpaGenericException("Catch up response has a different setId.");
+        }
+
+        RoundCache roundCache = grandpaSetState.getRoundCache();
+        GrandpaRound latestRound = roundCache.getLatestRound(grandpaSetState.getSetId());
+        if (catchUpResMessage.getRound().compareTo(latestRound.getRoundNumber()) <= 0) {
+            throw new GrandpaGenericException("Catching up into a round in the future.");
+        }
+
+        BlockState blockState = stateManager.getBlockState();
+        BlockHeader finalizedTarget = blockState.getHeaderByNumber(catchUpResMessage.getBlockNumber());
+        if (!finalizedTarget.getHash().equals(catchUpResMessage.getBlockHash())) {
+            throw new GrandpaGenericException("Catch up response with non-matching block hash and block number.");
+        }
+
+        GrandpaRound grandpaRound = new GrandpaRound();
+        //Todo: Maybe we should set previous block, as it is needed in the current implementation of findGhost
+        grandpaRound.setRoundNumber(catchUpResMessage.getRound());
+        grandpaRound.setLastFinalizedBlock(latestRound.getLastFinalizedBlock());
+        grandpaRound.setFinalizedBlock(finalizedTarget);
+        setPreVotesAndPvEquivocations(grandpaRound, catchUpResMessage.getPreVotes());
+        setPreCommitsAndPcEquivocations(grandpaRound, catchUpResMessage.getPreCommits());
+
+        boolean verified = JustificationVerifier.verify(Justification.fromCatchUpResMessage(catchUpResMessage));
+        if (!verified) {
+            throw new JustificationVerificationException("Justification could not be verified.");
+        }
+
+        BlockHeader bestFinalCandidate = grandpaService.findBestFinalCandidate(grandpaRound);
+        if (!bestFinalCandidate.getHash().equals(finalizedTarget.getHash())) {
+            throw new GrandpaGenericException("Unjustified Catch-up target finalization");
+        }
+
+        //Todo: Iterate over preVotes, for each check if we are at Stage::PRE_COMMIT_WAITS_FOR_PRE_VOTES
+        //      and updateGrandpaGhost if we have obtained enough preVotes. If grandpaGhost is updated,
+        //      finish the PRE_COMMIT_WAITS_FOR_PRE_VOTES stage.
+
+        //Todo: If preVotes and preCommits are valid, we updateGrandpaGhost, updateFinalizeEstimate
+        //      and attemptToFinalizeRound
+
+        //Todo: Play grandpa round for the currently created round
+    }
+
+    private void setPreVotesAndPvEquivocations(GrandpaRound grandpaRound, SignedVote[] votes) {
+        setVotesAndEquivocations(grandpaRound, votes, GrandpaRound::setPreVotes, GrandpaRound::setPvEquivocations);
+    }
+
+    private void setPreCommitsAndPcEquivocations(GrandpaRound grandpaRound, SignedVote[] votes) {
+        setVotesAndEquivocations(grandpaRound, votes, GrandpaRound::setPreCommits, GrandpaRound::setPcEquivocations);
+    }
+
+    private void setVotesAndEquivocations(GrandpaRound grandpaRound,
+                                          SignedVote[] votes,
+                                          BiConsumer<GrandpaRound, Map<Hash256, SignedVote>> setUniqueVotes,
+                                          BiConsumer<GrandpaRound, Map<Hash256, Set<SignedVote>>> setEquivocations) {
+
+        // Group votes by AuthorityPublicKey
+        Map<Hash256, List<SignedVote>> voteCount = Arrays.stream(votes)
+                .collect(Collectors.groupingBy(SignedVote::getAuthorityPublicKey));
+
+        Map<Hash256, SignedVote> uniqueVotes = new ConcurrentHashMap<>();
+        Map<Hash256, Set<SignedVote>> equivocations = new ConcurrentHashMap<>();
+
+        for (Map.Entry<Hash256, List<SignedVote>> entry : voteCount.entrySet()) {
+            List<SignedVote> voteList = entry.getValue();
+            Hash256 authorityKey = entry.getKey();
+
+            if (voteList.size() == 1) {
+                uniqueVotes.put(authorityKey, voteList.getFirst());
+            } else {
+                equivocations.put(authorityKey, new HashSet<>(voteList));
+            }
+        }
+
+        setUniqueVotes.accept(grandpaRound, uniqueVotes);
+        setEquivocations.accept(grandpaRound, equivocations);
+    }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -455,33 +455,27 @@ public class GrandpaMessageHandler {
         );
 
         for (SignedVote vote : allPreCommits.toList()) {
-            if (totalWeight.compareTo(threshold) >= 0)
-                break;
-            totalWeight = validateAndAccumulateVote(vote, finalizedBlock, totalWeight, result);
+            if (totalWeight.compareTo(threshold) >= 0) break;
+            totalWeight = increaseWeightAndAddVote(vote, finalizedBlock, totalWeight, result);
         }
 
         return result.toArray(SignedVote[]::new);
     }
 
-    private BigInteger validateAndAccumulateVote(SignedVote vote,
-                                                 BlockHeader finalizedBlock,
-                                                 BigInteger totalWeight,
-                                                 List<SignedVote> result) {
+    private BigInteger increaseWeightAndAddVote(SignedVote vote,
+                                                BlockHeader finalizedBlock,
+                                                BigInteger totalWeight,
+                                                List<SignedVote> result) {
 
         BlockState blockState = stateManager.getBlockState();
         if (finalizedBlock.getBlockNumber().compareTo(vote.getVote().getBlockNumber()) <= 0 &&
                 blockState.isDescendantOf(finalizedBlock.getHash(), vote.getVote().getBlockHash())) {
 
-            return addVoteAndIncreaseWeight(vote, totalWeight, result);
-        }
-        return totalWeight;
-    }
-
-    private BigInteger addVoteAndIncreaseWeight(SignedVote vote, BigInteger totalWeight, List<SignedVote> result) {
-        BigInteger voterWeight = getAuthorityWeight(vote.getAuthorityPublicKey()).orElse(BigInteger.ZERO);
-        if (voterWeight.compareTo(BigInteger.ZERO) > 0) {
-            totalWeight = totalWeight.add(voterWeight);
-            result.add(vote);
+            BigInteger voterWeight = getAuthorityWeight(vote.getAuthorityPublicKey()).orElse(BigInteger.ZERO);
+            if (voterWeight.compareTo(BigInteger.ZERO) > 0) {
+                totalWeight = totalWeight.add(voterWeight);
+                result.add(vote);
+            }
         }
         return totalWeight;
     }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -401,7 +401,7 @@ public class GrandpaMessageHandler {
      * Initializes a new round, determines the Grandpa Ghost and finalization estimate,
      * checks round compatibility, and executes the Play-Grandpa-Round if valid.
      *
-     * @param peerId            peer requesting catch-up message
+     * @param peerId            peer responding with catch-up message
      * @param catchUpResMessage received catch-up response message
      * @param peerIds           set of connected peer ids
      */

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -449,7 +449,7 @@ public class GrandpaMessageHandler {
         }
 
         //Todo: Iterate over preVotes, for each check if we are at Stage::PRE_COMMIT_WAITS_FOR_PRE_VOTES
-        //      and updateGrandpaGhost if we have obtained enough preVotes. If grandpaGhost is updated,
+        //      then updateGrandpaGhost if we have obtained enough preVotes. If grandpaGhost is updated,
         //      finish the PRE_COMMIT_WAITS_FOR_PRE_VOTES stage.
 
         //Todo: If preVotes and preCommits are valid, we updateGrandpaGhost, updateFinalizeEstimate

--- a/src/main/java/com/limechain/network/protocol/warp/dto/Justification.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/Justification.java
@@ -1,6 +1,7 @@
 package com.limechain.network.protocol.warp.dto;
 
 import com.limechain.grandpa.vote.SignedVote;
+import com.limechain.network.protocol.grandpa.messages.catchup.res.CatchUpResMessage;
 import com.limechain.network.protocol.grandpa.messages.commit.CommitMessage;
 import io.emeraldpay.polkaj.types.Hash256;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.Setter;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 @Setter
 @Getter
@@ -25,6 +27,20 @@ public class Justification {
         justification.setTargetHash(commitMessage.getVote().getBlockHash());
         justification.setTargetBlock(commitMessage.getVote().getBlockNumber());
         justification.setSignedVotes(commitMessage.getPreCommits());
+        return justification;
+    }
+
+    public static Justification fromCatchUpResMessage(CatchUpResMessage catchUpResMessage) {
+        SignedVote[] allVotes = Stream.concat(
+                Arrays.stream(catchUpResMessage.getPreVotes()),
+                Arrays.stream(catchUpResMessage.getPreCommits())
+        ).toArray(SignedVote[]::new);
+
+        Justification justification = new Justification();
+        justification.setRoundNumber(catchUpResMessage.getRound());
+        justification.setTargetHash(catchUpResMessage.getBlockHash());
+        justification.setTargetBlock(catchUpResMessage.getBlockNumber());
+        justification.setSignedVotes(allVotes);
         return justification;
     }
 


### PR DESCRIPTION
# Description

- Implemented handling of catch-up responses
- Made changes to the previous logic for collecting preVotes and preCommits on initiating catch-up response
- Placed "Todo" comments in handling catch-up response, describing what should be added as logic, to help those who implement play-grandpa-round and finalizing preVote stage.

Fixes #733 >