### PR TITLE
fix: Separated justification verification for preVotes from preCommits.

### DIFF
--- a/src/main/java/com/limechain/exception/sync/JustificationVerificationException.java
+++ b/src/main/java/com/limechain/exception/sync/JustificationVerificationException.java
@@ -4,4 +4,8 @@ public class JustificationVerificationException extends RuntimeException {
     public JustificationVerificationException(String message) {
         super(message);
     }
+
+    public JustificationVerificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/limechain/exception/sync/JustificationVerificationException.java
+++ b/src/main/java/com/limechain/exception/sync/JustificationVerificationException.java
@@ -4,8 +4,4 @@ public class JustificationVerificationException extends RuntimeException {
     public JustificationVerificationException(String message) {
         super(message);
     }
-
-    public JustificationVerificationException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -346,16 +345,9 @@ public class GrandpaMessageHandler {
         CompletableFuture<Boolean> verifiedFuture = verifiedPreVotesFuture.thenCombine(verifiedPreCommitsFuture,
                 (preVotes, preCommits) -> preVotes && preCommits);
 
-        try {
-            boolean verified = verifiedFuture.get();
-            if (!verified) {
-                throw new JustificationVerificationException("Justification could not be verified.");
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new JustificationVerificationException("Justification verification was interrupted.", e);
-        } catch (ExecutionException e) {
-            throw new JustificationVerificationException("Justification verification failed.", e);
+        boolean verified = verifiedFuture.join();
+        if (!verified) {
+            throw new JustificationVerificationException("Justification could not be verified.");
         }
 
         BlockHeader bestFinalCandidate = grandpaRound.getBestFinalCandidate();

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -36,6 +36,7 @@ import com.limechain.sync.JustificationVerifier;
 import com.limechain.sync.state.SyncState;
 import com.limechain.sync.warpsync.WarpSyncState;
 import com.limechain.utils.Ed25519Utils;
+import com.limechain.utils.async.AsyncExecutor;
 import com.limechain.utils.scale.ScaleUtils;
 import io.emeraldpay.polkaj.types.Hash256;
 import io.libp2p.core.PeerId;
@@ -50,7 +51,9 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -69,6 +72,8 @@ public class GrandpaMessageHandler {
     private final PeerMessageCoordinator messageCoordinator;
     private final WarpSyncState warpSyncState;
     private final PeerRequester requester;
+    private final AsyncExecutor asyncExecutor = AsyncExecutor.withPoolSize(10);
+
 
     /**
      * Handles a vote message, extracts signed vote, associates it with the correct round.
@@ -331,10 +336,23 @@ public class GrandpaMessageHandler {
         setPreVotesAndPvEquivocations(grandpaRound, catchUpResMessage.getPreVotes());
         setPreCommitsAndPcEquivocations(grandpaRound, catchUpResMessage.getPreCommits());
 
-        boolean verified = JustificationVerifier.verify(Justification.fromCatchUpResMessage(catchUpResMessage));
+        CompletableFuture<Boolean> verifiedPreVotesFuture = asyncExecutor.executeAsync(() ->
+                JustificationVerifier.verify(Justification.fromCatchUpResPreVotes(catchUpResMessage)));
 
-        if (!verified) {
-            throw new JustificationVerificationException("Justification could not be verified.");
+        CompletableFuture<Boolean> verifiedPreCommitsFuture = asyncExecutor.executeAsync(() ->
+                JustificationVerifier.verify(Justification.fromCatchUpResPreCommits(catchUpResMessage)));
+
+        // Combines verified of preVotes and preCommits - it is true only if both and verified.
+        CompletableFuture<Boolean> verifiedFuture = verifiedPreVotesFuture.thenCombine(verifiedPreCommitsFuture,
+                (preVotes, preCommits) -> preVotes && preCommits);
+
+        try {
+            boolean verified = verifiedFuture.get();
+            if (!verified) {
+                throw new JustificationVerificationException("Justification could not be verified.");
+            }
+        } catch (ExecutionException | InterruptedException e) {
+            throw new JustificationVerificationException("Justification verification failed.", e);
         }
 
         BlockHeader bestFinalCandidate = grandpaRound.getBestFinalCandidate();

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -351,7 +351,10 @@ public class GrandpaMessageHandler {
             if (!verified) {
                 throw new JustificationVerificationException("Justification could not be verified.");
             }
-        } catch (ExecutionException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new JustificationVerificationException("Justification verification was interrupted.", e);
+        } catch (ExecutionException e) {
             throw new JustificationVerificationException("Justification verification failed.", e);
         }
 

--- a/src/main/java/com/limechain/network/protocol/warp/dto/Justification.java
+++ b/src/main/java/com/limechain/network/protocol/warp/dto/Justification.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.stream.Stream;
 
 @Setter
 @Getter
@@ -28,20 +27,25 @@ public class Justification {
         justification.setTargetHash(commitMessage.getVote().getBlockHash());
         justification.setTargetBlock(commitMessage.getVote().getBlockNumber());
         justification.setSignedVotes(commitMessage.getPreCommits());
+
         return justification;
     }
 
-    public static Justification fromCatchUpResMessage(CatchUpResMessage catchUpResMessage) {
-        SignedVote[] allVotes = Stream.concat(
-                Arrays.stream(catchUpResMessage.getPreVotes()),
-                Arrays.stream(catchUpResMessage.getPreCommits())
-        ).toArray(SignedVote[]::new);
+    public static Justification fromCatchUpResPreVotes(CatchUpResMessage message) {
+        return fromCatchUpResMessage(message, message.getPreVotes());
+    }
 
+    public static Justification fromCatchUpResPreCommits(CatchUpResMessage message) {
+        return fromCatchUpResMessage(message, message.getPreCommits());
+    }
+
+    private static Justification fromCatchUpResMessage(CatchUpResMessage message, SignedVote[] signedVotes) {
         Justification justification = new Justification();
-        justification.setRoundNumber(catchUpResMessage.getRoundNumber());
-        justification.setTargetHash(catchUpResMessage.getBlockHash());
-        justification.setTargetBlock(catchUpResMessage.getBlockNumber());
-        justification.setSignedVotes(allVotes);
+        justification.setRoundNumber(message.getRoundNumber());
+        justification.setTargetHash(message.getBlockHash());
+        justification.setTargetBlock(message.getBlockNumber());
+        justification.setSignedVotes(signedVotes);
+
         return justification;
     }
 

--- a/src/main/java/com/limechain/sync/JustificationVerifier.java
+++ b/src/main/java/com/limechain/sync/JustificationVerifier.java
@@ -63,7 +63,11 @@ public class JustificationVerifier {
 
         if (justification.getAncestryVotes() != null &&
                 Arrays.stream(justification.getAncestryVotes())
-                        .anyMatch(vote -> !blockState.isDescendantOf(justification.getTargetHash(), vote.getHash()))
+                        .anyMatch(vote -> !blockState.isDescendantOf(
+                                        justification.getTargetHash(),
+                                        vote.getHash()
+                                )
+                        )
         ) {
             log.log(Level.WARNING, "Ancestry vote block is not a descendant of the target block");
             return false;


### PR DESCRIPTION
# Description
Separated justification verification for preVotes and preCommits. Previously, they were verified together as part of a single list. 
Now, we create two distinct justifications—one for preVotes and another for preCommits.