### PR TITLE
fix: Fix block import and execution.

### DIFF
--- a/src/main/java/com/limechain/storage/block/BlockHandler.java
+++ b/src/main/java/com/limechain/storage/block/BlockHandler.java
@@ -134,9 +134,9 @@ public class BlockHandler {
             }
 
             newRuntime.executeBlock(block);
-            log.fine(String.format("Executed block No: %s with hash: %s.",
+            log.info(String.format("Executed block No: %s with hash: %s.",
                     block.getHeader().getBlockNumber(), header.getHash()));
-            blockState.storeRuntime(header.getHash(), runtime);
+            blockState.storeRuntime(header.getHash(), newRuntime);
 
             asyncExecutor.executeAndForget(() -> transactionProcessor.maintainTransactionPool(block));
         } catch (Exception e) {


### PR DESCRIPTION
# Issue

After the full sync finishes and we start receiving and executing blocks from the block announce protocol Fruzhin fails with a "Call was labeled mandatory, but resulted in a n error".

# Solution

Store the proper runtime instance when executing every consecutive block.

Fixes #898

## Checklist:
- [X] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [X] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.