### PR TITLE
fix: Fix issue with peer kad protocol connectivity.

### DIFF
--- a/src/main/java/com/limechain/cli/Cli.java
+++ b/src/main/java/com/limechain/cli/Cli.java
@@ -33,7 +33,7 @@ public class Cli {
     public static final String RPC_METHODS = "rpc-methods";
     private static final String DB_RECREATE = "db-recreate";
     private static final String NODE_MODE = "node-mode";
-    private static final String NO_LEGACY_PROTOCOLS = "no-legacy-protocols";
+    private static final String USE_LEGACY_PROTOCOLS = "use-legacy-protocols";
     private static final String SYNC_MODE = "sync-mode";
     private static final String PROMETHEUS_PORT = "prometheus-port";
     // The cli arguments below are added so that Zombienet tests can run.
@@ -116,13 +116,13 @@ public class Cli {
             // TODO: separation of enums; this NodeRole enum is used for blockannounce
             //       what does running the node in NodeMode NONE mean?
             String nodeMode = cmd.getOptionValue(NODE_MODE, NodeRole.FULL.toString());
-            boolean noLegacyProtocols = cmd.hasOption(NO_LEGACY_PROTOCOLS);
+            boolean useLegacyProtocols = cmd.hasOption(USE_LEGACY_PROTOCOLS);
             SyncMode syncMode = parseSyncMode(cmd);
             boolean isPublic = cmd.hasOption(PUBLIC_RPC);
             RpcMethods rpcMethods = parseRpcMethods(cmd, isPublic);
             boolean unsafeEnabled = rpcMethods == RpcMethods.UNSAFE;
             int prometheusPort = Integer.parseInt(cmd.getOptionValue(PROMETHEUS_PORT, "9090"));
-            return new CliArguments(network, dbPath, dbRecreate, nodeKey, nodeMode, noLegacyProtocols, syncMode,
+            return new CliArguments(network, dbPath, dbRecreate, nodeKey, nodeMode, useLegacyProtocols, syncMode,
                     unsafeEnabled, prometheusPort);
         } catch (ParseException e) {
             formatter.printHelp("Specify the network name - " + String.join(", ", validChains), options);
@@ -143,7 +143,7 @@ public class Cli {
         Option nodeKey = new Option(null, NODE_KEY, true, "\nHEX for secret Ed25519 key");
         Option nodeMode = new Option("mode", NODE_MODE, true, "\nNode mode (light/full). " +
                 "Full by default.");
-        Option noLegacyProtocols = new Option(null, NO_LEGACY_PROTOCOLS, false,
+        Option useLegacyProtocols = new Option(null, USE_LEGACY_PROTOCOLS, false,
                 "\nDoesn't use legacy protocols if set");
         Option syncMode = new Option(null, SYNC_MODE, true,
                 "\nSync mode (warp/full) - warp by default");
@@ -175,7 +175,7 @@ public class Cli {
         dbClean.setRequired(false);
         nodeKey.setRequired(false);
         nodeMode.setRequired(false);
-        noLegacyProtocols.setRequired(false);
+        useLegacyProtocols.setRequired(false);
         syncMode.setRequired(false);
         publicRpc.setRequired(false);
         rpcMethods.setRequired(false);
@@ -196,7 +196,7 @@ public class Cli {
         result.addOption(dbClean);
         result.addOption(nodeKey);
         result.addOption(nodeMode);
-        result.addOption(noLegacyProtocols);
+        result.addOption(useLegacyProtocols);
         result.addOption(syncMode);
         result.addOption(publicRpc);
         result.addOption(rpcMethods);

--- a/src/main/java/com/limechain/cli/CliArguments.java
+++ b/src/main/java/com/limechain/cli/CliArguments.java
@@ -5,14 +5,15 @@ import com.limechain.sync.SyncMode;
 /**
  * Hold successfully parsed cli arguments
  *
- * @param network           the network
- * @param dbPath            the DB path
- * @param dbRecreate        flag for recreating the database for current network
- * @param nodeKey           HEX for secret Ed25519 key
- * @param noLegacyProtocols flag for disabling legacy protocols
- * @param syncMode          the sync mode
- * @param unsafeRpcEnabled  whether to enable unsafe RPC methods
+ * @param network            the network
+ * @param dbPath             the DB path
+ * @param dbRecreate         flag for recreating the database for current network
+ * @param nodeKey            HEX for secret Ed25519 key
+ * @param useLegacyProtocols flag for using legacy protocols
+ * @param syncMode           the sync mode
+ * @param unsafeRpcEnabled   whether to enable unsafe RPC methods
  */
 public record CliArguments(String network, String dbPath, boolean dbRecreate, String nodeKey, String nodeRole,
-                           boolean noLegacyProtocols, SyncMode syncMode, boolean unsafeRpcEnabled, int prometheusPort) {
+                           boolean useLegacyProtocols, SyncMode syncMode, boolean unsafeRpcEnabled,
+                           int prometheusPort) {
 }

--- a/src/main/java/com/limechain/network/NetworkService.java
+++ b/src/main/java/com/limechain/network/NetworkService.java
@@ -251,24 +251,28 @@ public class NetworkService implements NodeService {
         log.info("Current peerId " + hostBuilder.getPeerId().toString());
         Multihash hostId = Multihash.deserialize(hostBuilder.getPeerId().getBytes());
 
-        String pingProtocol = ProtocolUtils.PING_PROTOCOL;
-        String chainId = chainService.getChainSpec().getProtocolId();
-        boolean legacyProtocol = !cliArgs.noLegacyProtocols();
+        boolean legacyProtocol = cliArgs.useLegacyProtocols();
         String genesisBlockHashWithoutPrefix = StringUtils.remove0xPrefix(genesisBlockHash.getGenesisHash().toString());
-        String protocolId = legacyProtocol ?
-                chainId :
-                genesisBlockHashWithoutPrefix;
+        // The legacy approach was to use the protocol id from the chain spec. The newer approach is to use the
+        // genesis block hash instead.
+        String chainId = legacyProtocol
+                ? chainService.getChainSpec().getProtocolId()
+                : genesisBlockHashWithoutPrefix;
 
+        // Non-Polkadot protocols.
         String kadProtocolId = ProtocolUtils.getKadProtocol(chainId);
-        String warpProtocolId = ProtocolUtils.getWarpSyncProtocol(protocolId);
-        String lightProtocolId = ProtocolUtils.getLightMessageProtocol(protocolId);
-        String syncProtocolId = ProtocolUtils.getSyncProtocol(protocolId);
+        String pingProtocol = ProtocolUtils.PING_PROTOCOL;
+        // Request-response protocols.
+        String syncProtocolId = ProtocolUtils.getSyncProtocol(chainId);
+        String stateProtocolId = ProtocolUtils.getStateProtocol(chainId);
+        String warpProtocolId = ProtocolUtils.getWarpSyncProtocol(chainId);
+        String lightProtocolId = ProtocolUtils.getLightMessageProtocol(chainId);
         String beefyJustificationProtocolId = ProtocolUtils.getBeefyJustificationProtocol(
                 genesisBlockHashWithoutPrefix);
-        String stateProtocolId = ProtocolUtils.getStateProtocol(protocolId);
-        String transactionsProtocolId = ProtocolUtils.getTransactionsProtocol(protocolId);
-        String blockAnnounceProtocolId = ProtocolUtils.getBlockAnnounceProtocol(protocolId);
-        String grandpaProtocolId = ProtocolUtils.getGrandpaProtocol(protocolId, legacyProtocol);
+        // Notification protocols.
+        String transactionsProtocolId = ProtocolUtils.getTransactionsProtocol(chainId);
+        String blockAnnounceProtocolId = ProtocolUtils.getBlockAnnounceProtocol(chainId);
+        String grandpaProtocolId = ProtocolUtils.getGrandpaProtocol(chainId, legacyProtocol);
         String beefyNotificationProtocolId = ProtocolUtils.getBeefyNotificationProtocol(genesisBlockHashWithoutPrefix);
 
         // Non-Polkadot protocols.

--- a/src/main/java/com/limechain/network/ProtocolUtils.java
+++ b/src/main/java/com/limechain/network/ProtocolUtils.java
@@ -23,8 +23,8 @@ public final class ProtocolUtils {
         return String.format("/%s/state/2", chainId);
     }
 
-    public static String getKadProtocol(String chainId) {
-        return String.format("/%s/kad", chainId);
+    public static String getKadProtocol(String genesisBlockHash) {
+        return String.format("/%s/kad", genesisBlockHash);
     }
 
     public static String getTransactionsProtocol(String chainId) {

--- a/src/test/java/com/limechain/cli/CliTest.java
+++ b/src/test/java/com/limechain/cli/CliTest.java
@@ -30,7 +30,7 @@ class CliTest {
         assertTrue(options.hasOption("node-key"));
         assertTrue(options.hasOption("node-mode"));
         assertTrue(options.hasOption("mode"));
-        assertTrue(options.hasOption("no-legacy-protocols"));
+        assertTrue(options.hasOption("use-legacy-protocols"));
         assertTrue(options.hasOption("sync-mode"));
         assertTrue(options.hasOption("public-rpc"));
         assertTrue(options.hasOption("rpc-methods"));


### PR DESCRIPTION
# Issue

Fruzhin had issues connecting to boot nodes. The issue narrowed down to opening a p2p channel on the `/wnd2/kad` protocol. Some westend nodes stoped accepting connections on the legacy protocol strings (eg. /wnd2/kad, others were not confirmed as the kademlia channels were opened first from the polkadot specific ones).

# Solution

The flag `no-legacy-protocols` was switch to `use-legacy-protocols`. This makes the use of non-legacy protocol string the default behavior of the implementation.


## Checklist:
- [X] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [X] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.