### PR TITLE
feat: apply accumulated justifications

### DIFF
--- a/src/main/java/com/limechain/consensus/beefy/BeefyService.java
+++ b/src/main/java/com/limechain/consensus/beefy/BeefyService.java
@@ -24,7 +24,9 @@ import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -233,7 +235,7 @@ public class BeefyService implements FinalizedBlockChangeListener {
     private RoundAction determineRoundAction(BigInteger roundNumber) {
         Pair<BigInteger, BigInteger> roundsInterval = null;
         try {
-            roundsInterval = findAcceptedRoundsInterval();
+            roundsInterval = findAcceptedInterval();
         } catch (BeefyGenericException e) {
             log.warning(String.format("determineRoundAction: Error while finding accepted rounds interval %s", e));
             return RoundAction.INVALID;
@@ -250,7 +252,7 @@ public class BeefyService implements FinalizedBlockChangeListener {
         }
     }
 
-    private Pair<BigInteger, BigInteger> findAcceptedRoundsInterval() {
+    private Pair<BigInteger, BigInteger> findAcceptedInterval() {
         BeefyState beefyState = stateManager.getBeefyState();
 
         BeefySession currentSession = beefyState.getSessions().peekFirst();
@@ -305,6 +307,43 @@ public class BeefyService implements FinalizedBlockChangeListener {
         BeefyState beefyState = stateManager.getBeefyState();
         if (beefyState.getSessions().size() > 1) {
             beefyState.getSessions().removeIf(BeefySession::isMandatoryBlockFinalized);
+        }
+    }
+
+    private void applyPendingJustifications(SignedCommitment signedCommitment) {
+        BeefyState beefyState = stateManager.getBeefyState();
+
+        Pair<BigInteger, BigInteger> roundsInterval = null;
+        try {
+            roundsInterval = findAcceptedInterval();
+        } catch (BeefyGenericException e) {
+            log.warning(String.format("determineRoundAction: Error while finding accepted rounds interval %s", e));
+            return;
+        }
+
+        BigInteger startRoundNumber = roundsInterval.getLeft();
+        BigInteger endRoundNumber = roundsInterval.getRight();
+
+
+        if (!beefyState.getPendingJustifications().isEmpty()) {
+            LinkedHashMap<BigInteger, SignedCommitment> stillPending = new LinkedHashMap<>();
+            LinkedHashMap<BigInteger, SignedCommitment> justificationsToProcess = new LinkedHashMap<>();
+
+            BigInteger splitKey = endRoundNumber.add(BigInteger.ONE);
+            for (Map.Entry<BigInteger, SignedCommitment> entry : beefyState.getPendingJustifications().entrySet()) {
+                BigInteger key = entry.getKey();
+
+                if (key.compareTo(splitKey) >= 0) {
+                    stillPending.put(key, entry.getValue());
+                }
+                if (key.compareTo(startRoundNumber) >= 0) {
+                    justificationsToProcess.put(key, entry.getValue());
+                }
+            }
+
+            // Replace the pendingJustifications map with still-pending ones
+            beefyState.getPendingJustifications().clear();
+            beefyState.getPendingJustifications().putAll(stillPending);
         }
     }
 }

--- a/src/main/java/com/limechain/consensus/beefy/BeefyService.java
+++ b/src/main/java/com/limechain/consensus/beefy/BeefyService.java
@@ -354,8 +354,7 @@ public class BeefyService implements FinalizedBlockChangeListener {
         });
 
         // Update pendingJustification field in the state
-        beefyState.getPendingJustifications().clear();
-        beefyState.getPendingJustifications().putAll(stillPending);
+        beefyState.setPendingJustifications(stillPending);
 
         // Process justification that are in the accepted interval
         justificationsToProcess.values().forEach(this::finalizeJustification);

--- a/src/main/java/com/limechain/consensus/beefy/BeefyService.java
+++ b/src/main/java/com/limechain/consensus/beefy/BeefyService.java
@@ -21,7 +21,7 @@ import com.limechain.state.StateManager;
 import com.limechain.storage.block.state.BlockState;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
-import org.apache.commons.lang3.tuple.Pair;
+import org.javatuples.Pair;
 import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 @Log
@@ -68,10 +67,6 @@ public class BeefyService implements FinalizedBlockChangeListener {
         BigInteger targetVoteBlockNumber;
 
         BigInteger beefyFinalized = beefyState.getBeefyFinalized();
-        if (Objects.isNull(beefyFinalized)) {
-            throw new BeefyGenericException("Beefy finalized is not initialized yet.");
-        }
-
         BigInteger grandpaFinalized = beefyState.getGrandpaFinalized();
 
         // If the mandatory block (sessionStart) does not have a beefy justification yet, vote on it
@@ -79,15 +74,13 @@ public class BeefyService implements FinalizedBlockChangeListener {
             log.info(String.format("Vote BEEFY: vote target - mandatory block: #%s%n", sessionStartBlock));
             targetVoteBlockNumber = sessionStartBlock;
         } else {
-            if (Objects.isNull(grandpaFinalized)) {
-                throw new BeefyGenericException("Grandpa finalized is not initialized yet.");
-            }
 
             BigInteger diff = grandpaFinalized
                     .subtract(beefyFinalized)
                     .max(BigInteger.ZERO)
                     .add(BigInteger.ONE);
-            int diffInt = diff.min(BigInteger.valueOf(Integer.MAX_VALUE)).intValue();
+
+            int diffInt = diff.min(BigInteger.valueOf(Integer.MAX_VALUE)).intValueExact();
             int nextPowerOfTwo = (Integer.bitCount(diffInt) == 1) ? diffInt : Integer.highestOneBit(diffInt) << 1;
             int adjustedDiff = Math.max(MIN_BLOCK_DELTA, nextPowerOfTwo);
 
@@ -97,11 +90,12 @@ public class BeefyService implements FinalizedBlockChangeListener {
                     diffInt, nextPowerOfTwo, targetVoteBlockNumber));
         }
 
-        // Don't vote for targets until they've been finalized (`target` can be > `bestGrandpa` when `minDelta` is big enough).
+        // Don't vote for targets until they've been finalized (`target` can be > `grandpaFinalized`
+        // when `MIN_BLOCK_DELTA` is big enough).
         // Also, ensure it's not voting on a block that has already been voted on.
         if (targetVoteBlockNumber.compareTo(grandpaFinalized) > 0
                 || targetVoteBlockNumber.compareTo(beefyState.getLastVoted()) <= 0) {
-            return; // No voting if target is beyond grandpa finalized or it's not a new block
+            return; // No voting if target is beyond grandpa finalized, or it's not a new block
         }
 
         // If it's a valid vote target, update the last voted block
@@ -212,6 +206,7 @@ public class BeefyService implements FinalizedBlockChangeListener {
     }
 
     private void triageIncomingJustification(SignedCommitment signedCommitment) {
+
         BigInteger blockNumber = signedCommitment.getCommitment().getBlockNumber();
         RoundAction roundAction = determineRoundAction(blockNumber);
 
@@ -234,6 +229,7 @@ public class BeefyService implements FinalizedBlockChangeListener {
     }
 
     private RoundAction determineRoundAction(BigInteger roundNumber) {
+
         Pair<BigInteger, BigInteger> roundsInterval = null;
         try {
             roundsInterval = findAcceptedInterval();
@@ -241,8 +237,9 @@ public class BeefyService implements FinalizedBlockChangeListener {
             log.warning(String.format("determineRoundAction: Error while finding accepted rounds interval %s", e));
             return RoundAction.INVALID;
         }
-        BigInteger startRoundNumber = roundsInterval.getLeft();
-        BigInteger endRoundNumber = roundsInterval.getRight();
+
+        BigInteger startRoundNumber = roundsInterval.getValue0();
+        BigInteger endRoundNumber = roundsInterval.getValue1();
 
         if (roundNumber.compareTo(startRoundNumber) >= 0 && roundNumber.compareTo(endRoundNumber) <= 0) {
             return RoundAction.PROCESS;
@@ -262,21 +259,20 @@ public class BeefyService implements FinalizedBlockChangeListener {
         }
 
         BigInteger beefyFinalized = beefyState.getBeefyFinalized();
-        if (beefyFinalized == null) {
-            throw new BeefyGenericException("Beefy finalized is not initialized yet.");
-        }
 
         if (currentSession.isMandatoryBlockFinalized()) {
             BigInteger lowerBlock = beefyFinalized.max(currentSession.getMandatoryBlock());
-            return Pair.of(lowerBlock, beefyState.getGrandpaFinalized());
+            return Pair.with(lowerBlock, beefyState.getGrandpaFinalized());
         } else {
-            return Pair.of(currentSession.getMandatoryBlock(), currentSession.getMandatoryBlock());
+            return Pair.with(currentSession.getMandatoryBlock(), currentSession.getMandatoryBlock());
         }
     }
 
     private void finalizeJustification(SignedCommitment signedCommitment) {
+
         BeefyState beefyState = stateManager.getBeefyState();
         BigInteger blockNumber = signedCommitment.getCommitment().getBlockNumber();
+
         if (blockNumber.compareTo(beefyState.getBeefyFinalized()) <= 0) {
             log.fine(String.format("finalizeJustification: Round: %d has been already finalized.", blockNumber));
             return;
@@ -294,8 +290,10 @@ public class BeefyService implements FinalizedBlockChangeListener {
     }
 
     private void finalizeBeefyRound(BigInteger blockNumber) {
+
         BeefyState beefyState = stateManager.getBeefyState();
         BeefySession currentSession = beefyState.getSessions().peekFirst();
+
         if (currentSession == null) {
             throw new BeefyGenericException("No beefy session exists.");
         }
@@ -339,8 +337,8 @@ public class BeefyService implements FinalizedBlockChangeListener {
             return;
         }
 
-        BigInteger startRoundNumber = roundsInterval.getLeft();
-        BigInteger endRoundNumber = roundsInterval.getRight();
+        BigInteger startRoundNumber = roundsInterval.getValue0();
+        BigInteger endRoundNumber = roundsInterval.getValue1();
 
 
         if (!beefyState.getPendingJustifications().isEmpty()) {

--- a/src/main/java/com/limechain/consensus/beefy/BeefyService.java
+++ b/src/main/java/com/limechain/consensus/beefy/BeefyService.java
@@ -28,7 +28,6 @@ import java.math.BigInteger;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Log
@@ -327,9 +326,12 @@ public class BeefyService implements FinalizedBlockChangeListener {
     }
 
     private void applyPendingJustifications(SignedCommitment signedCommitment) {
+
         BeefyState beefyState = stateManager.getBeefyState();
 
-        Pair<BigInteger, BigInteger> roundsInterval = null;
+        if (beefyState.getPendingJustifications().isEmpty()) return;
+
+        Pair<BigInteger, BigInteger> roundsInterval;
         try {
             roundsInterval = findAcceptedInterval();
         } catch (BeefyGenericException e) {
@@ -337,29 +339,25 @@ public class BeefyService implements FinalizedBlockChangeListener {
             return;
         }
 
-        BigInteger startRoundNumber = roundsInterval.getValue0();
-        BigInteger endRoundNumber = roundsInterval.getValue1();
+        BigInteger start = roundsInterval.getValue0();
+        BigInteger end = roundsInterval.getValue1();
 
+        LinkedHashMap<BigInteger, SignedCommitment> stillPending = new LinkedHashMap<>();
+        LinkedHashMap<BigInteger, SignedCommitment> justificationsToProcess = new LinkedHashMap<>();
 
-        if (!beefyState.getPendingJustifications().isEmpty()) {
-            LinkedHashMap<BigInteger, SignedCommitment> stillPending = new LinkedHashMap<>();
-            LinkedHashMap<BigInteger, SignedCommitment> justificationsToProcess = new LinkedHashMap<>();
-
-            BigInteger splitKey = endRoundNumber.add(BigInteger.ONE);
-            for (Map.Entry<BigInteger, SignedCommitment> entry : beefyState.getPendingJustifications().entrySet()) {
-                BigInteger key = entry.getKey();
-
-                if (key.compareTo(splitKey) >= 0) {
-                    stillPending.put(key, entry.getValue());
-                }
-                if (key.compareTo(startRoundNumber) >= 0) {
-                    justificationsToProcess.put(key, entry.getValue());
-                }
+        beefyState.getPendingJustifications().forEach((key, value) -> {
+            if (key.compareTo(start) >= 0 && key.compareTo(end) <= 0) {
+                justificationsToProcess.put(key, value);
+            } else if (key.compareTo(end) > 0) {
+                stillPending.put(key, value);
             }
+        });
 
-            // Replace the pendingJustifications map with still-pending ones
-            beefyState.getPendingJustifications().clear();
-            beefyState.getPendingJustifications().putAll(stillPending);
-        }
+        // Update pendingJustification field in the state
+        beefyState.getPendingJustifications().clear();
+        beefyState.getPendingJustifications().putAll(stillPending);
+
+        // Process justification that are in the accepted interval
+        justificationsToProcess.values().forEach(this::finalizeJustification);
     }
 }

--- a/src/main/java/com/limechain/consensus/beefy/BeefyState.java
+++ b/src/main/java/com/limechain/consensus/beefy/BeefyState.java
@@ -4,6 +4,7 @@ import com.limechain.ServiceConsensusState;
 import com.limechain.consensus.beefy.dto.BeefyAuthoritySet;
 import com.limechain.consensus.beefy.dto.BeefySession;
 import com.limechain.consensus.beefy.dto.message.BeefyConsensusMessage;
+import com.limechain.exception.beefy.BeefyGenericException;
 import com.limechain.network.protocol.beefy.messages.justification.SignedCommitment;
 import com.limechain.network.protocol.beefy.messages.vote.VoteMessage;
 import com.limechain.runtime.Runtime;
@@ -117,6 +118,16 @@ public class BeefyState extends AbstractState implements ServiceConsensusState {
             case BEEFY_CHANGED_AUTHORITIES -> handleChangedBeefyAuthorities(consensusMessage, blockNumber);
             case BEEFY_ON_DISABLED -> disabledAuthority = consensusMessage.getDisabledAuthority();
         }
+    }
+
+    public BigInteger getBeefyFinalized() {
+        if (beefyFinalized == null) throw new BeefyGenericException("Beefy finalized is not initialized yet.");
+        return beefyFinalized;
+    }
+
+    public BigInteger getGrandpaFinalized() {
+        if (grandpaFinalized == null) throw new BeefyGenericException("Grandpa finalized is not initialized yet.");
+        return grandpaFinalized;
     }
 
     private void handleChangedBeefyAuthorities(BeefyConsensusMessage consensusMessage, BigInteger blockNumber) {

--- a/src/main/java/com/limechain/consensus/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/consensus/grandpa/round/GrandpaRound.java
@@ -311,13 +311,13 @@ public class GrandpaRound {
      * 2. During attempt-to-finalize, broadcasting a commit message for the best candidate block of the current round.
      */
     public void broadcastCommitMessage() {
-        SignedVote[] preCommits = getPreCommits().values().toArray(new SignedVote[0]);
+        SignedVote[] preCommitsArray = getPreCommits().values().toArray(new SignedVote[0]);
 
         CommitMessage commitMessage = new CommitMessage();
         commitMessage.setSetId(authoritySet.getSetId());
         commitMessage.setRoundNumber(roundNumber);
         commitMessage.setVote(Vote.fromBlockHeader(getBestFinalCandidate()));
-        commitMessage.setPreCommits(preCommits);
+        commitMessage.setPreCommits(preCommitsArray);
 
         peerMessageCoordinator.sendCommitMessageToPeers(commitMessage);
     }


### PR DESCRIPTION
# Description

- Implement the applyPendingJustifications method. It splits pending justifications from the beefy state into two maps: one for keys in the accepted interval (start ≤ key ≤ end) to finalize, and one for keys greater than the end that remain still pending. Replace the state’s pendingJustifications with the latter and finalize the former.

Fixes https://github.com/LimeChain/Fruzhin/issues/831