### PR TITLE
feat: Initiate grandpa.

### DIFF
--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -1,11 +1,186 @@
 package com.limechain.grandpa;
 
+import com.limechain.exception.grandpa.GrandpaGenericException;
+import com.limechain.grandpa.round.GrandpaRound;
+import com.limechain.grandpa.state.AuthoritySet;
+import com.limechain.grandpa.state.GrandpaSetState;
+import com.limechain.grandpa.state.RoundState;
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import com.limechain.network.protocol.warp.dto.Justification;
+import com.limechain.state.AbstractState;
+import com.limechain.state.StateManager;
+import com.limechain.storage.block.state.BlockState;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 
 @Log
 @Component
 @RequiredArgsConstructor
 public class GrandpaService {
+
+    private final StateManager stateManager;
+
+    public void start() {
+
+        try {
+            tryStartFromLastFinalizedBlock();
+
+            log.info(String.format("Grandpa service started with round #%d",
+                    stateManager.getGrandpaSetState().getCurrentGrandpaRound().getRoundNumber()));
+        } catch (RuntimeException e) {
+            log.warning(String.format("start: There was an error when starting grandpa: %s", e.getMessage()));
+        }
+    }
+
+    public void tryStartFromPreviousRound(GrandpaRound prevRound) {
+
+        GrandpaSetState state = stateManager.getGrandpaSetState();
+        GrandpaRound currentRound = state.getCurrentGrandpaRound();
+
+        if (currentRound != prevRound) {
+            log.fine("tryStartNextRound: We should only start a next round from the current one.");
+        }
+
+        try {
+            GrandpaRound nextRound = createNextRound(prevRound);
+            state.addNewGrandpaRound(nextRound);
+            playCurrentRound();
+        } catch (GrandpaGenericException e) {
+            log.warning(String.format("tryStartNextRound: Cannot start next round: %s", e.getMessage()));
+        }
+    }
+
+    public GrandpaRound createInitialRound(RoundState roundState) {
+
+        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
+        AuthoritySet authoritySet = roundState.getAuthoritySet();
+
+        return new GrandpaRound(roundState,
+                grandpaSetState.getThreshold(authoritySet.getAuthorities()),
+                isPrimary(roundState.getRoundNumber(), authoritySet));
+    }
+
+    public Optional<AuthoritySet> getAuthoritiesForBlock(BigInteger blockNumber) {
+        AuthoritySet authorities = null;
+
+        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
+
+        for (Map.Entry<BigInteger, AuthoritySet> entry : grandpaSetState.getPastSetChanges().entrySet()) {
+
+            if (entry.getKey().compareTo(blockNumber) <= 0) {
+                authorities = entry.getValue();
+            } else {
+                break;
+            }
+        }
+
+        return Optional.ofNullable(authorities);
+    }
+
+    private void tryStartFromLastFinalizedBlock() {
+
+        BlockState blockState = stateManager.getBlockState();
+        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
+
+        BlockHeader lastFinalized = blockState.getHighestFinalizedHeader();
+        Optional<AuthoritySet> authSetOpt = getAuthoritiesForBlock(lastFinalized.getBlockNumber());
+
+        if (authSetOpt.isEmpty()) {
+            log.fine(String.format("createRoundFromFinalizedBlock: No authority set found for block %d",
+                    lastFinalized.getBlockNumber()));
+            throw new GrandpaGenericException("No authority set found for block " + lastFinalized.getBlockNumber());
+        }
+
+        RoundState.RoundStateBuilder stateBuilder = RoundState.builder()
+                .roundNumber(BigInteger.ONE)
+                .lastFinalizedBlock(lastFinalized)
+                .authoritySet(authSetOpt.get());
+
+        if (lastFinalized.getBlockNumber().compareTo(BigInteger.ZERO) > 0) {
+            Optional<Justification> justificationOpt = blockState.getJustification(lastFinalized.getHash());
+            justificationOpt.ifPresent(justification -> {
+                if (!isFirstBlockOfSet(lastFinalized.getBlockNumber())) {
+                    stateBuilder.roundNumber(justification.getRoundNumber().add(BigInteger.ONE));
+                }
+            });
+        }
+
+        GrandpaRound currentRound = createInitialRound(stateBuilder.build());
+        grandpaSetState.addNewGrandpaRound(currentRound);
+        playCurrentRound();
+    }
+
+    private void playCurrentRound() {
+        if (AbstractState.isActiveAuthority()) {
+            stateManager.getGrandpaSetState().getCurrentGrandpaRound().play();
+        }
+    }
+
+    private GrandpaRound createNextRound(GrandpaRound round) {
+
+        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
+
+        BlockHeader lastFinalized = round.getFinalizedBlock() == null
+                ? round.getLastFinalizedBlock()
+                : round.getFinalizedBlock();
+
+        Optional<AuthoritySet> authSetOpt = getAuthoritiesForBlock(lastFinalized.getBlockNumber());
+        if (authSetOpt.isEmpty()) {
+            log.fine(String.format("createNextRound: No authority set found for block %d",
+                    lastFinalized.getBlockNumber()));
+            throw new GrandpaGenericException("No authority set found for block " + lastFinalized.getBlockNumber());
+        }
+
+        AuthoritySet authSetAtBlock = authSetOpt.get();
+        BigInteger newRoundNumber = round.getSetId().equals(authSetAtBlock.getSetId())
+                ? round.getRoundNumber().add(BigInteger.ONE)
+                : BigInteger.ONE;
+
+        return new GrandpaRound(round,
+                newRoundNumber,
+                authSetAtBlock.getSetId(),
+                authSetAtBlock.getAuthorities(),
+                grandpaSetState.getThreshold(authSetAtBlock.getAuthorities()),
+                isPrimary(newRoundNumber, authSetAtBlock),
+                lastFinalized
+        );
+    }
+
+    private boolean isPrimary(BigInteger roundState, AuthoritySet authoritySet) {
+
+        var keyPair = AbstractState.getGrandpaKeyPair();
+        if (keyPair == null) {
+            log.fine(("isPrimary: KeyPair is null."));
+            return false;
+        }
+
+        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
+        BigInteger primaryIndex = grandpaSetState.derivePrimary(roundState);
+
+        return Arrays.equals(authoritySet.getAuthorities()
+                        .get(primaryIndex.intValueExact())
+                        .getPublicKey(),
+                keyPair.getValue0()
+        );
+    }
+
+    private boolean isFirstBlockOfSet(BigInteger blockNumber) {
+
+        var pastSetChanges = stateManager.getGrandpaSetState().getPastSetChanges();
+
+        for (Map.Entry<BigInteger, AuthoritySet> entry : pastSetChanges.reversed().entrySet()) {
+
+            if (entry.getKey().compareTo(blockNumber) == 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/com/limechain/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/grandpa/GrandpaService.java
@@ -31,7 +31,7 @@ public class GrandpaService {
         try {
             tryStartFromLastFinalizedBlock();
 
-            log.info(String.format("Grandpa service started with round #%d",
+            log.info(String.format("start: Grandpa service started with round #%d",
                     stateManager.getGrandpaSetState().getCurrentGrandpaRound().getRoundNumber()));
         } catch (RuntimeException e) {
             log.warning(String.format("start: There was an error when starting grandpa: %s", e.getMessage()));

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -827,13 +827,13 @@ public class GrandpaRound {
     }
 
     private Justification createJustification() {
-        SignedVote[] preCommits = getPreCommits().values().toArray(new SignedVote[0]);
+        SignedVote[] signedVotes = getPreCommits().values().toArray(new SignedVote[0]);
 
         Justification justification = new Justification();
         justification.setRoundNumber(roundNumber);
         justification.setTargetHash(getBestFinalCandidate().getHash());
         justification.setTargetBlock(getBestFinalCandidate().getBlockNumber());
-        justification.setSignedVotes(preCommits);
+        justification.setSignedVotes(signedVotes);
 
         return justification;
     }

--- a/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/grandpa/round/GrandpaRound.java
@@ -5,7 +5,9 @@ import com.limechain.exception.grandpa.EstimateExecutionException;
 import com.limechain.exception.grandpa.GhostExecutionException;
 import com.limechain.exception.grandpa.GrandpaGenericException;
 import com.limechain.exception.storage.BlockStorageGenericException;
+import com.limechain.grandpa.GrandpaService;
 import com.limechain.grandpa.state.GrandpaSetState;
+import com.limechain.grandpa.state.RoundState;
 import com.limechain.grandpa.vote.SignedVote;
 import com.limechain.grandpa.vote.SubRound;
 import com.limechain.grandpa.vote.Vote;
@@ -17,6 +19,7 @@ import com.limechain.network.protocol.grandpa.messages.vote.FullVoteScaleWriter;
 import com.limechain.network.protocol.grandpa.messages.vote.SignedMessage;
 import com.limechain.network.protocol.grandpa.messages.vote.VoteMessage;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
+import com.limechain.network.protocol.warp.dto.Justification;
 import com.limechain.rpc.server.AppBean;
 import com.limechain.state.AbstractState;
 import com.limechain.state.StateManager;
@@ -152,6 +155,19 @@ public class GrandpaRound {
         this.lastFinalizedBlock = lastFinalizedBlock;
     }
 
+    public GrandpaRound(RoundState roundState,
+                        BigInteger threshold,
+                        boolean isPrimaryVoter) {
+
+        this.roundNumber = roundState.getRoundNumber();
+        this.setId = roundState.getAuthoritySet().getSetId();
+        this.authorities = roundState.getAuthoritySet().getAuthorities();
+        this.lastFinalizedBlock = roundState.getLastFinalizedBlock();
+        this.finalizedBlock = roundState.getFinalizedBlock();
+        this.threshold = threshold;
+        this.isPrimaryVoter = isPrimaryVoter;
+    }
+
     public void switchStage() {
         stage = switch (stage) {
             case StartStage ignored -> new PreVoteStage();
@@ -196,10 +212,23 @@ public class GrandpaRound {
         if (shouldUpdateEstimate && updateEstimate()) {
             attemptToFinalize();
 
-            //TODO update R + 1
+            updateNextRound();
         }
 
-        //TODO check if we can start next round.
+        boolean shouldStartNextRound = true;
+
+        if (previous != null) {
+            shouldStartNextRound = previous.finalizedBlock != null;
+        }
+
+        shouldStartNextRound = shouldStartNextRound && isCompletable;
+
+        if (shouldStartNextRound) {
+            log.fine(String.format("update: Starting next round from round #%d in set %d", this.roundNumber, setId));
+
+            ASYNC_EXECUTOR.executeAndForget(() -> Objects.requireNonNull(AppBean.getBean(GrandpaService.class))
+                    .tryStartFromPreviousRound(this));
+        }
     }
 
     /**
@@ -364,7 +393,7 @@ public class GrandpaRound {
         }
 
         if (finalizedBlock != null) {
-            blockState.setFinalizedHash(finalizedBlock, roundNumber, setId);
+            blockState.setFinalizedHash(finalizedBlock, createJustification(), setId);
 
             // Persisting round data into the database when a block is finalized
             GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
@@ -492,10 +521,6 @@ public class GrandpaRound {
                                                BlockHeader borderBlock) {
         BlockState blockState = stateManager.getBlockState();
 
-        if (roundNumber.equals(BigInteger.ZERO)) {
-            return grandpaGhost;
-        }
-
         Map<Hash256, BigInteger> possibleSelectedBlocks = getPossibleSelectedBlocks(
                 condition,
                 round
@@ -577,10 +602,6 @@ public class GrandpaRound {
     private BlockHeader findGrandpaGhost(Function<BigInteger, Boolean> condition,
                                          SubRound subround,
                                          BlockHeader currentBest) {
-
-        if (roundNumber.equals(BigInteger.ZERO)) {
-            return lastFinalizedBlock;
-        }
 
         Map<Hash256, BigInteger> blocks = getPossibleSelectedBlocks(condition, subround);
 
@@ -803,5 +824,26 @@ public class GrandpaRound {
             voteWeight = voteWeight.add(authorityWeight.orElse(BigInteger.ZERO));
         }
         return voteWeight;
+    }
+
+    private Justification createJustification() {
+        SignedVote[] preCommits = getPreCommits().values().toArray(new SignedVote[0]);
+
+        Justification justification = new Justification();
+        justification.setRoundNumber(roundNumber);
+        justification.setTargetHash(getBestFinalCandidate().getHash());
+        justification.setTargetBlock(getBestFinalCandidate().getBlockNumber());
+        justification.setSignedVotes(preCommits);
+
+        return justification;
+    }
+
+    private void updateNextRound() {
+
+        GrandpaRound nextRound = stateManager.getGrandpaSetState().getGrandpaRound(roundNumber.add(BigInteger.ONE));
+
+        if (nextRound != null) {
+            nextRound.update(true, false, false);
+        }
     }
 }

--- a/src/main/java/com/limechain/grandpa/state/AuthoritySet.java
+++ b/src/main/java/com/limechain/grandpa/state/AuthoritySet.java
@@ -1,0 +1,14 @@
+package com.limechain.grandpa.state;
+
+import com.limechain.chain.lightsyncstate.Authority;
+import lombok.Value;
+
+import java.math.BigInteger;
+import java.util.List;
+
+@Value
+public class AuthoritySet {
+
+    BigInteger setId;
+    List<Authority> authorities;
+}

--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -63,6 +63,7 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
             new PriorityQueue<>(AuthoritySetChange.getComparator());
 
     private final LinkedHashMap<BigInteger, AuthoritySet> pastSetChanges = new LinkedHashMap<>() {
+        @Override
         protected boolean removeEldestEntry(Map.Entry<BigInteger, AuthoritySet> eldest) {
             return SET_CHANGES_MAX.compareTo(BigInteger.valueOf(size())) <= 0;
         }

--- a/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
+++ b/src/main/java/com/limechain/grandpa/state/GrandpaSetState.java
@@ -8,7 +8,6 @@ import com.limechain.grandpa.round.GrandpaRound;
 import com.limechain.grandpa.vote.SignedVote;
 import com.limechain.grandpa.vote.Vote;
 import com.limechain.network.protocol.grandpa.messages.consensus.GrandpaConsensusMessage;
-import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.runtime.Runtime;
 import com.limechain.state.AbstractState;
 import com.limechain.storage.DBConstants;
@@ -31,6 +30,7 @@ import org.springframework.stereotype.Component;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,6 +49,7 @@ import java.util.logging.Level;
 public class GrandpaSetState extends AbstractState implements ServiceConsensusState {
 
     private static final BigInteger THRESHOLD_DENOMINATOR = BigInteger.valueOf(3);
+    private static final BigInteger SET_CHANGES_MAX = BigInteger.valueOf(3);
 
     private List<Authority> authorities;
     private BigInteger disabledAuthority;
@@ -58,8 +59,14 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
     private final KeyStore keyStore;
     private final KVRepository<String, Object> repository;
 
-    private final PriorityQueue<AuthoritySetChange> authoritySetChanges =
+    private final PriorityQueue<AuthoritySetChange> pendingSetChanges =
             new PriorityQueue<>(AuthoritySetChange.getComparator());
+
+    private final LinkedHashMap<BigInteger, AuthoritySet> pastSetChanges = new LinkedHashMap<>() {
+        protected boolean removeEldestEntry(Map.Entry<BigInteger, AuthoritySet> eldest) {
+            return SET_CHANGES_MAX.compareTo(BigInteger.valueOf(size())) <= 0;
+        }
+    };
 
     private GrandpaRound currentGrandpaRound;
 
@@ -130,43 +137,7 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
 
         updateAuthorityStatus();
 
-        if (AbstractState.isActiveAuthority()) {
-            BlockHeader lastFinalized = blockState.getHighestFinalizedHeader();
-
-            GrandpaRound initGrandpaRound = new GrandpaRound(
-                    currentGrandpaRound,
-                    BigInteger.ZERO,
-                    setId,
-                    authorities,
-                    getThreshold(authorities),
-                    false,
-                    lastFinalized
-            );
-
-            initGrandpaRound.setGrandpaGhost(lastFinalized);
-
-            addNewGrandpaRound(initGrandpaRound);
-
-            persistFinalizedRoundState(initGrandpaRound.getRoundNumber());
-
-            BigInteger primaryIndex = derivePrimary(BigInteger.ONE);
-            boolean isPrimary = Arrays.equals(authorities.get(primaryIndex.intValueExact()).getPublicKey(),
-                    AbstractState.getGrandpaKeyPair().getValue0());
-
-            GrandpaRound grandpaRound = new GrandpaRound(
-                    currentGrandpaRound,
-                    BigInteger.ONE,
-                    setId,
-                    authorities,
-                    getThreshold(authorities),
-                    isPrimary,
-                    lastFinalized
-            );
-
-            addNewGrandpaRound(grandpaRound);
-
-            log.log(Level.INFO, "Successfully transitioned to authority set id: " + setId);
-        }
+        log.log(Level.INFO, "Successfully transitioned to authority set id: " + setId);
     }
 
     public void setLightSyncState(LightSyncState initState) {
@@ -180,7 +151,7 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
      * @param blockNumber required to determine if it's time to apply the change
      */
     public boolean handleAuthoritySetChange(BigInteger blockNumber) {
-        AuthoritySetChange changeSetData = authoritySetChanges.peek();
+        AuthoritySetChange changeSetData = pendingSetChanges.peek();
 
         boolean updated = false;
         while (changeSetData != null) {
@@ -190,10 +161,13 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
             }
 
             startNewSet(changeSetData.getAuthorities());
-            authoritySetChanges.poll();
+            pendingSetChanges.poll();
             updated = true;
 
-            changeSetData = authoritySetChanges.peek();
+            pastSetChanges.put(changeSetData.getApplicationBlockNumber(),
+                    new AuthoritySet(this.setId, this.authorities));
+
+            changeSetData = pendingSetChanges.peek();
         }
 
         return updated;
@@ -201,12 +175,12 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
 
     public void handleGrandpaConsensusMessage(GrandpaConsensusMessage consensusMessage, BigInteger currentBlockNumber) {
         switch (consensusMessage.getFormat()) {
-            case GRANDPA_SCHEDULED_CHANGE -> authoritySetChanges.add(new ScheduledAuthoritySetChange(
+            case GRANDPA_SCHEDULED_CHANGE -> pendingSetChanges.add(new ScheduledAuthoritySetChange(
                     consensusMessage.getAuthorities(),
                     consensusMessage.getDelay(),
                     currentBlockNumber
             ));
-            case GRANDPA_FORCED_CHANGE -> authoritySetChanges.add(new ForcedAuthoritySetChange(
+            case GRANDPA_FORCED_CHANGE -> pendingSetChanges.add(new ForcedAuthoritySetChange(
                     consensusMessage.getAuthorities(),
                     consensusMessage.getDelay(),
                     consensusMessage.getAdditionalOffset(),
@@ -222,7 +196,8 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
 
     // We keep a maximum of 3 rounds at a time
     public synchronized void addNewGrandpaRound(GrandpaRound grandpaRound) {
-        if (currentGrandpaRound.getPrevious() != null && currentGrandpaRound.getPrevious().getPrevious() != null) {
+
+        if (currentGrandpaRound != null && currentGrandpaRound.getPrevious() != null) {
             // Setting the previous to null make it
             currentGrandpaRound.getPrevious().setPrevious(null);
         }
@@ -234,6 +209,10 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
 
         GrandpaRound current = currentGrandpaRound;
         while (!current.getRoundNumber().equals(roundNumber)) {
+
+            if (current.getRoundNumber().compareTo(roundNumber) < 0) {
+                return null;
+            }
 
             current = current.getPrevious();
             if (current == null) {
@@ -249,7 +228,8 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
     }
 
     public Authority[] fetchGrandpaAuthorities() {
-        return repository.find(StateUtil.generateAuthorityKey(DBConstants.GRANDPA_AUTHORITY_SET, setId), new Authority[0]);
+        return repository.find(
+                StateUtil.generateAuthorityKey(DBConstants.GRANDPA_AUTHORITY_SET, setId), new Authority[0]);
     }
 
     public void saveAuthoritySetId() {

--- a/src/main/java/com/limechain/grandpa/state/RoundState.java
+++ b/src/main/java/com/limechain/grandpa/state/RoundState.java
@@ -1,0 +1,17 @@
+package com.limechain.grandpa.state;
+
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import lombok.Builder;
+import lombok.Value;
+
+import java.math.BigInteger;
+
+@Value
+@Builder
+public class RoundState {
+
+    BlockHeader lastFinalizedBlock;
+    BlockHeader finalizedBlock;
+    BigInteger roundNumber;
+    AuthoritySet authoritySet;
+}

--- a/src/main/java/com/limechain/network/PeerRequester.java
+++ b/src/main/java/com/limechain/network/PeerRequester.java
@@ -108,9 +108,7 @@ public class PeerRequester {
             return response.getBlocksList();
         } catch (Exception ex) {
             log.fine("Error while fetching blocks, trying to fetch again");
-            if (!this.network.updateCurrentSelectedPeerWithNextBootnode()) {
-                this.network.updateCurrentSelectedPeer();
-            }
+            this.network.updateCurrentSelectedPeer();
             return requestBlocks(field, startNumber, startHash, amount);
         }
     }

--- a/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/BlockAnnounceEngine.java
@@ -107,8 +107,6 @@ public class BlockAnnounceEngine implements BaseEngine {
     private void handleBlockAnnounce(byte[] msg, PeerId peerId) {
         BlockAnnounceMessage announce = ScaleUtils.Decode.decode(msg, BlockAnnounceMessageScaleReader.getInstance());
         connectionManager.updatePeer(peerId, announce);
-        //TODO Yordan: Do we actually need this since each block has a runtime?
-        warpSyncState.syncBlockAnnounce(announce);
         log.log(Level.FINE, "Received block announce for block #" + announce.getHeader().getBlockNumber() +
                 " from " + peerId +
                 " with hash:" + announce.getHeader().getHash() +

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaEngine.java
@@ -234,7 +234,7 @@ public class GrandpaEngine implements BaseEngine {
         // TODO: We need to actually update our peer's infos on each message.
         writeNeighbourMessage(stream, stream.remotePeerId());
 
-        if (!SyncMode.HEAD.equals(AbstractState.getSyncMode()) && AbstractState.isActiveAuthority()) {
+        if (SyncMode.HEAD.equals(AbstractState.getSyncMode()) && AbstractState.isActiveAuthority()) {
             grandpaMessageHandler.initiateAndSendCatchUpRequest(neighbourMessage, stream.remotePeerId());
         }
     }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -380,14 +380,12 @@ public class GrandpaMessageHandler {
             round.complete();
         }
 
-        for (SignedVote v : catchUpResMessage.getPreVotes()) {
-            round.getPreVotes().put(v.getAuthorityPublicKey(), v);
-            round.update(false, true, false);
-        }
-        for (SignedVote v : catchUpResMessage.getPreCommits()) {
-            round.getPreCommits().put(v.getAuthorityPublicKey(), v);
-            round.update(false, false, true);
-        }
+
+        setPreVotesAndPvEquivocations(round, catchUpResMessage.getPreVotes());
+        round.update(false, true, false);
+
+        setPreCommitsAndPcEquivocations(round, catchUpResMessage.getPreCommits());
+        round.update(false, false, true);
 
         if (isNewerThanCurrent) {
             grandpaSetState.getCurrentGrandpaRound().complete();

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -1,10 +1,14 @@
 package com.limechain.network.protocol.grandpa;
 
-import com.limechain.chain.lightsyncstate.Authority;
 import com.limechain.exception.grandpa.GrandpaGenericException;
+import com.limechain.exception.storage.HeaderNotFoundException;
+import com.limechain.exception.storage.LowerThanRootException;
 import com.limechain.exception.sync.JustificationVerificationException;
+import com.limechain.grandpa.GrandpaService;
 import com.limechain.grandpa.round.GrandpaRound;
+import com.limechain.grandpa.state.AuthoritySet;
 import com.limechain.grandpa.state.GrandpaSetState;
+import com.limechain.grandpa.state.RoundState;
 import com.limechain.grandpa.vote.SignedVote;
 import com.limechain.grandpa.vote.SubRound;
 import com.limechain.grandpa.vote.Vote;
@@ -27,8 +31,8 @@ import com.limechain.state.AbstractState;
 import com.limechain.state.StateManager;
 import com.limechain.storage.block.state.BlockState;
 import com.limechain.sync.JustificationVerifier;
+import com.limechain.sync.SyncMode;
 import com.limechain.sync.state.SyncState;
-import com.limechain.sync.warpsync.WarpSyncState;
 import com.limechain.utils.Ed25519Utils;
 import com.limechain.utils.async.AsyncExecutor;
 import com.limechain.utils.scale.ScaleUtils;
@@ -44,6 +48,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,8 +69,8 @@ public class GrandpaMessageHandler {
     private static final int THREAD_POOL_SIZE = 4;
 
     private final StateManager stateManager;
+    private final GrandpaService grandpaService;
     private final PeerMessageCoordinator messageCoordinator;
-    private final WarpSyncState warpSyncState;
     private final AsyncExecutor asyncExecutor = AsyncExecutor.withPoolSize(THREAD_POOL_SIZE);
 
 
@@ -85,7 +90,14 @@ public class GrandpaMessageHandler {
 
         // TODO: If we're not an active authority no round will be playing. We should only verify and broadcast.
         BigInteger voteMessageRoundNumber = voteMessage.getRound();
-        BigInteger currentRoundNumber = grandpaSetState.getCurrentGrandpaRound().getRoundNumber();
+
+        GrandpaRound currentRound = grandpaSetState.getCurrentGrandpaRound();
+        if (currentRound == null) {
+            log.fine("handleVoteMessage: No running grandpa round.");
+            return;
+        }
+
+        BigInteger currentRoundNumber = currentRound.getRoundNumber();
 
         if (voteMessageRoundNumber.compareTo(currentRoundNumber.subtract(BigInteger.ONE)) < 0) {
             throw new GrandpaGenericException("Vote message is invalid as it refers to a round that is " +
@@ -145,14 +157,20 @@ public class GrandpaMessageHandler {
      * @param peerId        sender of the message
      */
     public synchronized void handleCommitMessage(CommitMessage commitMessage, PeerId peerId) {
+        if (!commitMessage.getSetId().equals(stateManager.getGrandpaSetState().getSetId())) {
+            log.fine(String.format("handleCommitMessage: Received commit set id, %d, doesn't match local set id, %d",
+                    commitMessage.getSetId(), stateManager.getGrandpaSetState().getSetId()));
+            return;
+        }
+
         if (commitMessage.getVote().getBlockNumber().compareTo(
                 stateManager.getSyncState().getLastFinalizedBlockNumber()) <= 0) {
-            log.log(Level.FINE, String.format("Received commit message for finalized block %d from peer %s",
+            log.fine(String.format("Received commit message for finalized block %d from peer %s",
                     commitMessage.getVote().getBlockNumber(), peerId));
             return;
         }
 
-        log.log(Level.FINE, "Received commit message from peer " + peerId
+        log.fine("Received commit message from peer " + peerId
                 + " for block #" + commitMessage.getVote().getBlockNumber()
                 + " with hash " + commitMessage.getVote().getBlockHash()
                 + " with setId " + commitMessage.getSetId() + " and round " + commitMessage.getRoundNumber()
@@ -161,17 +179,79 @@ public class GrandpaMessageHandler {
         boolean verified = JustificationVerifier.verify(Justification.fromCommitMessage(commitMessage));
 
         if (!verified) {
-            log.log(Level.WARNING, "Could not verify commit from peer: " + peerId);
+            log.warning("Could not verify commit from peer: " + peerId);
             return;
         }
 
-        GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
-        GrandpaRound grandpaRound = grandpaSetState.getGrandpaRound(commitMessage.getRoundNumber());
-        grandpaRound.addCommitMessageToArchive(commitMessage);
-
-        if (warpSyncState.isWarpSyncFinished() && !AbstractState.isActiveAuthority()) {
-            updateSyncStateAndRuntime(commitMessage);
+        if (!SyncMode.HEAD.equals(AbstractState.getSyncMode())) {
+            handleCommitPreHead(commitMessage);
+        } else {
+            handleCommitAtHead(commitMessage);
         }
+    }
+
+    /**
+     * Handles commit messages during the process of syncing.<br>
+     * If the block from the commit message is present in the block tree it is finalized, otherwise the best block is
+     * finalized since it is an ancestor of the one in the message. This is only always true during syncing.
+     *
+     * @param commitMessage the message received via the grandpa sub-stream.
+     */
+    private void handleCommitPreHead(CommitMessage commitMessage) {
+
+        BlockState blockState = stateManager.getBlockState();
+        SyncState syncState = stateManager.getSyncState();
+
+        if (!blockState.hasHeader(commitMessage.getVote().getBlockHash())) {
+
+            BlockHeader bestBlockHeader;
+            try {
+                bestBlockHeader = blockState.bestBlockHeader();
+                blockState.setFinalizedHash(bestBlockHeader,
+                        null,
+                        stateManager.getGrandpaSetState().getSetId());
+                syncState.finalizeHeader(bestBlockHeader);
+
+                log.info(String.format(
+                        "handleCommitPreHead: Commit block #%d not in tree. Finalized best block with #%d and hash %s",
+                        commitMessage.getVote().getBlockNumber(),
+                        bestBlockHeader.getBlockNumber(),
+                        bestBlockHeader.getHash()));
+            } catch (HeaderNotFoundException e) {
+                log.warning("handleCommitPreHead: No block header found for best block.");
+                return;
+            } catch (LowerThanRootException e) {
+                log.warning("handleCommitPreHead: Lower than root exception for best block.");
+            }
+
+            blockState.getJustifications()
+                    .put(commitMessage.getVote().getBlockHash(), Justification.fromCommitMessage(commitMessage));
+
+            return;
+        }
+
+        syncState.finalizedCommitMessage(commitMessage);
+        log.info(String.format(
+                "handleCommitPreHead: Finalized block with #%d and hash %s",
+                commitMessage.getVote().getBlockNumber(), commitMessage.getVote().getBlockHash()));
+    }
+
+    /**
+     * Handles commit messages when the node is at the head of the chain.<br>
+     *
+     * @param commitMessage the message
+     */
+    private void handleCommitAtHead(CommitMessage commitMessage) {
+
+        if (AbstractState.isActiveAuthority()) {
+            // TODO: When we receive a grandpa justification we should apply it and create an appropriate round.
+            return;
+        }
+
+        stateManager.getSyncState().finalizedCommitMessage(commitMessage);
+        log.fine(String.format(
+                "handleCommitAtHead: Finalized block with #%d and hash %s",
+                commitMessage.getVote().getBlockNumber(), commitMessage.getVote().getBlockHash()));
     }
 
     /**
@@ -256,43 +336,68 @@ public class GrandpaMessageHandler {
                                       Supplier<Set<PeerId>> peerIds) {
 
         GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
+
         if (!peerIds.get().contains(peerId)) {
-            throw new GrandpaGenericException("Receiving catching up response from a non-peer.");
+            throw new GrandpaGenericException("handleCatchUpResponse: Response from a non-peer.");
         }
 
         if (!catchUpResMessage.getSetId().equals(grandpaSetState.getSetId())) {
-            throw new GrandpaGenericException("Catch up response has a different setId.");
+            throw new GrandpaGenericException("handleCatchUpResponse: Response has a different setId.");
         }
 
-        GrandpaRound latestRound = grandpaSetState.getCurrentGrandpaRound();
-        if (catchUpResMessage.getRoundNumber().compareTo(latestRound.getRoundNumber()) <= 0) {
-            throw new GrandpaGenericException("Catching up into a round in the past.");
+        GrandpaRound round = grandpaSetState.getCurrentGrandpaRound();
+        if (catchUpResMessage.getRoundNumber().compareTo(round.getRoundNumber()) <= 0) {
+            throw new GrandpaGenericException("handleCatchUpResponse: Catching up into a round in the past.");
         }
 
         BlockState blockState = stateManager.getBlockState();
-        BlockHeader finalizedTarget = blockState.getHeaderByNumber(catchUpResMessage.getBlockNumber());
-        if (!finalizedTarget.getHash().equals(catchUpResMessage.getBlockHash())) {
-            throw new GrandpaGenericException("Catch up response with non-matching block hash and block number.");
+        if (blockState.hasHeader(catchUpResMessage.getBlockHash())) {
+            throw new GrandpaGenericException("handleCatchUpResponse: Response for a block not in tree received.");
         }
 
-        List<Authority> authorities = grandpaSetState.getAuthorities();
-        BigInteger threshold = grandpaSetState.getThreshold(authorities);
+        verifyCatchupMessage(catchUpResMessage);
 
-        GrandpaRound grandpaRound = new GrandpaRound(
-                null,
-                catchUpResMessage.getRoundNumber(),
-                catchUpResMessage.getSetId(),
-                authorities,
-                threshold,
-                false,
-                latestRound.getLastFinalizedBlock()
-        );
+        boolean isNewerThanCurrent = catchUpResMessage.getBlockNumber().compareTo(round.getRoundNumber()) > 0;
 
-        //Todo: Maybe we should set previous block, as it is needed in the current implementation of findGhost
-        grandpaRound.setFinalizedBlock(finalizedTarget);
-        setPreVotesAndPvEquivocations(grandpaRound, catchUpResMessage.getPreVotes());
-        setPreCommitsAndPcEquivocations(grandpaRound, catchUpResMessage.getPreCommits());
+        if (isNewerThanCurrent) {
 
+            RoundState roundState = RoundState.builder()
+                    .roundNumber(catchUpResMessage.getRoundNumber())
+                    .lastFinalizedBlock(round.getLastFinalizedBlock())
+                    .finalizedBlock(BlockHeader.fromHash(catchUpResMessage.getBlockHash()))
+                    .build();
+
+            Optional<AuthoritySet> authSetOpt = grandpaService.getAuthoritiesForBlock(
+                    roundState.getFinalizedBlock().getBlockNumber());
+
+            if (authSetOpt.isEmpty()) {
+                log.warning(String.format("createNextRound: No authority set found for block %d",
+                        roundState.getFinalizedBlock().getBlockNumber()));
+                return;
+            }
+
+            round = grandpaService.createInitialRound(roundState);
+            round.complete();
+        }
+
+        for (SignedVote v : catchUpResMessage.getPreVotes()) {
+            round.getPreVotes().put(v.getAuthorityPublicKey(), v);
+            round.update(false, true, false);
+        }
+        for (SignedVote v : catchUpResMessage.getPreCommits()) {
+            round.getPreCommits().put(v.getAuthorityPublicKey(), v);
+            round.update(false, false, true);
+        }
+
+        if (isNewerThanCurrent) {
+            grandpaSetState.getCurrentGrandpaRound().complete();
+            grandpaSetState.addNewGrandpaRound(round);
+        }
+
+        grandpaService.tryStartFromPreviousRound(round);
+    }
+
+    private void verifyCatchupMessage(CatchUpResMessage catchUpResMessage) {
         CompletableFuture<Boolean> verifiedPreVotesFuture = asyncExecutor.executeAsync(() ->
                 JustificationVerifier.verify(Justification.fromCatchUpResPreVotes(catchUpResMessage)));
 
@@ -307,20 +412,6 @@ public class GrandpaMessageHandler {
         if (!verified) {
             throw new JustificationVerificationException("Justification could not be verified.");
         }
-
-        BlockHeader bestFinalCandidate = grandpaRound.getBestFinalCandidate();
-        if (!bestFinalCandidate.getHash().equals(finalizedTarget.getHash())) {
-            throw new GrandpaGenericException("Unjustified Catch-up target finalization");
-        }
-
-        //Todo: Iterate over preVotes, for each check if we are at Stage::PRE_COMMIT_WAITS_FOR_PRE_VOTES
-        //      then updateGrandpaGhost if we have obtained enough preVotes. If grandpaGhost is updated,
-        //      finish the PRE_COMMIT_WAITS_FOR_PRE_VOTES stage.
-
-        //Todo: If preVotes and preCommits are valid, we updateGrandpaGhost, updateFinalizeEstimate
-        //      and attemptToFinalizeRound
-
-        //Todo: Play grandpa round for the currently created round
     }
 
     private boolean isMessageSignatureValid(VoteMessage voteMessage) {
@@ -446,15 +537,6 @@ public class GrandpaMessageHandler {
 
         setUniqueVotes.accept(grandpaRound, uniqueVotes);
         setEquivocations.accept(grandpaRound, equivocations);
-    }
-
-    private void updateSyncStateAndRuntime(CommitMessage commitMessage) {
-        SyncState syncState = stateManager.getSyncState();
-        BigInteger lastFinalizedBlockNumber = syncState.getLastFinalizedBlockNumber();
-        if (commitMessage.getVote().getBlockNumber().compareTo(lastFinalizedBlockNumber) <= 0) {
-            return;
-        }
-        syncState.finalizedCommitMessage(commitMessage);
     }
 
     private SignedVote[] getPreVoteJustification(GrandpaRound requestedRound) {

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -455,8 +455,6 @@ public class GrandpaMessageHandler {
             return;
         }
         syncState.finalizedCommitMessage(commitMessage);
-
-        new Thread(() -> warpSyncState.updateRuntime(lastFinalizedBlockNumber)).start();
     }
 
     private SignedVote[] getPreVoteJustification(GrandpaRound requestedRound) {

--- a/src/main/java/com/limechain/network/protocol/warp/DigestHelper.java
+++ b/src/main/java/com/limechain/network/protocol/warp/DigestHelper.java
@@ -15,8 +15,7 @@ import com.limechain.network.protocol.warp.dto.HeaderDigest;
 import com.limechain.utils.Sr25519Utils;
 import com.limechain.utils.scale.ScaleUtils;
 import io.emeraldpay.polkaj.schnorrkel.Schnorrkel;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.experimental.UtilityClass;
 
 import java.util.Arrays;
 import java.util.List;
@@ -26,10 +25,10 @@ import java.util.stream.Collectors;
 /**
  * Helper class for processing different types of header digests
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@UtilityClass
 public class DigestHelper {
 
-    public static List<BabeConsensusMessage> getBabeConsensusMessages(HeaderDigest[] headerDigests) {
+    public List<BabeConsensusMessage> getBabeConsensusMessages(HeaderDigest[] headerDigests) {
         return Arrays.stream(headerDigests)
                 .filter(headerDigest -> DigestType.CONSENSUS_MESSAGE.equals(headerDigest.getType()) &&
                         ConsensusEngine.BABE.equals(headerDigest.getId()))
@@ -38,7 +37,7 @@ public class DigestHelper {
                 .collect(Collectors.toList());
     }
 
-    public static List<GrandpaConsensusMessage> getGrandpaConsensusMessages(HeaderDigest[] headerDigests) {
+    public List<GrandpaConsensusMessage> getGrandpaConsensusMessages(HeaderDigest[] headerDigests) {
         return Arrays.stream(headerDigests)
                 .filter(headerDigest -> DigestType.CONSENSUS_MESSAGE.equals(headerDigest.getType()) &&
                         ConsensusEngine.GRANDPA.equals(headerDigest.getId()))
@@ -47,7 +46,7 @@ public class DigestHelper {
                 .collect(Collectors.toList());
     }
 
-    public static List<BeefyConsensusMessage> getBeefyConsensusMessages(HeaderDigest[] headerDigests) {
+    public List<BeefyConsensusMessage> getBeefyConsensusMessages(HeaderDigest[] headerDigests) {
         return Arrays.stream(headerDigests)
                 .filter(headerDigest -> DigestType.CONSENSUS_MESSAGE.equals(headerDigest.getType()) &&
                         ConsensusEngine.BEEFY.equals(headerDigest.getId()))
@@ -56,7 +55,7 @@ public class DigestHelper {
                 .collect(Collectors.toList());
     }
 
-    public static Optional<BabePreDigest> getBabePreRuntimeDigest(HeaderDigest[] headerDigests) {
+    public Optional<BabePreDigest> getBabePreRuntimeDigest(HeaderDigest[] headerDigests) {
         return Arrays.stream(headerDigests)
                 .filter(headerDigest -> DigestType.PRE_RUNTIME.equals(headerDigest.getType()) &&
                         ConsensusEngine.BABE.equals(headerDigest.getId()))
@@ -65,7 +64,7 @@ public class DigestHelper {
                 .map(message -> ScaleUtils.Decode.decode(message, PreDigestReader.getInstance()));
     }
 
-    public static HeaderDigest buildSealHeaderDigest(BlockHeader blockHeader, Schnorrkel.KeyPair keyPair) {
+    public HeaderDigest buildSealHeaderDigest(BlockHeader blockHeader, Schnorrkel.KeyPair keyPair) {
         byte[] signedMessage = Sr25519Utils.signMessage(
                 keyPair.getPublicKey(), keyPair.getSecretKey(), blockHeader.getBlake2bHash(true));
         HeaderDigest sealHeaderDigest = new HeaderDigest();

--- a/src/main/java/com/limechain/runtime/RuntimeImpl.java
+++ b/src/main/java/com/limechain/runtime/RuntimeImpl.java
@@ -201,7 +201,7 @@ public class RuntimeImpl implements Runtime {
     }
 
     @Override
-    public void persistsChanges() {
+    public synchronized void persistsChanges() {
         context.getTrieAccessor().persistChanges();
     }
 

--- a/src/main/java/com/limechain/storage/block/BlockHandler.java
+++ b/src/main/java/com/limechain/storage/block/BlockHandler.java
@@ -168,8 +168,6 @@ public class BlockHandler {
                             cm, header.getBlockNumber())
                     );
 
-            grandpaSetState.handleAuthoritySetChange(header.getBlockNumber());
-
             DigestHelper.getBeefyConsensusMessages(header.getDigest())
                     .forEach(cm -> {
                                 //Todo: handleBeefyConsensusMessage

--- a/src/main/java/com/limechain/storage/block/state/BlockState.java
+++ b/src/main/java/com/limechain/storage/block/state/BlockState.java
@@ -8,7 +8,6 @@ import com.limechain.exception.storage.BlockStorageGenericException;
 import com.limechain.exception.storage.HeaderNotFoundException;
 import com.limechain.exception.storage.LowerThanRootException;
 import com.limechain.exception.storage.RoundAndSetIdNotFoundException;
-import com.limechain.grandpa.vote.Vote;
 import com.limechain.network.protocol.warp.dto.Block;
 import com.limechain.network.protocol.warp.dto.BlockBody;
 import com.limechain.network.protocol.warp.dto.BlockHeader;

--- a/src/main/java/com/limechain/storage/block/state/BlockState.java
+++ b/src/main/java/com/limechain/storage/block/state/BlockState.java
@@ -11,6 +11,7 @@ import com.limechain.exception.storage.RoundAndSetIdNotFoundException;
 import com.limechain.network.protocol.warp.dto.Block;
 import com.limechain.network.protocol.warp.dto.BlockBody;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
+import com.limechain.network.protocol.warp.dto.Justification;
 import com.limechain.network.protocol.warp.scale.reader.BlockBodyReader;
 import com.limechain.network.protocol.warp.scale.writer.BlockBodyWriter;
 import com.limechain.rpc.subscriptions.chainsub.ChainSub;
@@ -22,6 +23,7 @@ import com.limechain.storage.block.tree.BlockNode;
 import com.limechain.storage.block.tree.BlockTree;
 import com.limechain.utils.scale.ScaleUtils;
 import io.emeraldpay.polkaj.types.Hash256;
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.java.Log;
 import org.javatuples.Pair;
@@ -49,6 +51,7 @@ public class BlockState extends AbstractState {
     private final KVRepository<String, Object> db;
 
     private final Map<Hash256, Block> unfinalizedBlocks;
+    private final Map<Hash256, Justification> justifications;
     private final BlockHeader genesisBlockHeader;
     private BlockTree blockTree;
     private Hash256 lastFinalized;
@@ -56,6 +59,7 @@ public class BlockState extends AbstractState {
     public BlockState(KVRepository<String, Object> db, GenesisBlockHash genesisBlockHash) {
         this.db = db;
         unfinalizedBlocks = new HashMap<>();
+        justifications = new HashMap<>();
         genesisBlockHeader = genesisBlockHash.getGenesisBlockHeader();
     }
 
@@ -757,7 +761,19 @@ public class BlockState extends AbstractState {
         return unfinalizedBlocks.get(hash);
     }
 
+    public Optional<Justification> getJustification(final Hash256 hash) {
+        return Optional.ofNullable(justifications.get(hash));
+    }
+
     /* Block finalization */
+
+    public void setFinalizedHash(final BlockHeader header,
+                                 @Nullable final Justification justification,
+                                 final BigInteger setId) {
+        setFinalizedHash(header, setId, justification == null
+                ? BigInteger.ZERO
+                : justification.getRoundNumber());
+    }
 
     /**
      * Sets the hash of the latest finalized block
@@ -767,7 +783,7 @@ public class BlockState extends AbstractState {
      * @param setId  The set ID of the finalized block.
      * @throws BlockNodeNotFoundException if the block corresponding to the provided hash is not found.
      */
-    public void setFinalizedHash(final BlockHeader header, final BigInteger round, final BigInteger setId) {
+    private void setFinalizedHash(final BlockHeader header, final BigInteger setId, final BigInteger round) {
         Hash256 hash = header.getHash();
         if (!hasHeader(hash)) {
             throw new BlockNodeNotFoundException("Cannot finalise unknown block " + hash);

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -6,6 +6,7 @@ import com.limechain.babe.coordinator.SlotCoordinator;
 import com.limechain.config.HostConfig;
 import com.limechain.exception.storage.BlockNodeNotFoundException;
 import com.limechain.exception.sync.BlockExecutionException;
+import com.limechain.grandpa.GrandpaService;
 import com.limechain.network.NetworkService;
 import com.limechain.network.PeerMessageCoordinator;
 import com.limechain.network.PeerRequester;
@@ -65,6 +66,7 @@ public class FullSyncMachine {
     private final TrieStorage trieStorage = AppBean.getBean(TrieStorage.class);
     private final RuntimeBuilder runtimeBuilder = AppBean.getBean(RuntimeBuilder.class);
     private final SlotCoordinator slotCoordinator = AppBean.getBean(SlotCoordinator.class);
+    private final GrandpaService grandpaService = AppBean.getBean(GrandpaService.class);
     private Runtime runtime = null;
 
     public FullSyncMachine(NetworkService networkService,
@@ -134,6 +136,7 @@ public class FullSyncMachine {
             slotCoordinator.start(List.of(
                     AppBean.getBean(BabeService.class)
             ));
+            grandpaService.start();
         }
 
         AbstractState.setSyncMode(SyncMode.HEAD);
@@ -192,13 +195,7 @@ public class FullSyncMachine {
     private void executeBlocks(List<Block> receivedBlockDatas, TrieAccessor trieAccessor) {
         BlockState blockState = stateManager.getBlockState();
         for (Block block : receivedBlockDatas) {
-            log.fine("Block number to be executed is " + block.getHeader().getBlockNumber());
-
-            try {
-                blockHandler.addBlockToTree(block, Instant.now());
-            } catch (BlockNodeNotFoundException ex) {
-                log.fine("Executing block with number " + block.getHeader().getBlockNumber() + " which has no parent in block state.");
-            }
+            log.info("Block number to be executed is " + block.getHeader().getBlockNumber());
 
             // Check the block for valid inherents
             // NOTE: This is only relevant for block production.
@@ -217,8 +214,12 @@ public class FullSyncMachine {
             runtime.executeBlock(block);
             log.fine("Block executed successfully");
 
-            // Persist the updates to the trie structure
-            trieAccessor.persistChanges();
+            try {
+                blockHandler.addBlockToTree(block, Instant.now());
+            } catch (BlockNodeNotFoundException ex) {
+                log.fine("Executing block with number " + block.getHeader().getBlockNumber()
+                        + " which has no parent in block state.");
+            }
 
             BlockHeader blockHeader = block.getHeader();
             boolean blockUpdatedRuntime = Arrays.stream(blockHeader.getDigest())
@@ -232,11 +233,9 @@ public class FullSyncMachine {
                 blockState.storeRuntime(blockHeader.getHash(), runtime);
             }
 
-            try {
+            if (blockState.getJustifications().isEmpty()) {
                 stateManager.getSyncState().finalizeHeader(blockHeader);
-                blockState.setFinalizedHash(blockHeader, BigInteger.ZERO, BigInteger.ZERO);
-            } catch (BlockNodeNotFoundException ignored) {
-                log.fine("Executing block with number " + block.getHeader().getBlockNumber() + " which has no parent in block state.");
+                blockState.setFinalizedHash(blockHeader, null, BigInteger.ZERO);
             }
         }
     }

--- a/src/main/java/com/limechain/sync/state/SyncState.java
+++ b/src/main/java/com/limechain/sync/state/SyncState.java
@@ -5,6 +5,7 @@ import com.limechain.constants.GenesisBlockHash;
 import com.limechain.exception.storage.HeaderNotFoundException;
 import com.limechain.network.protocol.grandpa.messages.commit.CommitMessage;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
+import com.limechain.network.protocol.warp.dto.Justification;
 import com.limechain.state.AbstractState;
 import com.limechain.storage.DBConstants;
 import com.limechain.storage.KVRepository;
@@ -100,7 +101,9 @@ public class SyncState extends AbstractState {
 
     private boolean updateBlockState(CommitMessage commitMessage, BlockHeader blockHeader) {
         try {
-            blockState.setFinalizedHash(blockHeader, commitMessage.getRoundNumber(), commitMessage.getSetId());
+            blockState.setFinalizedHash(blockHeader,
+                    Justification.fromCommitMessage(commitMessage),
+                    commitMessage.getSetId());
         } catch (RuntimeException e) {
             log.fine(e.getMessage());
             return false;

--- a/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
+++ b/src/main/java/com/limechain/sync/warpsync/WarpSyncState.java
@@ -3,9 +3,7 @@ package com.limechain.sync.warpsync;
 import com.limechain.exception.global.RuntimeCodeException;
 import com.limechain.exception.trie.TrieDecoderException;
 import com.limechain.network.PeerRequester;
-import com.limechain.network.protocol.blockannounce.messages.BlockAnnounceMessage;
 import com.limechain.network.protocol.lightclient.pb.LightClientMessage;
-import com.limechain.network.protocol.warp.dto.DigestType;
 import com.limechain.runtime.Runtime;
 import com.limechain.runtime.RuntimeBuilder;
 import com.limechain.state.StateManager;
@@ -22,10 +20,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.java.Log;
 
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -52,57 +46,16 @@ public class WarpSyncState {
     private byte[] runtimeCode;
 
     protected final RuntimeBuilder runtimeBuilder;
-    //TODO Yordan: maybe we won't need this anymore.
-    private final Set<BigInteger> scheduledRuntimeUpdateBlocks;
 
     public WarpSyncState(StateManager stateManager,
                          KVRepository<String, Object> db,
                          RuntimeBuilder runtimeBuilder,
                          PeerRequester requester) {
 
-        this(stateManager,
-                db,
-                runtimeBuilder,
-                new HashSet<>(),
-                requester
-        );
-    }
-
-    public WarpSyncState(StateManager stateManager,
-                         KVRepository<String, Object> db,
-                         RuntimeBuilder runtimeBuilder, Set<BigInteger> scheduledRuntimeUpdateBlocks,
-                         PeerRequester requester) {
-
         this.stateManager = stateManager;
         this.db = db;
         this.runtimeBuilder = runtimeBuilder;
-        this.scheduledRuntimeUpdateBlocks = scheduledRuntimeUpdateBlocks;
         this.requester = requester;
-    }
-
-    /**
-     * Update the state with information from a block announce message.
-     * Schedule runtime updates found in header, to be executed when block is verified.
-     *
-     * @param blockAnnounceMessage received block announce message
-     */
-    public void syncBlockAnnounce(BlockAnnounceMessage blockAnnounceMessage) {
-        boolean hasRuntimeUpdate = Arrays.stream(blockAnnounceMessage.getHeader().getDigest())
-                .anyMatch(d -> d.getType() == DigestType.RUN_ENV_UPDATED);
-
-        if (hasRuntimeUpdate) {
-            scheduledRuntimeUpdateBlocks.add(blockAnnounceMessage.getHeader().getBlockNumber());
-        }
-    }
-
-    public void updateRuntime(BigInteger blockNumber) {
-        if (!scheduledRuntimeUpdateBlocks.contains(blockNumber)) {
-            return;
-        }
-        updateRuntimeCode();
-        buildRuntime();
-        BigInteger lastFinalizedBlockNumber = stateManager.getSyncState().getLastFinalizedBlockNumber();
-        scheduledRuntimeUpdateBlocks.remove(lastFinalizedBlockNumber);
     }
 
     private static final byte[] CODE_KEY_BYTES =

--- a/src/test/java/com/limechain/sync/warpsync/WarpSyncActionTest.java
+++ b/src/test/java/com/limechain/sync/warpsync/WarpSyncActionTest.java
@@ -4,11 +4,7 @@ import com.google.protobuf.ByteString;
 import com.limechain.exception.global.RuntimeCodeException;
 import com.limechain.network.NetworkService;
 import com.limechain.network.PeerRequester;
-import com.limechain.network.protocol.blockannounce.messages.BlockAnnounceMessage;
 import com.limechain.network.protocol.lightclient.pb.LightClientMessage;
-import com.limechain.network.protocol.warp.dto.BlockHeader;
-import com.limechain.network.protocol.warp.dto.DigestType;
-import com.limechain.network.protocol.warp.dto.HeaderDigest;
 import com.limechain.runtime.Runtime;
 import com.limechain.runtime.RuntimeBuilder;
 import com.limechain.state.StateManager;
@@ -40,7 +36,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unused")
@@ -105,36 +100,6 @@ class WarpSyncActionTest {
             verify(repository).save(DBConstants.RUNTIME_CODE, runtimeCode);
             assertEquals(runtimeCode, warpSyncState.getRuntimeCode());
         }
-    }
-
-    @Test
-    void syncBlockAnnounceWhenHasRunEnvUpdatedDigestShouldScheduleRuntimeUpdate() {
-        BlockAnnounceMessage blockAnnounceMessage = mock(BlockAnnounceMessage.class);
-        BlockHeader blockHeader = mock(BlockHeader.class);
-        HeaderDigest headerDigest = mock(HeaderDigest.class);
-        BigInteger blockNumber = mock(BigInteger.class);
-        when(blockAnnounceMessage.getHeader()).thenReturn(blockHeader);
-        when(blockHeader.getDigest()).thenReturn(new HeaderDigest[]{headerDigest});
-        when(headerDigest.getType()).thenReturn(DigestType.RUN_ENV_UPDATED);
-        when(blockHeader.getBlockNumber()).thenReturn(blockNumber);
-
-        warpSyncState.syncBlockAnnounce(blockAnnounceMessage);
-
-        verify(scheduledRuntimeUpdateBlocks).add(blockNumber);
-    }
-
-    @Test
-    void syncBlockAnnounceWhenNoRunEnvUpdatedDigestShouldDoNothing() {
-        BlockAnnounceMessage blockAnnounceMessage = mock(BlockAnnounceMessage.class);
-        BlockHeader blockHeader = mock(BlockHeader.class);
-        HeaderDigest headerDigest = mock(HeaderDigest.class);
-        when(blockAnnounceMessage.getHeader()).thenReturn(blockHeader);
-        when(blockHeader.getDigest()).thenReturn(new HeaderDigest[]{headerDigest});
-        when(headerDigest.getType()).thenReturn(DigestType.OTHER);
-
-        warpSyncState.syncBlockAnnounce(blockAnnounceMessage);
-
-        verifyNoInteractions(scheduledRuntimeUpdateBlocks);
     }
 
     @Test


### PR DESCRIPTION
# Description

The PR implements the following logic related to GRANDPA:
- Initializing a round at the end of the full sync process.
- Appropriately start rounds on catch up responses.
- Starting next round from within a round when a certain criteria is met.

Currently if we are not a part of the voter set we do not have have the logic to apply incoming justifications. This means that in a set that we are not voting in we would be stagnant in the first round. That is in no way ideal and will be improved in the future.

Fixes #400.
