### PR TITLE
feat: implement beefy justifications broadcasting

### DIFF
--- a/src/main/java/com/limechain/network/PeerMessageCoordinator.java
+++ b/src/main/java/com/limechain/network/PeerMessageCoordinator.java
@@ -2,6 +2,7 @@ package com.limechain.network;
 
 import com.limechain.network.kad.KademliaService;
 import com.limechain.network.protocol.beefy.messages.justification.SignedCommitment;
+import com.limechain.network.protocol.beefy.messages.justification.SignedCommitmentScaleWriter;
 import com.limechain.network.protocol.beefy.messages.vote.BeefyVoteMessage;
 import com.limechain.network.protocol.beefy.messages.vote.BeefyVoteMessageScaleWriter;
 import com.limechain.network.protocol.blockannounce.NodeRole;
@@ -136,13 +137,16 @@ public class PeerMessageCoordinator {
 
     public void sendBeefyVoteMessageToPeers(BeefyVoteMessage voteMessage) {
         byte[] scaleMessage = ScaleUtils.Encode.encode(BeefyVoteMessageScaleWriter.getInstance(), voteMessage);
-        sendMessageToActivePeers(peerId -> asyncExecutor.executeAndForget(() -> network.getBeefyService().sendVoteMessage(
+        sendMessageToActivePeers(peerId -> asyncExecutor.executeAndForget(() -> network.getBeefyService().sendMessage(
                 network.getHost(), peerId, scaleMessage
         )));
     }
 
     public void sendSignedCommitmentToPeers(SignedCommitment signedCommitment) {
-        //TODO: implement
+        byte[] scaleMessage = ScaleUtils.Encode.encode(SignedCommitmentScaleWriter.getInstance(), signedCommitment);
+        sendMessageToActivePeers(peerId -> asyncExecutor.executeAndForget(() -> network.getBeefyService().sendMessage(
+                network.getHost(), peerId, scaleMessage
+        )));
     }
 
     private void sendMessageToActivePeers(Consumer<PeerId> messageAction) {

--- a/src/main/java/com/limechain/network/protocol/beefy/BeefyController.java
+++ b/src/main/java/com/limechain/network/protocol/beefy/BeefyController.java
@@ -13,9 +13,14 @@ public class BeefyController extends BaseController<BeefyEngine> {
     }
 
     /**
-     * Sends a beefy vote message over the controller stream
+     * Sends a BEEFY message over the controller stream.
+     * <p>
+     * Since both vote messages and signed commitments are transmitted over the same stream,
+     * there is no need for separate logic after the message is encoded.
+     * </p>
+     * @param encodedMessage the encoded BEEFY message to send, which can be either a vote message or a signed commitment.
      */
-    public void sendVoteMessage(byte[] encodedBeefyVoteMessage) {
-        engine.writeBeefyVoteMessage(stream, encodedBeefyVoteMessage);
+    public void sendMessage(byte[] encodedMessage) {
+        engine.writeMessage(stream, encodedMessage);
     }
 }

--- a/src/main/java/com/limechain/network/protocol/beefy/BeefyEngine.java
+++ b/src/main/java/com/limechain/network/protocol/beefy/BeefyEngine.java
@@ -86,7 +86,8 @@ public class BeefyEngine implements BaseEngine {
      * @param encodedMessage the scale encoded BEEFY message to send (either a vote message or a signed commitment).
      */
     public void writeMessage(Stream stream, byte[] encodedMessage) {
-        log.log(Level.FINE, "Sending beefy message to peer " + stream.remotePeerId());
+        BeefyMessageType type = BeefyMessageType.getByType(encodedMessage[0]);
+        log.log(Level.FINE, "Sending beefy " + type + " to peer " + stream.remotePeerId());
         stream.writeAndFlush(encodedMessage);
     }
 

--- a/src/main/java/com/limechain/network/protocol/beefy/BeefyEngine.java
+++ b/src/main/java/com/limechain/network/protocol/beefy/BeefyEngine.java
@@ -77,14 +77,17 @@ public class BeefyEngine implements BaseEngine {
     }
 
     /**
-     * Send our BEEFY vote message from {@link BeefyService} on a given <b>responder</b> stream.
-     *
-     * @param stream             <b>responder</b> stream to write the message to
-     * @param encodedBeefyVoteMessage scale encoded BeefyVoteMessage object
+     * Sends a BEEFY message over the given responder stream.
+     * <p>
+     * Since both vote messages and signed commitments are transmitted over the same stream,
+     * there's no need for separate logic after the message is encoded.
+     * </p>
+     * @param stream the responder stream to write the message to.
+     * @param encodedMessage the scale encoded BEEFY message to send (either a vote message or a signed commitment).
      */
-    public void writeBeefyVoteMessage(Stream stream, byte[] encodedBeefyVoteMessage) {
-        log.log(Level.FINE, "Sending vote message to peer " + stream.remotePeerId());
-        stream.writeAndFlush(encodedBeefyVoteMessage);
+    public void writeMessage(Stream stream, byte[] encodedMessage) {
+        log.log(Level.FINE, "Sending beefy message to peer " + stream.remotePeerId());
+        stream.writeAndFlush(encodedMessage);
     }
 
     private void handleInitiatorStreamMessage(BeefyMessageType messageType, Stream stream) {

--- a/src/main/java/com/limechain/network/protocol/beefy/BeefyService.java
+++ b/src/main/java/com/limechain/network/protocol/beefy/BeefyService.java
@@ -21,18 +21,21 @@ public class BeefyService extends NetworkService<Beefy> {
     }
 
     /**
-     * Sends a beefy vote message to a peer. If there is no initiator stream opened with the peer,
+     * Sends a BEEFY message to a peer.
+     * <p>
+     * Sends both vote messages and signed commitments, as both are transmitted over
+     * the same initiator stream. If there is no initiator stream opened with the peer,
      * sends a handshake instead.
-     *
-     * @param us our host object
-     * @param peerId message receiver
-     * @param encodedMessage scale encoded representation of the BeefyVoteMessage object
+     * </p>
+     * @param us our host object.
+     * @param peerId the message receiver.
+     * @param encodedMessage a scale encoded representation of either a BeefyVoteMessage or a SignedCommitment.
      */
-    public void sendVoteMessage(Host us, PeerId peerId, byte[] encodedMessage) {
+    public void sendMessage(Host us, PeerId peerId, byte[] encodedMessage) {
         Optional.ofNullable(connectionManager.getPeerInfo(peerId))
                 .map(p -> p.getBeefyStreams().getInitiator())
                 .ifPresentOrElse(
-                        stream -> new BeefyController(stream).sendVoteMessage(encodedMessage),
+                        stream -> new BeefyController(stream).sendMessage(encodedMessage),
                         () -> sendHandshake(us, peerId)
                 );
     }


### PR DESCRIPTION
# Description

- The node broadcasts Vote/Justification Messages in vote() and triageIncomintVote() methods. The handleVote() result decides which one to send. If it returns a SignedCommitment, send a Justification; otherwise, forward an external vote or broadcast a self-created vote.
- We use a single beefy stream: after scale-encoding the Vote/Justification and converting it to a byte array, a single method is invoked in BeefyController, BeefyService, and BeefyEngine for both types of beefy messages.

Fixes https://github.com/LimeChain/Fruzhin/issues/818

## Checklist:
- [X] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [X] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.