### PR TITLE
feat: handle vote and justification messages

### DIFF
--- a/src/main/java/com/limechain/consensus/beefy/BeefyService.java
+++ b/src/main/java/com/limechain/consensus/beefy/BeefyService.java
@@ -434,6 +434,7 @@ public class BeefyService implements FinalizedBlockChangeListener {
                             "Rejected beefy message — block %d is earlier than current session's mandatory block %d.",
                     blockNumber, mandatoryBlock
             ));
+
             return false;
         }
 
@@ -444,6 +445,7 @@ public class BeefyService implements FinalizedBlockChangeListener {
                     "isBeefyMessageAcceptable: Rejected beefy message — authority set ID mismatch. Expected: %d, got: %d.",
                     setId, commitmentSetId
             ));
+
             return false;
         }
 
@@ -459,6 +461,7 @@ public class BeefyService implements FinalizedBlockChangeListener {
                     "isBeefyMessageAcceptable: Rejected beefy message — block %d outside accepted round range [%d, %d].",
                     blockNumber, start, end
             ));
+
             return false;
         }
 
@@ -466,6 +469,7 @@ public class BeefyService implements FinalizedBlockChangeListener {
                 "isBeefyMessageAcceptable: Accepted beefy message — block %d is within round range [%d, %d] and set ID %d.",
                 blockNumber, start, end, setId
         ));
+
         return true;
     }
 }

--- a/src/main/java/com/limechain/consensus/beefy/BeefyService.java
+++ b/src/main/java/com/limechain/consensus/beefy/BeefyService.java
@@ -46,6 +46,8 @@ public class BeefyService implements FinalizedBlockChangeListener {
     private final StateManager stateManager;
     private final KeyStore keyStore;
 
+    private Pair<BigInteger, BigInteger> cachedAcceptedInterval;
+
     @Override
     public void finalizedBlockChanged(FinalizedBlockChangeEvent event) {
 
@@ -54,6 +56,9 @@ public class BeefyService implements FinalizedBlockChangeListener {
         beefyState.setGrandpaFinalized(event.getGrandpaFinalized().getBlockNumber());
         processConsensusMessages(event.getBlockHeaders());
         beefyState.persistState();
+
+        // update beefy message cached interval
+        cachedAcceptedInterval = findAcceptedInterval();
     }
 
     public void vote() {
@@ -194,6 +199,23 @@ public class BeefyService implements FinalizedBlockChangeListener {
         return Optional.empty();
     }
 
+    private void reportDoubleVoting(DoubleVotingProof doubleVotingProof) {
+
+        BlockState blockState = stateManager.getBlockState();
+        Runtime runtime = blockState.getRuntime(blockState.getHighestFinalizedHash());
+        runtime.generateBeefyKeyOwnershipProof(doubleVotingProof.getFirst().getCommitment().getAuthoritySetId(),
+                        doubleVotingProof.getFirst().getAuthorityId())
+                .ifPresentOrElse(key ->
+                                runtime.submitReportBeefyDoubleVotingUnsignedExtrinsic(
+                                        doubleVotingProof, key.getProof()
+                                ),
+                        () -> log.warning(String.format(
+                                "reportDoubleVoting: Failed to report Beefy double voting for block number: %s.",
+                                doubleVotingProof.getFirst().getCommitment().getBlockNumber()
+                        ))
+                );
+    }
+
     /**
      * Examines BEEFY authority consensus messages and detects authority set changes or disabled authorities.
      * <p>
@@ -291,15 +313,13 @@ public class BeefyService implements FinalizedBlockChangeListener {
     }
 
     private RoundAction determineRoundAction(BigInteger roundNumber) {
+        BeefyState beefyState = stateManager.getBeefyState();
 
-        Pair<BigInteger, BigInteger> roundsInterval = null;
-        try {
-            roundsInterval = findAcceptedInterval();
-        } catch (BeefyGenericException e) {
-            log.warning(String.format("determineRoundAction: Error while finding accepted rounds interval %s", e));
+        if (beefyState.getSessions().isEmpty()) {
+            log.warning("determineRoundAction: No beefy session exists.");
             return RoundAction.INVALID;
         }
-
+        Pair<BigInteger, BigInteger> roundsInterval = findAcceptedInterval();
         BigInteger startRoundNumber = roundsInterval.getValue0();
         BigInteger endRoundNumber = roundsInterval.getValue1();
 
@@ -314,24 +334,18 @@ public class BeefyService implements FinalizedBlockChangeListener {
 
     private Pair<BigInteger, BigInteger> findAcceptedInterval() {
         BeefyState beefyState = stateManager.getBeefyState();
-
         BeefySession currentSession = beefyState.getSessions().peekFirst();
-        if (currentSession == null) {
-            throw new BeefyGenericException("No beefy session exists.");
-        }
-
-        BigInteger beefyFinalized = beefyState.getBeefyFinalized();
+        BigInteger mandatoryBlock = currentSession.getMandatoryBlock();
 
         if (currentSession.isMandatoryBlockFinalized()) {
-            BigInteger lowerBlock = beefyFinalized.max(currentSession.getMandatoryBlock());
+            BigInteger lowerBlock = beefyState.getBeefyFinalized().max(currentSession.getMandatoryBlock());
             return Pair.with(lowerBlock, beefyState.getGrandpaFinalized());
         } else {
-            return Pair.with(currentSession.getMandatoryBlock(), currentSession.getMandatoryBlock());
+            return Pair.with(mandatoryBlock, mandatoryBlock);
         }
     }
 
     private void finalizeJustification(SignedCommitment signedCommitment) {
-
         BeefyState beefyState = stateManager.getBeefyState();
         BigInteger blockNumber = signedCommitment.getCommitment().getBlockNumber();
 
@@ -343,12 +357,15 @@ public class BeefyService implements FinalizedBlockChangeListener {
         try {
             finalizeBeefyRound(blockNumber);
         } catch (BeefyGenericException e) {
-            log.warning(String.format("finalizeJustification: Error while finalizing beefy round: %s", e));
+            log.warning(String.format("finalizeJustification: Error while finalizing beefy round: %s", e.getMessage()));
             return;
         }
 
         beefyState.setBeefyFinalized(blockNumber);
         beefyState.persistState();
+
+        // update beefy message cached interval
+        cachedAcceptedInterval = findAcceptedInterval();
     }
 
     private void finalizeBeefyRound(BigInteger blockNumber) {
@@ -364,23 +381,6 @@ public class BeefyService implements FinalizedBlockChangeListener {
         removeFinishedSessions();
     }
 
-    public void reportDoubleVoting(DoubleVotingProof doubleVotingProof) {
-
-        BlockState blockState = stateManager.getBlockState();
-        Runtime runtime = blockState.getRuntime(blockState.getHighestFinalizedHash());
-        runtime.generateBeefyKeyOwnershipProof(doubleVotingProof.getFirst().getCommitment().getAuthoritySetId(),
-                        doubleVotingProof.getFirst().getAuthorityId())
-                .ifPresentOrElse(key ->
-                                runtime.submitReportBeefyDoubleVotingUnsignedExtrinsic(
-                                        doubleVotingProof, key.getProof()
-                                ),
-                        () -> log.warning(String.format(
-                                "reportDoubleVoting: Failed to report Beefy double voting for block number: %s.",
-                                doubleVotingProof.getFirst().getCommitment().getBlockNumber()
-                        ))
-                );
-    }
-
     private void removeFinishedSessions() {
         BeefyState beefyState = stateManager.getBeefyState();
         if (beefyState.getSessions().size() > 1) {
@@ -394,14 +394,12 @@ public class BeefyService implements FinalizedBlockChangeListener {
 
         if (beefyState.getPendingJustifications().isEmpty()) return;
 
-        Pair<BigInteger, BigInteger> roundsInterval;
-        try {
-            roundsInterval = findAcceptedInterval();
-        } catch (BeefyGenericException e) {
-            log.warning(String.format("determineRoundAction: Error while finding accepted rounds interval %s", e));
+        if (beefyState.getSessions().isEmpty()) {
+            log.warning("applyPendingJustifications: No session exists.");
             return;
         }
 
+        Pair<BigInteger, BigInteger> roundsInterval = findAcceptedInterval();
         BigInteger start = roundsInterval.getValue0();
         BigInteger end = roundsInterval.getValue1();
 
@@ -421,5 +419,52 @@ public class BeefyService implements FinalizedBlockChangeListener {
 
         // Process justification that are in the accepted interval
         justificationsToProcess.values().forEach(this::finalizeJustification);
+    }
+
+    public boolean isBeefyMessageAcceptable(Commitment commitment) {
+        BeefyState beefyState = stateManager.getBeefyState();
+        BigInteger blockNumber = commitment.getBlockNumber();
+        BeefySession currentSession = beefyState.getSessions().peekFirst();
+
+        BigInteger mandatoryBlock = currentSession.getMandatoryBlock();
+        if (blockNumber.compareTo(mandatoryBlock) < 0) {
+            log.warning(String.format(
+                    "isBeefyMessageAcceptable: " +
+                            "Rejected beefy message — block %d is earlier than current session's mandatory block %d.",
+                    blockNumber, mandatoryBlock
+            ));
+            return false;
+        }
+
+        BigInteger setId = currentSession.getAuthoritySet().getSetId();
+        BigInteger commitmentSetId = commitment.getAuthoritySetId();
+        if (!setId.equals(commitmentSetId)) {
+            log.warning(String.format(
+                    "isBeefyMessageAcceptable: Rejected beefy message — authority set ID mismatch. Expected: %d, got: %d.",
+                    setId, commitmentSetId
+            ));
+            return false;
+        }
+
+        if (cachedAcceptedInterval == null) {
+            cachedAcceptedInterval = findAcceptedInterval();
+        }
+
+        BigInteger start = cachedAcceptedInterval.getValue0();
+        BigInteger end = cachedAcceptedInterval.getValue1();
+
+        if (blockNumber.compareTo(start) < 0 || blockNumber.compareTo(end) > 0) {
+            log.warning(String.format(
+                    "isBeefyMessageAcceptable: Rejected — block %d outside accepted round range [%d, %d].",
+                    blockNumber, start, end
+            ));
+            return false;
+        }
+
+        log.fine(String.format(
+                "isBeefyMessageAcceptable: Accepted — block %d is within round range [%d, %d] and set ID %d.",
+                blockNumber, start, end, setId
+        ));
+        return true;
     }
 }

--- a/src/main/java/com/limechain/consensus/beefy/BeefyService.java
+++ b/src/main/java/com/limechain/consensus/beefy/BeefyService.java
@@ -456,14 +456,14 @@ public class BeefyService implements FinalizedBlockChangeListener {
 
         if (blockNumber.compareTo(start) < 0 || blockNumber.compareTo(end) > 0) {
             log.warning(String.format(
-                    "isBeefyMessageAcceptable: Rejected — block %d outside accepted round range [%d, %d].",
+                    "isBeefyMessageAcceptable: Rejected beefy message — block %d outside accepted round range [%d, %d].",
                     blockNumber, start, end
             ));
             return false;
         }
 
         log.fine(String.format(
-                "isBeefyMessageAcceptable: Accepted — block %d is within round range [%d, %d] and set ID %d.",
+                "isBeefyMessageAcceptable: Accepted beefy message — block %d is within round range [%d, %d] and set ID %d.",
                 blockNumber, start, end, setId
         ));
         return true;

--- a/src/main/java/com/limechain/consensus/beefy/BeefyState.java
+++ b/src/main/java/com/limechain/consensus/beefy/BeefyState.java
@@ -45,6 +45,7 @@ public class BeefyState extends AbstractState implements ServiceConsensusState {
 
     private BigInteger disabledAuthority;
 
+    //TODO: remove authority set from here
     private BeefyAuthoritySet authoritySet;
 
     private BigInteger roundNumber;

--- a/src/main/java/com/limechain/network/protocol/beefy/BeefyMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/beefy/BeefyMessageHandler.java
@@ -11,11 +11,14 @@ import com.limechain.network.protocol.beefy.messages.justification.SignedCommitm
 import com.limechain.network.protocol.beefy.messages.vote.VoteMessage;
 import com.limechain.runtime.hostapi.dto.Key;
 import com.limechain.runtime.hostapi.dto.VerifySignature;
+import com.limechain.state.StateManager;
 import com.limechain.utils.EcdsaUtils;
 import com.limechain.utils.HashUtils;
 import com.limechain.utils.scale.ScaleUtils;
+import io.emeraldpay.polkaj.types.Hash264;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
+import org.javatuples.Pair;
 import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
@@ -26,25 +29,50 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Component
 public class BeefyMessageHandler {
+    private final Object lock = new Object();
 
     private final BeefyService beefyService;
-
-    private final BeefyState beefyState;
+    private final StateManager stateManager;
 
     public void handleVoteMessage(VoteMessage voteMessage) {
+        BeefyState beefyState = stateManager.getBeefyState();
+        Commitment commitment = voteMessage.getCommitment();
 
-        if (!isVoteMessageValid(voteMessage)) {
-            log.warning(String.format(
-                    "handleBeefyVoteMessage: Invalid vote message for round %s, set %s",
-                    voteMessage.getCommitment().getBlockNumber(), voteMessage.getCommitment().getAuthoritySetId()
-            ));
+        boolean hasExistingSession = !beefyState.getSessions().isEmpty();
+        if (hasExistingSession && !beefyService.isBeefyMessageAcceptable(commitment)) {
             return;
         }
 
-        beefyService.triageIncomingVote(voteMessage);
+        synchronized (lock) {
+            Hash264 authorityIdHash = new Hash264(voteMessage.getAuthorityId());
+            BigInteger blockNumber = voteMessage.getCommitment().getBlockNumber();
+            Pair<Hash264, BigInteger> voteKey = Pair.with(authorityIdHash, blockNumber);
+
+            if (hasExistingSession) {
+                BeefySession currentSession = beefyState.getSessions().peekFirst();
+                if (currentSession.getPreviousVotes().containsKey(voteKey)) {
+                    log.fine(String.format(
+                            "handleBeefyVoteMessage: Skipping already known vote message from authority: %s for block: %s.",
+                            authorityIdHash, blockNumber
+                    ));
+                }
+            }
+            if (!isVoteMessageValid(voteMessage)) {
+                log.warning(String.format(
+                        "handleBeefyVoteMessage: Invalid vote message for round %s, set %s",
+                        commitment.getBlockNumber(), commitment.getAuthoritySetId()
+                ));
+                return;
+            }
+            beefyService.triageIncomingVote(voteMessage);
+        }
     }
 
     public void handleSignedCommitment(SignedCommitment signedCommitment) {
+        BeefyState beefyState = stateManager.getBeefyState();
+        if (!beefyState.getSessions().isEmpty() && !beefyService.isBeefyMessageAcceptable(signedCommitment.getCommitment())) {
+            return;
+        }
 
         if (!isJustificationValid(signedCommitment)) {
             log.warning(String.format(
@@ -58,7 +86,7 @@ public class BeefyMessageHandler {
     }
 
     private boolean isJustificationValid(SignedCommitment signedCommitment) {
-
+        BeefyState beefyState = stateManager.getBeefyState();
         Commitment commitment = signedCommitment.getCommitment();
         List<Optional<byte[]>> signatures = signedCommitment.getSignatures();
         BeefySession beefySession = beefyState.getSessions().peekFirst();

--- a/src/main/java/com/limechain/network/protocol/beefy/BeefyMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/beefy/BeefyMessageHandler.java
@@ -35,28 +35,27 @@ public class BeefyMessageHandler {
     private final StateManager stateManager;
 
     public void handleVoteMessage(BeefyVoteMessage voteMessage) {
+
         BeefyState beefyState = stateManager.getBeefyState();
         Commitment commitment = voteMessage.getCommitment();
 
-        boolean hasExistingSession = !beefyState.getSessions().isEmpty();
-        if (hasExistingSession && !beefyService.isBeefyMessageAcceptable(commitment)) {
+        if (beefyState.getSessions().isEmpty() || !beefyService.isBeefyMessageAcceptable(commitment)) {
             return;
         }
 
         synchronized (lock) {
+            BeefySession currentSession = beefyState.getSessions().peekFirst();
             Hash264 authorityIdHash = new Hash264(voteMessage.getAuthorityId());
             BigInteger blockNumber = voteMessage.getCommitment().getBlockNumber();
             Pair<Hash264, BigInteger> voteKey = Pair.with(authorityIdHash, blockNumber);
 
-            if (hasExistingSession) {
-                BeefySession currentSession = beefyState.getSessions().peekFirst();
-                if (currentSession.getPreviousVotes().containsKey(voteKey)) {
-                    log.fine(String.format(
-                            "handleBeefyVoteMessage: Skipping already known vote message from authority: %s for block: %s.",
-                            authorityIdHash, blockNumber
-                    ));
-                }
+            if (currentSession.getPreviousVotes().containsKey(voteKey)) {
+                log.fine(String.format(
+                        "handleBeefyVoteMessage: Skipping already known vote message from authority: %s for block: %s.",
+                        authorityIdHash, blockNumber
+                ));
             }
+
             if (!isVoteMessageValid(voteMessage)) {
                 log.warning(String.format(
                         "handleBeefyVoteMessage: Invalid vote message for round %s, set %s",
@@ -69,8 +68,9 @@ public class BeefyMessageHandler {
     }
 
     public void handleSignedCommitment(SignedCommitment signedCommitment) {
+
         BeefyState beefyState = stateManager.getBeefyState();
-        if (!beefyState.getSessions().isEmpty() && !beefyService.isBeefyMessageAcceptable(signedCommitment.getCommitment())) {
+        if (beefyState.getSessions().isEmpty() || !beefyService.isBeefyMessageAcceptable(signedCommitment.getCommitment())) {
             return;
         }
 

--- a/src/main/java/com/limechain/sync/warpsync/action/VerifyJustificationAction.java
+++ b/src/main/java/com/limechain/sync/warpsync/action/VerifyJustificationAction.java
@@ -92,6 +92,11 @@ public class VerifyJustificationAction implements WarpSyncAction {
                 .forEach(cm -> stateManager.getGrandpaSetState().handleGrandpaConsensusMessage(
                         cm, header)
                 );
+        //TODO think of a better way to initialize a beefy session with the last mandatory block.
+        DigestHelper.getBeefyConsensusMessages(header.getDigest())
+                .forEach(cm -> stateManager.getBeefyState().handleBeefyConsensusMessage(
+                        cm, header.getBlockNumber())
+                );
 
         SyncState syncState = stateManager.getSyncState();
         log.log(Level.INFO, "Verified justification. Block hash is now at #"

--- a/src/main/java/com/limechain/sync/warpsync/action/VerifyJustificationAction.java
+++ b/src/main/java/com/limechain/sync/warpsync/action/VerifyJustificationAction.java
@@ -92,11 +92,6 @@ public class VerifyJustificationAction implements WarpSyncAction {
                 .forEach(cm -> stateManager.getGrandpaSetState().handleGrandpaConsensusMessage(
                         cm, header)
                 );
-        //TODO think of a better way to initialize a beefy session with the last mandatory block.
-        DigestHelper.getBeefyConsensusMessages(header.getDigest())
-                .forEach(cm -> stateManager.getBeefyState().handleBeefyConsensusMessage(
-                        cm, header.getBlockNumber())
-                );
 
         SyncState syncState = stateManager.getSyncState();
         log.log(Level.INFO, "Verified justification. Block hash is now at #"

--- a/src/test/java/com/limechain/consensus/beefy/BeefyServiceTest.java
+++ b/src/test/java/com/limechain/consensus/beefy/BeefyServiceTest.java
@@ -18,7 +18,6 @@ import com.limechain.runtime.hostapi.dto.VerifySignature;
 import com.limechain.state.StateManager;
 import com.limechain.storage.block.state.BlockState;
 import com.limechain.storage.crypto.KeyStore;
-import com.limechain.storage.crypto.KeyType;
 import com.limechain.utils.EcdsaUtils;
 import com.limechain.utils.HashUtils;
 import com.limechain.utils.scale.ScaleUtils;
@@ -38,7 +37,6 @@ import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -151,7 +149,6 @@ class BeefyServiceTest {
         when(stateManager.getBeefyState()).thenReturn(mockBeefyState);
         when(mockBeefyState.getSessions()).thenReturn(mockedBeefySessions);
         when(mockBeefyState.getSessions().peekFirst()).thenReturn(mockedBeefySession1);
-        when(mockBeefyState.getBeefyFinalized()).thenReturn(BEEFY_FINALIZED);
         when(mockedBeefySession1.isMandatoryBlockFinalized()).thenReturn(false);
         when(mockedBeefySession1.getMandatoryBlock()).thenReturn(MANDATORY_BLOCK_NUM);
 


### PR DESCRIPTION
# Description

- Introduced cachedAcceptedInterval filed for storing start & end round numbers. Its purpose is to reduce the calls to acceptInterval() method. CachedAcceptedInterval filed is being updated on finalization of a beefy round and finalizedBlockChanged event.
- Implemented filter method for incoming votes and justifications. It is applied when there is an existing session. If there is no session, incoming message goes through validation and then we try to process it. We call acceptInterval() and if meanwhile a beefy session is created, we would have an existing one and will determine the round action. If there is still no session, we invalidate the message.
- Enhanced checks in handling votes and justifications in BeefyMessageHandler class.

Fixes #866 

### Checklist:

- [x]  I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [x]  My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ]  I have updated the documentation accordingly.
- [ ]  I have added tests to cover my changes.
- [x] All new and existing tests passed.