### PR TITLE
fix: babe validators flow

### DIFF
--- a/src/main/java/com/limechain/consensus/babe/Authorship.java
+++ b/src/main/java/com/limechain/consensus/babe/Authorship.java
@@ -35,6 +35,7 @@ public class Authorship {
         EpochData nextEpochData = epochState.getNextEpochData() != null
                 ? epochState.getNextEpochData()
                 : epochState.getCurrentEpochData();
+
         EpochDescriptor nextEpochDescriptor = epochState.getNextEpochDescriptor() != null
                 ? epochState.getNextEpochDescriptor()
                 : epochState.getCurrentEpochDescriptor();

--- a/src/main/java/com/limechain/consensus/babe/BabeService.java
+++ b/src/main/java/com/limechain/consensus/babe/BabeService.java
@@ -188,7 +188,7 @@ public class BabeService implements SlotChangeListener {
         Authority authority = stateManager.getEpochState()
                 .getCurrentEpochData()
                 .getAuthorities()
-                .get((int) digest.getAuthorityIndex()); // this is not self casting
+                .get(digest.getAuthorityIndexAsInt());
 
         Schnorrkel.KeyPair keyPair = keyStore.getKeyPair(KeyType.BABE, authority.getPublicKey())
                 .map(keyStore::convertToSchnorrKeypair)

--- a/src/main/java/com/limechain/consensus/babe/BabeService.java
+++ b/src/main/java/com/limechain/consensus/babe/BabeService.java
@@ -4,8 +4,10 @@ import com.limechain.consensus.babe.coordinator.SlotChangeEvent;
 import com.limechain.consensus.babe.coordinator.SlotChangeListener;
 import com.limechain.consensus.babe.dto.InherentData;
 import com.limechain.consensus.babe.dto.InherentType;
+import com.limechain.consensus.babe.dto.ParachainInherentData;
 import com.limechain.consensus.babe.dto.Slot;
 import com.limechain.consensus.babe.dto.predigest.BabePreDigest;
+import com.limechain.consensus.babe.scale.predigest.ParachainInherentDataWriter;
 import com.limechain.consensus.babe.scale.predigest.PreDigestWriter;
 import com.limechain.consensus.dto.Authority;
 import com.limechain.exception.misc.BabeGenericException;
@@ -43,7 +45,6 @@ import org.springframework.stereotype.Component;
 import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -72,14 +73,20 @@ public class BabeService implements SlotChangeListener {
         this.blockHandler = blockHandler;
     }
 
-    private void executeEpochLottery(BigInteger epochIndex) {
+    private void executeEpochLottery(BigInteger epochIndex, BigInteger currentSlotNumber) {
+
         EpochState epochState = stateManager.getEpochState();
         var epochStartSlotNumber = epochState.getEpochStartSlotNumber(epochIndex);
         var epochEndSlotNumber = epochStartSlotNumber.add(epochState.getEpochLength());
 
-        for (BigInteger slot = epochStartSlotNumber;
+        var start = currentSlotNumber.compareTo(epochStartSlotNumber) > 0
+                ? currentSlotNumber
+                : epochStartSlotNumber;
+
+        for (BigInteger slot = start;
              slot.compareTo(epochEndSlotNumber) < 0;
              slot = slot.add(BigInteger.ONE)) {
+
             BabePreDigest babePreDigest = Authorship.claimSlot(epochState, slot, keyStore);
             if (babePreDigest != null) {
                 slotToPreRuntimeDigest.put(slot, babePreDigest);
@@ -88,13 +95,13 @@ public class BabeService implements SlotChangeListener {
     }
 
     private void handleSlot(Slot slot, BabePreDigest preDigest) {
-        log.fine(String.format("Producing block for slot %s in epoch %s.",
-                slot.getNumber(), slot.getEpochIndex()));
 
         Block block;
         try {
             BlockHeader parentHeader = getParentBlockHeader(slot.getNumber());
             block = produceBlock(parentHeader, slot, preDigest);
+            log.info(String.format("Producing block for slot %s in epoch %s.", slot.getNumber(), slot.getEpochIndex()));
+
         } catch (Exception e) {
             log.warning(String.format("Exception producing block: %s", e.getMessage()));
             return;
@@ -106,7 +113,8 @@ public class BabeService implements SlotChangeListener {
     private Block produceBlock(BlockHeader parentHeader, Slot slot, BabePreDigest preDigest) {
         BlockHeader newBlockHeader = new BlockHeader();
         newBlockHeader.setParentHash(parentHeader.getHash());
-        newBlockHeader.setBlockNumber(slot.getNumber().add(BigInteger.ONE));
+        newBlockHeader.setBlockNumber(parentHeader.getBlockNumber().add(BigInteger.ONE));
+        newBlockHeader.setDigest(producePreRuntimeDigest(newBlockHeader, preDigest));
 
         BlockState blockState = stateManager.getBlockState();
         Runtime runtime = blockState.getRuntime(parentHeader.getHash());
@@ -115,7 +123,7 @@ public class BabeService implements SlotChangeListener {
 
         log.fine("Initialized block via runtime call.");
 
-        ExtrinsicArray inherents = produceBlockInherents(slot, newRuntime);
+        ExtrinsicArray inherents = produceBlockInherents(slot, newRuntime, parentHeader);
         log.fine("Finished with inherents for block.");
 
         List<ValidTransaction> transactions = produceBlockTransactions(slot, newRuntime);
@@ -130,7 +138,8 @@ public class BabeService implements SlotChangeListener {
         }
         log.fine("Finished with finalizing block.");
 
-        finalizedHeader.setDigest(produceDigests(finalizedHeader, preDigest));
+        finalizedHeader.setDigest(produceSealDigest(finalizedHeader, preDigest));
+
         log.fine("Finished with digests for block.");
 
         List<Extrinsic> bodyExtrinsics = new ArrayList<>(Arrays.asList(inherents.getExtrinsics()));
@@ -145,29 +154,48 @@ public class BabeService implements SlotChangeListener {
         return new Block(finalizedHeader, body);
     }
 
-    private HeaderDigest[] produceDigests(BlockHeader header, BabePreDigest digest) {
-        // Make a copy of the digests from the header.
-        int length = header.getDigest().length;
-        HeaderDigest[] newDigests = Arrays.copyOf(header.getDigest(), length + 2);
+    private HeaderDigest[] producePreRuntimeDigest(BlockHeader header, BabePreDigest digest) {
 
-        // Setup pre-digest.
+        HeaderDigest[] existingDigests = header.getDigest();
+        int length = existingDigests != null
+                ? existingDigests.length
+                : 0;
+
+        HeaderDigest[] updatedDigests = existingDigests != null
+                ? Arrays.copyOf(existingDigests, length + 1)
+                : new HeaderDigest[1];
+
         HeaderDigest preDigest = new HeaderDigest();
         preDigest.setId(ConsensusEngine.BABE);
         preDigest.setType(DigestType.PRE_RUNTIME);
         preDigest.setMessage(ScaleUtils.Encode.encode(PreDigestWriter.getInstance(), digest));
 
-        newDigests[length + 1] = preDigest;
+        updatedDigests[length] = preDigest;
+        return updatedDigests;
+    }
 
-        Authority auth = stateManager.getEpochState().getCurrentEpochData().getAuthorities()
-                .get((int) digest.getAuthorityIndex());
+    private HeaderDigest[] produceSealDigest(BlockHeader header, BabePreDigest digest) {
 
-        Schnorrkel.KeyPair keyPair = keyStore.getKeyPair(KeyType.BABE, auth.getPublicKey())
+        HeaderDigest[] existingDigests = header.getDigest();
+        int length = existingDigests != null
+                ? existingDigests.length
+                : 0;
+
+        HeaderDigest[] updatedDigests = existingDigests != null
+                ? Arrays.copyOf(existingDigests, length + 1)
+                : new HeaderDigest[1];
+
+        Authority authority = stateManager.getEpochState()
+                .getCurrentEpochData()
+                .getAuthorities()
+                .get((int) digest.getAuthorityIndex()); // this is not self casting
+
+        Schnorrkel.KeyPair keyPair = keyStore.getKeyPair(KeyType.BABE, authority.getPublicKey())
                 .map(keyStore::convertToSchnorrKeypair)
-                .orElseThrow(() -> new KeyStoreException("No KeyPair found for provided pub key."));
+                .orElseThrow(() -> new KeyStoreException("No key pair found for provided public key."));
 
-        newDigests[length + 2] = DigestHelper.buildSealHeaderDigest(header, keyPair);
-
-        return newDigests;
+        updatedDigests[length] = DigestHelper.buildSealHeaderDigest(header, keyPair);
+        return updatedDigests;
     }
 
     private List<ValidTransaction> produceBlockTransactions(Slot slot, Runtime runtime) {
@@ -186,7 +214,7 @@ public class BabeService implements SlotChangeListener {
         while (timeout.isPositive()) {
             timeout = Duration.between(Instant.now(), slotEnd);
             // Next-Ready-Extrinsic
-            ValidTransaction transaction = transactionState.pollTransactionWithTimer(timeout.get(ChronoUnit.MILLIS));
+            ValidTransaction transaction = transactionState.pollTransactionWithTimer(timeout.toMillis());
 
             boolean isTimedOut = transaction == null;
             if (isTimedOut) {
@@ -221,19 +249,24 @@ public class BabeService implements SlotChangeListener {
         return toAdd;
     }
 
-    private ExtrinsicArray produceBlockInherents(Slot slot, Runtime runtime) {
+    private ExtrinsicArray produceBlockInherents(Slot slot, Runtime runtime, BlockHeader parentHeader) {
         InherentData inherentData = new InherentData();
 
-        inherentData.getData().put(InherentType.TIMESTAMP0.toByteArray(),
-                ScaleUtils.Encode.encode(new UInt64Writer(), BigInteger.valueOf(slot.getStart().toEpochMilli())));
+        BigInteger timestamp = BigInteger.valueOf(slot.getStart().toEpochMilli());
+        BigInteger slotNumber = slot.getNumber();
+        ParachainInherentData parachainInherentData = new ParachainInherentData(parentHeader);
 
-        inherentData.getData().put(InherentType.BABESLOT.toByteArray(),
-                ScaleUtils.Encode.encode(new UInt64Writer(), slot.getNumber()));
+        var encodedTimestamp = ScaleUtils.Encode.encode(new UInt64Writer(), timestamp);
+        var encodedSlotNumber = ScaleUtils.Encode.encode(new UInt64Writer(), slotNumber);
+        var encodedParachainInherentData = ScaleUtils.Encode.encode(ParachainInherentDataWriter.getInstance(),
+                parachainInherentData);
+
+        inherentData.getData().put(InherentType.TIMESTAMP0, encodedTimestamp);
+        inherentData.getData().put(InherentType.BABESLOT, encodedSlotNumber);
 
         // Empty till we find out what this exactly is used for.
-        inherentData.getData().put(InherentType.PARACHN0.toByteArray(), new byte[]{});
-        // Empty till we find out what this exactly is used for.
-        inherentData.getData().put(InherentType.NEWHEADS.toByteArray(), new byte[]{});
+        inherentData.getData().put(InherentType.PARACHN0, encodedParachainInherentData);
+        inherentData.getData().put(InherentType.NEWHEADS, new byte[]{0});
 
         ExtrinsicArray inherentExtrinsics = runtime.inherentExtrinsics(inherentData);
 
@@ -256,7 +289,9 @@ public class BabeService implements SlotChangeListener {
             throw new BlockStorageGenericException("Could not get best block header");
         }
 
-        boolean parentIsGenesis = blockState.getGenesisBlockHeader().getHash().equals(parentHeader.getHash());
+        boolean parentIsGenesis = blockState.getGenesisBlockHash().getGenesisHash()
+                .equals(parentHeader.getHash());
+
         if (!parentIsGenesis) {
             BigInteger bestBlockSlotNum = DigestHelper.getBabePreRuntimeDigest(parentHeader.getDigest())
                     .orElseThrow(() ->
@@ -290,9 +325,16 @@ public class BabeService implements SlotChangeListener {
             asyncExecutor.executeAndForget(() -> handleSlot(slot, preDigest));
         }
 
+        // This check is intended when the node is running on network without any blocks
+        BlockState blockState = stateManager.getBlockState();
+        if (slotToPreRuntimeDigest.isEmpty() &&
+                blockState.getGenesisBlockHash().getGenesisHash().equals(blockState.getLastFinalized())) {
+            executeEpochLottery(BigInteger.ZERO, slot.getNumber());
+        }
+
         if (event.isLastSlotFromCurrentEpoch()) {
             BigInteger nextEpochIndex = slot.getEpochIndex().add(BigInteger.ONE);
-            executeEpochLottery(nextEpochIndex);
+            executeEpochLottery(nextEpochIndex, BigInteger.ZERO);
         }
     }
 }

--- a/src/main/java/com/limechain/consensus/babe/BlockProductionVerifier.java
+++ b/src/main/java/com/limechain/consensus/babe/BlockProductionVerifier.java
@@ -66,7 +66,7 @@ public class BlockProductionVerifier implements SlotChangeListener {
         }
 
         // TODO Key should be available before the start of the method so that we avoid duplicate code.
-        byte[] authorityPublicKey = getAuthority(authorities, (int) preDigest.getAuthorityIndex())
+        byte[] authorityPublicKey = getAuthority(authorities, preDigest.getAuthorityIndexAsInt())
                 .getPublicKey();
         byte[] signatureData = sealDigest.getMessage();
         VerifySignature signature = new VerifySignature(
@@ -96,7 +96,7 @@ public class BlockProductionVerifier implements SlotChangeListener {
             case BABE_PRIMARY -> {
                 VrfOutputAndProof vrfOutputAndProof = VrfOutputAndProof.wrap(
                         preDigest.getVrfOutput(), preDigest.getVrfProof());
-                return isPrimarySlotWinnerValid((int) preDigest.getAuthorityIndex(),
+                return isPrimarySlotWinnerValid(preDigest.getAuthorityIndexAsInt(),
                         preDigest.getSlotNumber(),
                         authorities,
                         randomness,
@@ -107,7 +107,7 @@ public class BlockProductionVerifier implements SlotChangeListener {
             case BABE_SECONDARY_VRF -> {
                 VrfOutputAndProof vrfOutputAndProof = VrfOutputAndProof.wrap(
                         preDigest.getVrfOutput(), preDigest.getVrfProof());
-                return isSecondaryVrfSlotWinnerValid((int) preDigest.getAuthorityIndex(),
+                return isSecondaryVrfSlotWinnerValid(preDigest.getAuthorityIndexAsInt(),
                         preDigest.getSlotNumber(),
                         authorities,
                         randomness,
@@ -115,7 +115,7 @@ public class BlockProductionVerifier implements SlotChangeListener {
                         vrfOutputAndProof);
             }
             case BABE_SECONDARY_PLAIN -> {
-                return isSecondaryPlainSlotWinnerValid((int) preDigest.getAuthorityIndex(),
+                return isSecondaryPlainSlotWinnerValid(preDigest.getAuthorityIndexAsInt(),
                         preDigest.getSlotNumber(),
                         authorities,
                         randomness);

--- a/src/main/java/com/limechain/consensus/babe/EpochState.java
+++ b/src/main/java/com/limechain/consensus/babe/EpochState.java
@@ -68,8 +68,8 @@ public class EpochState extends AbstractState implements ServiceConsensusState {
     }
 
     public void switchEpoch() {
-        currentEpochData = nextEpochData;
-        currentEpochDescriptor = nextEpochDescriptor;
+        if (nextEpochData != null) currentEpochData = nextEpochData;
+        if (nextEpochDescriptor != null) currentEpochDescriptor = nextEpochDescriptor;
     }
 
     public void setGenesisSlotNumber(BigInteger retrievedGenesisSlotNumber) {

--- a/src/main/java/com/limechain/consensus/babe/dto/InherentData.java
+++ b/src/main/java/com/limechain/consensus/babe/dto/InherentData.java
@@ -13,5 +13,5 @@ public class InherentData {
     /**
      * The key are the bytes of an {@link InherentType} and the value are scale encoded bytes. Retains insertion order.
      */
-    private final LinkedHashMap<byte[], byte[]> data = new LinkedHashMap<>();
+    private final LinkedHashMap<InherentType, byte[]> data = new LinkedHashMap<>();
 }

--- a/src/main/java/com/limechain/consensus/babe/dto/ParachainInherentData.java
+++ b/src/main/java/com/limechain/consensus/babe/dto/ParachainInherentData.java
@@ -1,0 +1,18 @@
+package com.limechain.consensus.babe.dto;
+
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ParachainInherentData {
+
+    private BlockHeader parentHeader;
+    // currently fields below aren't used, so they are omitted
+//    private List<> bitfields;
+//    private List<> backedCandidates;
+//    private List<> disputes;
+}

--- a/src/main/java/com/limechain/consensus/babe/dto/predigest/BabePreDigest.java
+++ b/src/main/java/com/limechain/consensus/babe/dto/predigest/BabePreDigest.java
@@ -15,4 +15,12 @@ public class BabePreDigest {
      private BigInteger slotNumber;
      private byte[] vrfOutput;
      private byte[] vrfProof;
+
+     public int getAuthorityIndexAsInt() {
+          if (authorityIndex < 0 || authorityIndex > Integer.MAX_VALUE) {
+               throw new IllegalArgumentException("Authority index out of valid int range: " + authorityIndex);
+          }
+
+          return (int) authorityIndex;
+     }
 }

--- a/src/main/java/com/limechain/consensus/babe/scale/predigest/ParachainInherentDataWriter.java
+++ b/src/main/java/com/limechain/consensus/babe/scale/predigest/ParachainInherentDataWriter.java
@@ -1,0 +1,30 @@
+package com.limechain.consensus.babe.scale.predigest;
+
+import com.limechain.consensus.babe.dto.ParachainInherentData;
+import com.limechain.network.protocol.blockannounce.scale.BlockHeaderScaleWriter;
+import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import io.emeraldpay.polkaj.scale.ScaleWriter;
+import io.emeraldpay.polkaj.scale.writer.ListWriter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class ParachainInherentDataWriter implements ScaleWriter<ParachainInherentData> {
+
+    private static final ParachainInherentDataWriter INSTANCE = new ParachainInherentDataWriter();
+
+    private ParachainInherentDataWriter() {}
+
+    public static ParachainInherentDataWriter getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void write(ScaleCodecWriter writer, ParachainInherentData parachainInherentData) throws IOException {
+        // currently bitfields, backedCandidates, disputes fields aren't used, so we encode them directly as empty lists
+        new ListWriter<>(getInstance()).write(writer, new ArrayList<>());
+        new ListWriter<>(getInstance()).write(writer, new ArrayList<>());
+        new ListWriter<>(getInstance()).write(writer, new ArrayList<>());
+        writer.write(BlockHeaderScaleWriter.getInstance(), parachainInherentData.getParentHeader());
+    }
+}

--- a/src/main/java/com/limechain/consensus/babe/scale/predigest/PreDigestWriter.java
+++ b/src/main/java/com/limechain/consensus/babe/scale/predigest/PreDigestWriter.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 
 public class PreDigestWriter implements ScaleWriter<BabePreDigest> {
 
-    private static final PreDigestWriter  INSTANCE = new PreDigestWriter();
+    private static final PreDigestWriter INSTANCE = new PreDigestWriter();
 
     private final UInt64Writer uint64Writer;
 

--- a/src/main/java/com/limechain/consensus/grandpa/round/PreVoteStage.java
+++ b/src/main/java/com/limechain/consensus/grandpa/round/PreVoteStage.java
@@ -29,7 +29,7 @@ public class PreVoteStage implements StageState {
             }
         });
 
-        log.info(String.format("Round #{}: Start prevote stage", round.getRoundNumber()));
+        log.info(String.format("Round #%d: Start prevote stage", round.getRoundNumber()));
         long delay = (DURATION * 2) - (System.currentTimeMillis() - round.getStartTime().toEpochMilli());
 
         round.setOnStageTimerHandler(Executors.newScheduledThreadPool(1));

--- a/src/main/java/com/limechain/constants/GenesisBlockHash.java
+++ b/src/main/java/com/limechain/constants/GenesisBlockHash.java
@@ -2,6 +2,7 @@ package com.limechain.constants;
 
 import com.google.protobuf.ByteString;
 import com.limechain.chain.ChainService;
+import com.limechain.exception.global.RuntimeCodeException;
 import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.network.protocol.warp.dto.HeaderDigest;
 import com.limechain.trie.TrieStructureFactory;
@@ -14,6 +15,7 @@ import lombok.Getter;
 import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -23,6 +25,7 @@ import java.util.Map;
 @Component
 @Getter
 public class GenesisBlockHash {
+
     private final Hash256 genesisHash;
     private final Map<ByteString, ByteString> genesisStorage;
     private final TrieStructure<NodeData> genesisTrie;
@@ -54,6 +57,17 @@ public class GenesisBlockHash {
         blockHeader.setDigest(new HeaderDigest[0]);
 
         return blockHeader;
+    }
+
+    public byte[] getRuntimeWasmFromGenesis() {
+        ByteString key = ByteString.copyFrom(":code".getBytes(StandardCharsets.UTF_8));
+        ByteString wasm = genesisStorage.get(key);
+
+        if (wasm == null) {
+            throw new RuntimeCodeException("Genesis storage is missing the :code key");
+        }
+
+        return wasm.toByteArray();
     }
 
     /**

--- a/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockHeaderScaleWriter.java
+++ b/src/main/java/com/limechain/network/protocol/blockannounce/scale/BlockHeaderScaleWriter.java
@@ -6,11 +6,13 @@ import com.limechain.network.protocol.warp.dto.HeaderDigest;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
 import io.emeraldpay.polkaj.scale.ScaleWriter;
 import io.emeraldpay.polkaj.scale.writer.ListWriter;
+import io.emeraldpay.polkaj.types.Hash256;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -38,14 +40,27 @@ public class BlockHeaderScaleWriter implements ScaleWriter<BlockHeader> {
         // NOTE: Usage of BlockNumberWriter is intentionally omitted here,
         //  since we want this to be a compact int, not a var size int
         writer.writeCompact(blockHeader.getBlockNumber().intValueExact());
-        writer.writeUint256(blockHeader.getStateRoot().getBytes());
-        writer.writeUint256(blockHeader.getExtrinsicsRoot().getBytes());
 
-        // filter out the seal if we're writing unsealed
-        List<HeaderDigest> digestItems = Arrays.stream(blockHeader.getDigest())
-            .filter(digest -> sealed || digest.getType() != DigestType.SEAL)
-            .toList();
+        writeHashOrEmpty(writer, blockHeader.getStateRoot());
+        writeHashOrEmpty(writer, blockHeader.getExtrinsicsRoot());
 
+        List<HeaderDigest> digestItems = getFilteredDigests(blockHeader, sealed);
         new ListWriter<>(headerDigestScaleWriter).write(writer, digestItems);
+    }
+
+    private void writeHashOrEmpty(ScaleCodecWriter writer, Hash256 hash) throws IOException {
+        byte[] bytes = (hash != null) ? hash.getBytes() : new byte[32];
+        writer.writeUint256(bytes);
+    }
+
+    private List<HeaderDigest> getFilteredDigests(BlockHeader blockHeader, boolean sealed) {
+
+        if (blockHeader.getDigest() == null || blockHeader.getDigest().length == 0) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(blockHeader.getDigest())
+                .filter(digest -> sealed || digest.getType() != DigestType.SEAL)
+                .toList();
     }
 }

--- a/src/main/java/com/limechain/rpc/config/CommonConfig.java
+++ b/src/main/java/com/limechain/rpc/config/CommonConfig.java
@@ -40,6 +40,7 @@ import java.util.List;
 @Configuration
 @EnableScheduling
 public class CommonConfig {
+
     @Bean
     public static AutoJsonRpcServiceImplExporter autoJsonRpcServiceImplExporter() {
         final var jsonService = new AutoJsonRpcServiceImplExporter();
@@ -138,5 +139,4 @@ public class CommonConfig {
     public GenesisBlockHash genesisBlockHash(ChainService chainService) {
         return new GenesisBlockHash(chainService);
     }
-
 }

--- a/src/main/java/com/limechain/runtime/RuntimeEndpoint.java
+++ b/src/main/java/com/limechain/runtime/RuntimeEndpoint.java
@@ -24,7 +24,7 @@ public enum RuntimeEndpoint {
     BLOCKBUILDER_FINALIZE_BLOCK("BlockBuilder_finalize_block"),
     BLOCKBUILDER_CHECK_INHERENTS("BlockBuilder_check_inherents"),
     BLOCKBUILDER_APPLY_EXTRINISIC("BlockBuilder_apply_extrinsic"),
-    BLOCKBUILDER_INHERENT_EXTRINISICS("BlockBuilder_inherent_extrinisics"),
+    BLOCKBUILDER_INHERENT_EXTRINISICS("BlockBuilder_inherent_extrinsics"),
     METADATA_METADATA("Metadata_metadata"),
     SESSION_KEYS_GENERATE_SESSION_KEYS("SessionKeys_generate_session_keys"),
     SESSION_KEYS_DECODE_SESSION_KEYS("SessionKeys_decode_session_keys"),

--- a/src/main/java/com/limechain/runtime/RuntimeImpl.java
+++ b/src/main/java/com/limechain/runtime/RuntimeImpl.java
@@ -178,7 +178,6 @@ public class RuntimeImpl implements Runtime {
         return ScaleUtils.Decode.decode(encodedResponse, BlockHeaderReader.getInstance());
     }
 
-
     @Override
     public byte[] checkInherents(Block block, InherentData inherentData) {
         byte[] encodedRequest = serializeCheckInherentsParameter(block, inherentData);

--- a/src/main/java/com/limechain/storage/block/state/BlockState.java
+++ b/src/main/java/com/limechain/storage/block/state/BlockState.java
@@ -14,8 +14,10 @@ import com.limechain.network.protocol.warp.dto.BlockHeader;
 import com.limechain.network.protocol.warp.dto.Justification;
 import com.limechain.network.protocol.warp.scale.reader.BlockBodyReader;
 import com.limechain.network.protocol.warp.scale.writer.BlockBodyWriter;
+import com.limechain.rpc.server.AppBean;
 import com.limechain.rpc.subscriptions.chainsub.ChainSub;
 import com.limechain.runtime.Runtime;
+import com.limechain.runtime.RuntimeBuilder;
 import com.limechain.state.AbstractState;
 import com.limechain.storage.DBConstants;
 import com.limechain.storage.KVRepository;
@@ -53,15 +55,17 @@ public class BlockState extends AbstractState {
 
     private final Map<Hash256, Block> unfinalizedBlocks;
     private final LinkedHashMap<Hash256, Justification> justifications;
-    private final BlockHeader genesisBlockHeader;
+    private final GenesisBlockHash genesisBlockHash;
     private BlockTree blockTree;
     private Hash256 lastFinalized;
 
-    public BlockState(KVRepository<String, Object> db, GenesisBlockHash genesisBlockHash) {
+    public BlockState(KVRepository<String, Object> db,
+                      GenesisBlockHash genesisBlockHash) {
+
         this.db = db;
-        unfinalizedBlocks = new HashMap<>();
-        justifications = new LinkedHashMap<>();
-        genesisBlockHeader = genesisBlockHash.getGenesisBlockHeader();
+        this.unfinalizedBlocks = new HashMap<>();
+        this.justifications = new LinkedHashMap<>();
+        this.genesisBlockHash = genesisBlockHash;
     }
 
     @Override
@@ -71,18 +75,24 @@ public class BlockState extends AbstractState {
         }
         initialized = true;
 
-        blockTree = new BlockTree(genesisBlockHeader);
+        Hash256 genesisHash = genesisBlockHash.getGenesisHash();
+        BlockHeader genesisHeader = genesisBlockHash.getGenesisBlockHeader();
 
-        Hash256 genesisBlockHash = genesisBlockHeader.getHash();
-        lastFinalized = genesisBlockHash;
+        blockTree = new BlockTree(genesisHeader);
+        lastFinalized = genesisHash;
 
-        setArrivalTime(genesisBlockHash, Instant.now());
-        setHeader(genesisBlockHeader);
-        db.save(BlockStateHelper.headerHashKey(genesisBlockHeader.getBlockNumber()), genesisBlockHash);
-        setBlockBody(genesisBlockHash, new BlockBody(new ArrayList<>()));
+        setArrivalTime(genesisHash, Instant.now());
+        setHeader(genesisHeader);
+        db.save(BlockStateHelper.headerHashKey(genesisHeader.getBlockNumber()), genesisHash);
+        setBlockBody(genesisHash, new BlockBody(new ArrayList<>()));
 
         //set the latest finalized head to the genesis header
-        finalizeBlock(genesisBlockHeader, BigInteger.ZERO, BigInteger.ZERO);
+        finalizeBlock(genesisHeader, BigInteger.ZERO, BigInteger.ZERO);
+
+        RuntimeBuilder runtimeBuilder = AppBean.getBean(RuntimeBuilder.class);
+        byte[] genesisRuntimeWasm = genesisBlockHash.getRuntimeWasmFromGenesis();
+        Runtime runtime = runtimeBuilder.buildRuntime(genesisRuntimeWasm);
+        storeRuntime(genesisHash, runtime);
     }
 
     @Override
@@ -364,6 +374,7 @@ public class BlockState extends AbstractState {
         if (!unfinalizedBlocks.containsKey(block.getHeader().getHash())) {
             ChainSub.getInstance().notifyNewChainHead(block.getHeader());
         }
+
         // Store block in unfinalized blocks
         unfinalizedBlocks.put(block.getHeader().getHash(), block);
     }
@@ -781,7 +792,7 @@ public class BlockState extends AbstractState {
             throw new BlockNodeNotFoundException("Cannot finalise unknown block " + hash);
         }
 
-        if (!hash.equals(genesisBlockHeader.getHash())
+        if (!hash.equals(genesisBlockHash.getGenesisHash())
                 && getHighestFinalizedNumber().compareTo(header.getBlockNumber()) >= 0) {
             throw new LowerThanRootException("Finalized block with number "
                     + header.getBlockNumber() + " is lower than root");
@@ -806,8 +817,8 @@ public class BlockState extends AbstractState {
 
         // if nothing was previously finalized, set the first slot of the network to the
         // slot number of block 1, which is now being set as final
-        if (Objects.equals(this.lastFinalized, genesisBlockHeader.getHash())
-                && Objects.equals(hash, genesisBlockHeader.getHash())) {
+        if (Objects.equals(this.lastFinalized, genesisBlockHash.getGenesisHash())
+                && Objects.equals(hash, genesisBlockHash.getGenesisHash())) {
             //TODO: Implement when BABE is implemented - setFirstSlotOnFinalisation
         }
 
@@ -912,7 +923,7 @@ public class BlockState extends AbstractState {
         List<Hash256> subchain = rangeInMemory(lastFinalized, currentFinalizedHash);
 
         for (Hash256 subchainHash : subchain) {
-            if (Objects.equals(subchainHash, genesisBlockHeader.getHash())) {
+            if (Objects.equals(subchainHash, genesisBlockHash.getGenesisHash())) {
                 continue;
             }
 

--- a/src/main/java/com/limechain/sync/warpsync/action/VerifyJustificationAction.java
+++ b/src/main/java/com/limechain/sync/warpsync/action/VerifyJustificationAction.java
@@ -86,10 +86,14 @@ public class VerifyJustificationAction implements WarpSyncAction {
                 .forEach(cm -> stateManager.getGrandpaSetState().handleGrandpaConsensusMessage(
                         cm, header)
                 );
+
         DigestHelper.getBeefyConsensusMessages(header.getDigest())
                 .forEach(cm -> stateManager.getBeefyState().handleBeefyConsensusMessage(
                         cm, header.getBlockNumber())
                 );
+
+        DigestHelper.getBabeConsensusMessages(header.getDigest())
+                .forEach(cm -> stateManager.getEpochState().updateNextEpochConfig(cm));
 
         SyncState syncState = stateManager.getSyncState();
         log.log(Level.INFO, "Verified justification. Block hash is now at #"

--- a/src/main/java/com/limechain/utils/scale/writers/BlockInherentsWriter.java
+++ b/src/main/java/com/limechain/utils/scale/writers/BlockInherentsWriter.java
@@ -1,15 +1,15 @@
 package com.limechain.utils.scale.writers;
 
 import com.limechain.consensus.babe.dto.InherentData;
+import com.limechain.consensus.babe.dto.InherentType;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
 import io.emeraldpay.polkaj.scale.ScaleWriter;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.javatuples.Pair;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.Map;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class BlockInherentsWriter implements ScaleWriter<InherentData> {
@@ -21,16 +21,16 @@ public class BlockInherentsWriter implements ScaleWriter<InherentData> {
     }
 
     public void write(ScaleCodecWriter writer, InherentData request) throws IOException {
-        LinkedHashMap<byte[], byte[]> data = request.getData();
+
+        LinkedHashMap<InherentType, byte[]> data = request.getData();
         writer.writeCompact(data.size());
 
-        List<Pair<byte[], byte[]>> pairs = data.entrySet().stream()
-                .map(e -> new Pair<>(e.getKey(), e.getValue()))
-                .toList();
+        for (Map.Entry<InherentType, byte[]> entry : data.entrySet()) {
+            byte[] key = entry.getKey().toByteArray();
+            byte[] value = entry.getValue();
 
-        for (Pair<byte[], byte[]> pair : pairs) {
-            writer.writeByteArray(pair.getValue0());
-            writer.writeAsList(pair.getValue1());
+            writer.writeByteArray(key);
+            writer.writeAsList(value);
         }
     }
 }


### PR DESCRIPTION
# Description

This PR refactors the BABE validator logic to enable starting a local network from genesis, ensuring proper block production and sealing from the very first block. The changes are backward-compatible and apply seamlessly when acting as a validator on other networks.

Partially fixes:  https://github.com/LimeChain/Fruzhin/issues/422

## Checklist:
- [X] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [X] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.