### PR TITLE
728 Implement PreCommit Stage

### DIFF
--- a/src/main/java/com/limechain/grandpa/round/CompletedStage.java
+++ b/src/main/java/com/limechain/grandpa/round/CompletedStage.java
@@ -8,7 +8,7 @@ public class CompletedStage implements StageState {
     @Override
     public void start(GrandpaRound round) {
         round.setOnFinalizeHandler(null);
-        round.getOnStageTimerHandler().shutdown();
+        round.clearOnStageTimerHandler();
         end(round);
     }
 

--- a/src/main/java/com/limechain/grandpa/round/FinalizeStage.java
+++ b/src/main/java/com/limechain/grandpa/round/FinalizeStage.java
@@ -1,13 +1,51 @@
 package com.limechain.grandpa.round;
 
+import com.limechain.exception.grandpa.GrandpaGenericException;
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import lombok.extern.java.Log;
+
+@Log
 public class FinalizeStage implements StageState {
 
     @Override
     public void start(GrandpaRound round) {
+
+        log.fine(String.format("Round %d entered the Finalize stage.", round.getRoundNumber()));
+
+        if (isRoundReadyToBeFinalized(round)) {
+            end(round);
+            return;
+        }
+
+        round.setOnFinalizeHandler(() -> {
+            if (isRoundReadyToBeFinalized(round)) {
+                end(round);
+            }
+        });
     }
 
     @Override
     public void end(GrandpaRound round) {
+        log.info(String.format("Round %d met finalization conditions and will be finalized.", round.getRoundNumber()));
+        round.setOnFinalizeHandler(null);
+        round.attemptToFinalizeAt();
+        log.fine(String.format("Round %d exits Finalize stage.", round.getRoundNumber()));
+
+        round.end();
+    }
+
+    private boolean isRoundReadyToBeFinalized(GrandpaRound round) {
+        BlockHeader finalized;
+        try {
+            finalized = round.getFinalizedBlock();
+        } catch (GrandpaGenericException e) {
+            log.warning("Finalized block not found, round cannot be finalized.");
+            return false;
+        }
+
+        BlockHeader prevBestFinalCandidate = round.getPrevBestFinalCandidate();
+
+        return prevBestFinalCandidate != null
+                && finalized.getBlockNumber().compareTo(prevBestFinalCandidate.getBlockNumber()) >= 0;
     }
 }
-

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -254,7 +254,7 @@ public class GrandpaRound {
      *
      * @return if the current round is completable
      */
-    public boolean checkIfRoundIsCompletable() {
+    public boolean checkIfCompletable() {
 
         Map<Vote, Long> votes = getDirectVotes(SubRound.PRE_COMMIT);
         long votesCount = votes.values().stream()
@@ -370,7 +370,7 @@ public class GrandpaRound {
 
         BlockHeader result = selectBlockWithMostVotes(blocks, getPrevBestFinalCandidate());
         this.grandpaGhost = result;
-        this.isCompletable = checkIfRoundIsCompletable();
+        this.isCompletable = checkIfCompletable();
 
         return result;
     }

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -182,7 +182,7 @@ public class GrandpaRound {
         return Optional.ofNullable(finalizeEstimate).orElse(lastFinalizedBlock);
     }
 
-    private void attemptToFinalizeAt() {
+    public void attemptToFinalizeAt() {
 
         BlockState blockState = stateManager.getBlockState();
         BigInteger lastFinalizedBlockNumber = blockState.getHighestFinalizedNumber();

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -350,7 +350,7 @@ public class GrandpaRound {
      *
      * @return GRANDPA GHOST block as a vote
      */
-    private BlockHeader findGrandpaGhost() {
+    public BlockHeader findGrandpaGhost() {
 
         if (roundNumber.equals(BigInteger.ZERO)) {
             return lastFinalizedBlock;

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -104,9 +104,9 @@ public class GrandpaRound {
     private Vote preCommitChoice;
 
     /**
-     * Is current round completable
+     * Updated when the Grandpa Ghost is calculated.<BR>
+     * Default value is false.
      */
-    @Nullable
     private boolean isCompletable;
 
     private Map<Hash256, SignedVote> preVotes = new ConcurrentHashMap<>();

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -657,4 +657,11 @@ public class GrandpaRound {
 
         peerMessageCoordinator.sendCommitMessageToPeers(commitMessage);
     }
+
+    public void clearOnStageTimerHandler() {
+        if (onStageTimerHandler != null && onStageTimerHandler.isShutdown()) {
+            onStageTimerHandler.shutdown();
+            onStageTimerHandler = null;
+        }
+    }
 }

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -103,6 +103,12 @@ public class GrandpaRound {
     @Nullable
     private Vote preCommitChoice;
 
+    /**
+     * Is current round completable
+     */
+    @Nullable
+    private boolean isCompletable;
+
     private Map<Hash256, SignedVote> preVotes = new ConcurrentHashMap<>();
     private Map<Hash256, SignedVote> preCommits = new ConcurrentHashMap<>();
     private Vote primaryVote;
@@ -248,7 +254,7 @@ public class GrandpaRound {
      *
      * @return if the current round is completable
      */
-    public boolean isCompletable() {
+    public boolean checkIfRoundIsCompletable() {
 
         Map<Vote, Long> votes = getDirectVotes(SubRound.PRE_COMMIT);
         long votesCount = votes.values().stream()
@@ -362,10 +368,11 @@ public class GrandpaRound {
             throw new GhostExecutionException("GHOST not found");
         }
 
-        BlockHeader grandpaGhost = selectBlockWithMostVotes(blocks, getPrevBestFinalCandidate());
-        this.grandpaGhost = grandpaGhost;
+        BlockHeader result = selectBlockWithMostVotes(blocks, getPrevBestFinalCandidate());
+        this.grandpaGhost = result;
+        this.isCompletable = checkIfRoundIsCompletable();
 
-        return grandpaGhost;
+        return result;
     }
 
     /**

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -248,7 +248,7 @@ public class GrandpaRound {
      *
      * @return if the current round is completable
      */
-    private boolean isCompletable() {
+    public boolean isCompletable() {
 
         Map<Vote, Long> votes = getDirectVotes(SubRound.PRE_COMMIT);
         long votesCount = votes.values().stream()

--- a/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
+++ b/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
@@ -38,10 +38,11 @@ public class PreCommitStage implements StageState {
         try {
 
             Vote grandpaGhost = Vote.fromBlockHeader(round.getGrandpaGhost());
+            log.fine(String.format("Round %d ended pre-commit stage.", round.getRoundNumber()));
+
             round.broadcastVoteMessage(grandpaGhost, SubRound.PRE_COMMIT);
             round.setState(new FinalizeStage());
             round.getState().start(round);
-            log.fine(String.format("Round %d ended pre-commit stage.", round.getRoundNumber()));
 
         } catch (GrandpaGenericException e) {
             log.fine(String.format("Round %d cannot end now: %s", round.getRoundNumber(), e.getMessage()));

--- a/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
+++ b/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
@@ -1,13 +1,102 @@
 package com.limechain.grandpa.round;
 
+import lombok.extern.java.Log;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Log
 public class PreCommitStage implements StageState {
 
     @Override
     public void start(GrandpaRound round) {
+        log.fine(String.format("Round %d started pre-commit stage.", round.getRoundNumber()));
+
+        long timeout = round.getStartTime().toEpochMilli() + (4 * GrandpaRound.DURATION);
+
+        round.setOnStageTimerHandler(Executors.newScheduledThreadPool(1));
+        round.getOnStageTimerHandler().scheduleAtFixedRate(() -> {
+            long currentTime = System.currentTimeMillis();
+
+            if (currentTime >= timeout || round.isCompletable()) {
+                log.info("first log msg");
+                round.getOnStageTimerHandler().shutdown();
+            }
+        }, 0, 500, TimeUnit.MILLISECONDS);
+
     }
 
     @Override
     public void end(GrandpaRound round) {
     }
+
+//    void VotingRoundImpl::startPrecommitStage() {
+//        SL_DEBUG(logger_, "Round #{}: Start precommit stage", round_number_);
+//
+//        // Continue to receive messages
+//        // until T>=Tstart + 4 * Duration or round is completable
+//
+//        // spec: Receive-Messages(
+//        //  until Bpv>=Best-Final-Candidate(r-1)
+//        //  and (Time>=Tr+4T or r is completable)
+//        // )
+//
+//        if (completable()) {
+//            SL_DEBUG(logger_, "Round #{} is already completable", round_number_);
+//            stage_ = Stage::PRECOMMIT_RUNS;
+//            endPrecommitStage();
+//            return;
+//        }
+//
+//        stage_timer_handle_ = scheduler_->scheduleWithHandle(
+//                [wself{weak_from_this()}] {
+//            if (auto self = wself.lock()) {
+//                if (self->stage_ == Stage::PRECOMMIT_RUNS) {
+//                    SL_DEBUG(self->logger_,
+//                            "Round #{}: Time of precommit stage is out",
+//                            self->round_number_);
+//                    self->endPrecommitStage();
+//                }
+//            }
+//        },
+//        toMilliseconds(duration_ * 4 - (scheduler_->now() - start_time_)));
+//
+//        on_complete_handler_ = [this] {
+//            if (stage_ == Stage::PRECOMMIT_RUNS) {
+//                SL_DEBUG(logger_, "Round #{}: Became completable", round_number_);
+//                endPrecommitStage();
+//            }
+//        };
+//
+//        stage_ = Stage::PRECOMMIT_RUNS;
+//    }
+//
+//    void VotingRoundImpl::endPrecommitStage() {
+//        if (stage_ == Stage::COMPLETED) {
+//            return;
+//        }
+//        BOOST_ASSERT(stage_ == Stage::PRECOMMIT_RUNS
+//                || stage_ == Stage::PRECOMMIT_WAITS_FOR_PREVOTES);
+//
+//        stage_timer_handle_.reset();
+//
+//        // https://github.com/paritytech/finality-grandpa/blob/8c45a664c05657f0c71057158d3ba555ba7d20de/src/voter/voting_round.rs#L630-L633
+//        if (not prevote_ghost_) {
+//            stage_ = Stage::PRECOMMIT_WAITS_FOR_PREVOTES;
+//            logger_->debug("Round #{}: Precommit waits for prevotes", round_number_);
+//            return;
+//        }
+//
+//        on_complete_handler_ = nullptr;
+//
+//        stage_ = Stage::END_PRECOMMIT;
+//
+//        SL_DEBUG(logger_, "Round #{}: End precommit stage", round_number_);
+//
+//        // Broadcast vote for precommit stage
+//        doPrecommit();
+//
+//        startWaitingStage();
+//    }
 }
 

--- a/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
+++ b/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
@@ -1,5 +1,8 @@
 package com.limechain.grandpa.round;
 
+import com.limechain.exception.grandpa.GrandpaGenericException;
+import com.limechain.grandpa.vote.SubRound;
+import com.limechain.grandpa.vote.Vote;
 import lombok.extern.java.Log;
 
 import java.util.concurrent.Executors;
@@ -12,91 +15,39 @@ public class PreCommitStage implements StageState {
     public void start(GrandpaRound round) {
         log.fine(String.format("Round %d started pre-commit stage.", round.getRoundNumber()));
 
-        long timeout = round.getStartTime().toEpochMilli() + (4 * GrandpaRound.DURATION);
+        if (round.isCompletable()) {
+            end(round);
+        }
+
+        long timeElapsed = System.currentTimeMillis() - round.getStartTime().toEpochMilli();
+        long timeRemaining = (4 * GrandpaRound.DURATION) - timeElapsed;
 
         round.setOnStageTimerHandler(Executors.newScheduledThreadPool(1));
-        round.getOnStageTimerHandler().scheduleAtFixedRate(() -> {
-            long currentTime = System.currentTimeMillis();
-
-            if (currentTime >= timeout || round.isCompletable()) {
-                log.info("first log msg");
-                round.getOnStageTimerHandler().shutdown();
-            }
-        }, 0, 500, TimeUnit.MILLISECONDS);
-
+        round.getOnStageTimerHandler().schedule(() -> {
+            log.fine(String.format("Round %d 4 * T timer triggered.", round.getRoundNumber()));
+            end(round);
+        }, timeRemaining, TimeUnit.MILLISECONDS);
     }
 
     @Override
     public void end(GrandpaRound round) {
+        log.fine(String.format("Round %d ended pre-commit stage.", round.getRoundNumber()));
+
+        if (!round.getOnStageTimerHandler().isShutdown()) {
+            round.getOnStageTimerHandler().shutdown();
+        }
+        round.setOnStageTimerHandler(null);
+
+        try {
+
+            Vote grandpaGhost = Vote.fromBlockHeader(round.getGrandpaGhost());
+            round.broadcastVoteMessage(grandpaGhost, SubRound.PRE_COMMIT);
+            round.setState(new FinalizeStage());
+            round.getState().start(round);
+            log.fine(String.format("Round %d ended start stage.", round.getRoundNumber()));
+
+        } catch (GrandpaGenericException e) {
+            log.fine(String.format("Round %d could not end now: %s", round.getRoundNumber(), e.getMessage()));
+        }
     }
-
-//    void VotingRoundImpl::startPrecommitStage() {
-//        SL_DEBUG(logger_, "Round #{}: Start precommit stage", round_number_);
-//
-//        // Continue to receive messages
-//        // until T>=Tstart + 4 * Duration or round is completable
-//
-//        // spec: Receive-Messages(
-//        //  until Bpv>=Best-Final-Candidate(r-1)
-//        //  and (Time>=Tr+4T or r is completable)
-//        // )
-//
-//        if (completable()) {
-//            SL_DEBUG(logger_, "Round #{} is already completable", round_number_);
-//            stage_ = Stage::PRECOMMIT_RUNS;
-//            endPrecommitStage();
-//            return;
-//        }
-//
-//        stage_timer_handle_ = scheduler_->scheduleWithHandle(
-//                [wself{weak_from_this()}] {
-//            if (auto self = wself.lock()) {
-//                if (self->stage_ == Stage::PRECOMMIT_RUNS) {
-//                    SL_DEBUG(self->logger_,
-//                            "Round #{}: Time of precommit stage is out",
-//                            self->round_number_);
-//                    self->endPrecommitStage();
-//                }
-//            }
-//        },
-//        toMilliseconds(duration_ * 4 - (scheduler_->now() - start_time_)));
-//
-//        on_complete_handler_ = [this] {
-//            if (stage_ == Stage::PRECOMMIT_RUNS) {
-//                SL_DEBUG(logger_, "Round #{}: Became completable", round_number_);
-//                endPrecommitStage();
-//            }
-//        };
-//
-//        stage_ = Stage::PRECOMMIT_RUNS;
-//    }
-//
-//    void VotingRoundImpl::endPrecommitStage() {
-//        if (stage_ == Stage::COMPLETED) {
-//            return;
-//        }
-//        BOOST_ASSERT(stage_ == Stage::PRECOMMIT_RUNS
-//                || stage_ == Stage::PRECOMMIT_WAITS_FOR_PREVOTES);
-//
-//        stage_timer_handle_.reset();
-//
-//        // https://github.com/paritytech/finality-grandpa/blob/8c45a664c05657f0c71057158d3ba555ba7d20de/src/voter/voting_round.rs#L630-L633
-//        if (not prevote_ghost_) {
-//            stage_ = Stage::PRECOMMIT_WAITS_FOR_PREVOTES;
-//            logger_->debug("Round #{}: Precommit waits for prevotes", round_number_);
-//            return;
-//        }
-//
-//        on_complete_handler_ = nullptr;
-//
-//        stage_ = Stage::END_PRECOMMIT;
-//
-//        SL_DEBUG(logger_, "Round #{}: End precommit stage", round_number_);
-//
-//        // Broadcast vote for precommit stage
-//        doPrecommit();
-//
-//        startWaitingStage();
-//    }
 }
-

--- a/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
+++ b/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
@@ -32,12 +32,8 @@ public class PreCommitStage implements StageState {
 
     @Override
     public void end(GrandpaRound round) {
-        log.fine(String.format("Round %d ended pre-commit stage.", round.getRoundNumber()));
 
-        if (round.getOnStageTimerHandler() != null && !round.getOnStageTimerHandler().isShutdown()) {
-            round.getOnStageTimerHandler().shutdown();
-            round.setOnStageTimerHandler(null);
-        }
+        round.clearOnStageTimerHandler();
 
         try {
 
@@ -45,7 +41,7 @@ public class PreCommitStage implements StageState {
             round.broadcastVoteMessage(grandpaGhost, SubRound.PRE_COMMIT);
             round.setState(new FinalizeStage());
             round.getState().start(round);
-            log.fine(String.format("Round %d ended start stage.", round.getRoundNumber()));
+            log.fine(String.format("Round %d ended pre-commit stage.", round.getRoundNumber()));
 
         } catch (GrandpaGenericException e) {
             log.fine(String.format("Round %d cannot end now: %s", round.getRoundNumber(), e.getMessage()));

--- a/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
+++ b/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
@@ -17,6 +17,7 @@ public class PreCommitStage implements StageState {
 
         if (round.isCompletable()) {
             end(round);
+            return;
         }
 
         long timeElapsed = System.currentTimeMillis() - round.getStartTime().toEpochMilli();
@@ -33,10 +34,10 @@ public class PreCommitStage implements StageState {
     public void end(GrandpaRound round) {
         log.fine(String.format("Round %d ended pre-commit stage.", round.getRoundNumber()));
 
-        if (!round.getOnStageTimerHandler().isShutdown()) {
+        if (round.getOnStageTimerHandler() != null && !round.getOnStageTimerHandler().isShutdown()) {
             round.getOnStageTimerHandler().shutdown();
+            round.setOnStageTimerHandler(null);
         }
-        round.setOnStageTimerHandler(null);
 
         try {
 
@@ -47,7 +48,7 @@ public class PreCommitStage implements StageState {
             log.fine(String.format("Round %d ended start stage.", round.getRoundNumber()));
 
         } catch (GrandpaGenericException e) {
-            log.fine(String.format("Round %d could not end now: %s", round.getRoundNumber(), e.getMessage()));
+            log.fine(String.format("Round %d cannot end now: %s", round.getRoundNumber(), e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
+++ b/src/main/java/com/limechain/grandpa/round/PreCommitStage.java
@@ -25,7 +25,7 @@ public class PreCommitStage implements StageState {
 
         round.setOnStageTimerHandler(Executors.newScheduledThreadPool(1));
         round.getOnStageTimerHandler().schedule(() -> {
-            log.fine(String.format("Round %d 4 * T timer triggered.", round.getRoundNumber()));
+            log.fine(String.format("Round %d timer triggered.", round.getRoundNumber()));
             end(round);
         }, timeRemaining, TimeUnit.MILLISECONDS);
     }

--- a/src/main/java/com/limechain/grandpa/round/StartStage.java
+++ b/src/main/java/com/limechain/grandpa/round/StartStage.java
@@ -34,7 +34,6 @@ public class StartStage implements StageState {
 
     @Override
     public void end(GrandpaRound round) {
-
         log.fine(String.format("Round %d ended start stage.", round.getRoundNumber()));
         round.setState(new PreVoteStage());
         round.getState().start(round);

--- a/src/main/java/com/limechain/grandpa/round/StartStage.java
+++ b/src/main/java/com/limechain/grandpa/round/StartStage.java
@@ -34,6 +34,7 @@ public class StartStage implements StageState {
 
     @Override
     public void end(GrandpaRound round) {
+
         log.fine(String.format("Round %d ended start stage.", round.getRoundNumber()));
         round.setState(new PreVoteStage());
         round.getState().start(round);


### PR DESCRIPTION
# Description

- If ```round.isCompletable() = true``` or timer ```Time >= t + 4 * T``` is expires -> end pre-commit stage
- end() method waits ```round.getGrandpaGhost()``` to have a value before proceeding to the next stage
- Once GrandpaGhost is available, a vote message is broadcast
- ```isCompleted``` field is added to ```GrandpaRound``` that is updated, when ```findGrandpaGhost``` is executed and the previous method for checking if the round is completable is renamed to ```checkIfCompletable```

Fixes https://github.com/LimeChain/Fruzhin/issues/728