### PR TITLE
Add authorities and setId copy to grandpaRound

### DIFF
--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/catchup/res/CatchUpResMessage.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/catchup/res/CatchUpResMessage.java
@@ -14,7 +14,7 @@ import java.math.BigInteger;
 @NoArgsConstructor
 @Builder
 public class CatchUpResMessage {
-    private BigInteger round;
+    private BigInteger roundNumber;
     private BigInteger setId;
     private SignedVote[] preVotes;
     private SignedVote[] preCommits;

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/catchup/res/CatchUpResMessageScaleReader.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/catchup/res/CatchUpResMessageScaleReader.java
@@ -40,7 +40,7 @@ public class CatchUpResMessageScaleReader implements ScaleReader<CatchUpResMessa
 
         CatchUpResMessage catchUpResMessage = new CatchUpResMessage();
         catchUpResMessage.setSetId(uint64Reader.read(reader));
-        catchUpResMessage.setRound(uint64Reader.read(reader));
+        catchUpResMessage.setRoundNumber(uint64Reader.read(reader));
         catchUpResMessage.setPreVotes(signedVoteListReader
                 .read(reader).toArray(SignedVote[]::new));
         catchUpResMessage.setPreCommits(signedVoteListReader

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/catchup/res/CatchUpResMessageScaleWriter.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/catchup/res/CatchUpResMessageScaleWriter.java
@@ -29,7 +29,7 @@ public class CatchUpResMessageScaleWriter implements ScaleWriter<CatchUpResMessa
     public void write(ScaleCodecWriter writer, CatchUpResMessage catchUpResMessage) throws IOException {
         writer.writeByte(GrandpaMessageType.CATCH_UP_RESPONSE.getType());
         uint64Writer.write(writer, catchUpResMessage.getSetId());
-        uint64Writer.write(writer, catchUpResMessage.getRound());
+        uint64Writer.write(writer, catchUpResMessage.getRoundNumber());
         signedVoteListWriter.write(writer, Arrays.asList(catchUpResMessage.getPreVotes()));
         signedVoteListWriter.write(writer, Arrays.asList(catchUpResMessage.getPreCommits()));
         writer.writeUint256(catchUpResMessage.getBlockHash().getBytes());

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessage.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessage.java
@@ -11,7 +11,7 @@ import java.math.BigInteger;
 @NoArgsConstructor
 public class NeighbourMessage {
     private int version;
-    private BigInteger round;
+    private BigInteger roundNumber;
     private BigInteger setId;
     private BigInteger lastFinalizedBlock;
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessageScaleReader.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessageScaleReader.java
@@ -31,7 +31,7 @@ public class NeighbourMessageScaleReader implements ScaleReader<NeighbourMessage
         }
         NeighbourMessage neighbourMessage = new NeighbourMessage();
         neighbourMessage.setVersion(reader.readByte());
-        neighbourMessage.setRound(uint64Reader.read(reader));
+        neighbourMessage.setRoundNumber(uint64Reader.read(reader));
         neighbourMessage.setSetId(uint64Reader.read(reader));
         neighbourMessage.setLastFinalizedBlock(BigInteger.valueOf(reader.readUint32()));
         return neighbourMessage;

--- a/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessageScaleWriter.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/messages/neighbour/NeighbourMessageScaleWriter.java
@@ -25,7 +25,7 @@ public class NeighbourMessageScaleWriter implements ScaleWriter<NeighbourMessage
     public void write(ScaleCodecWriter writer, NeighbourMessage neighbourMessage) throws IOException {
         writer.writeByte(GrandpaMessageType.NEIGHBOUR.getType());
         writer.writeByte(neighbourMessage.getVersion());
-        uint64Writer.write(writer, neighbourMessage.getRound());
+        uint64Writer.write(writer, neighbourMessage.getRoundNumber());
         uint64Writer.write(writer, neighbourMessage.getSetId());
         writer.writeUint32(neighbourMessage.getLastFinalizedBlock().longValue());
     }

--- a/src/main/java/com/limechain/network/protocol/message/ProtocolMessageBuilder.java
+++ b/src/main/java/com/limechain/network/protocol/message/ProtocolMessageBuilder.java
@@ -6,6 +6,7 @@ import com.limechain.network.protocol.grandpa.messages.neighbour.NeighbourMessag
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.rpc.server.AppBean;
 import com.limechain.state.StateManager;
+import com.limechain.sync.state.SyncState;
 import lombok.experimental.UtilityClass;
 
 import java.math.BigInteger;
@@ -16,14 +17,18 @@ public class ProtocolMessageBuilder {
 
     public NeighbourMessage buildNeighbourMessage() {
         StateManager stateManager = AppBean.getBean(StateManager.class);
-        GrandpaSetState grandpaSetState = AppBean.getBean(GrandpaSetState.class);
+        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
+        SyncState syncState = stateManager.getSyncState();
+
         BigInteger setId = grandpaSetState.getSetId();
+        BigInteger roundNumber = grandpaSetState.getCurrentGrandpaRound().getRoundNumber();
+        BigInteger bestFinalizedBlockNumber = syncState.getLastFinalizedBlockNumber();
 
         return new NeighbourMessage(
                 NEIGHBOUR_MESSAGE_VERSION,
-                stateManager.getGrandpaSetState().getCurrentGrandpaRound().getRoundNumber(),
+                roundNumber,
                 setId,
-                stateManager.getSyncState().getLastFinalizedBlockNumber()
+                bestFinalizedBlockNumber
         );
     }
 

--- a/src/main/java/com/limechain/network/protocol/warp/dto/Justification.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/Justification.java
@@ -38,7 +38,7 @@ public class Justification {
         ).toArray(SignedVote[]::new);
 
         Justification justification = new Justification();
-        justification.setRoundNumber(catchUpResMessage.getRound());
+        justification.setRoundNumber(catchUpResMessage.getRoundNumber());
         justification.setTargetHash(catchUpResMessage.getBlockHash());
         justification.setTargetBlock(catchUpResMessage.getBlockNumber());
         justification.setSignedVotes(allVotes);

--- a/src/main/java/com/limechain/storage/block/state/BlockState.java
+++ b/src/main/java/com/limechain/storage/block/state/BlockState.java
@@ -892,15 +892,6 @@ public class BlockState extends AbstractState {
         return BlockStateHelper.bytesToRoundAndSetId(data);
     }
 
-    public Vote getLastFinalizedBlockAsVote() {
-        var lastFinalizedBlockHeader = getHighestFinalizedHeader();
-
-        return new Vote(
-                lastFinalizedBlockHeader.getHash(),
-                lastFinalizedBlockHeader.getBlockNumber()
-        );
-    }
-
     /**
      * Store all the blocks between last saved finalized and current finalized block in database
      * and delete them from the unfinalized block map

--- a/src/main/java/com/limechain/sync/JustificationVerifier.java
+++ b/src/main/java/com/limechain/sync/JustificationVerifier.java
@@ -41,8 +41,8 @@ public class JustificationVerifier {
         GrandpaSetState grandpaSetState = AppBean.getBean(GrandpaSetState.class);
         BlockState blockState = AppBean.getBean(BlockState.class);
 
-        BigInteger threshold = grandpaSetState.getThreshold();
-        Authority[] authorities = grandpaSetState.getAuthorities().toArray(new Authority[0]);
+        List<Authority> authorities = grandpaSetState.getAuthorities();
+        BigInteger threshold = grandpaSetState.getThreshold(authorities);
 
         // Implementation from: https://github.com/smol-dot/smoldot
         // lib/src/finality/justification/verify.rs
@@ -52,7 +52,7 @@ public class JustificationVerifier {
         }
 
         BigInteger setId = grandpaSetState.getSetId();
-        Set<Hash256> authorityKeys = Arrays.stream(authorities)
+        Set<Hash256> authorityKeys = authorities.stream()
                 .map(Authority::getPublicKey)
                 .map(Hash256::new)
                 .collect(Collectors.toSet());

--- a/src/test/java/com/limechain/grandpa/state/GrandpaSetStateTest.java
+++ b/src/test/java/com/limechain/grandpa/state/GrandpaSetStateTest.java
@@ -44,17 +44,17 @@ class GrandpaSetStateTest {
         Authority authority9 = new Authority(Ed25519Utils.generateKeyPair().publicKey().bytes(), BigInteger.ONE);
         Authority authority10 = new Authority(Ed25519Utils.generateKeyPair().publicKey().bytes(), BigInteger.ONE);
 
-        grandpaSetState.startNewSet(
-                List.of(
-                        authority1, authority2, authority3, authority4, authority5,
-                        authority6, authority7, authority8, authority9, authority10
-                )
+        List<Authority> authorities = List.of(
+                authority1, authority2, authority3, authority4, authority5,
+                authority6, authority7, authority8, authority9, authority10
         );
+
+        grandpaSetState.startNewSet(authorities);
 
         // Total weight: 10
         // Faulty: (10 - 1) / 3 = 3
         // Threshold: 10 - faulty = 7
-        assertEquals(BigInteger.valueOf(7), grandpaSetState.getThreshold());
+        assertEquals(BigInteger.valueOf(7), grandpaSetState.getThreshold(authorities));
     }
 
     @Test


### PR DESCRIPTION
# Description

- Add authorities and setId fields to GrandpaRound to retain a copy linked to the specified round, ensuring still running rounds from the previous set remain unaffected when switching sets and have access to the right authorities and right setId.