### PR TITLE
refactor: remove state persist form warp sync.

### DIFF
--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncMachine.java
@@ -107,12 +107,9 @@ public class WarpSyncMachine {
 
     private void finishWarpSync() {
         SyncState syncState = stateManager.getSyncState();
-        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
         BlockState blockState = stateManager.getBlockState();
 
         this.warpState.setWarpSyncFinished(true);
-        syncState.persistState();
-        grandpaSetState.persistState();
 
         blockState.setupPostWarpSync(syncState.getLastFinalizedBlockHash(), syncState.getLastFinalizedBlockNumber());
 


### PR DESCRIPTION
# Description

This PR removes the state persistence at the end of the warp sync. The idea of persisting the whole state is to be done when the node shuts down. That will be implemented in #791 