### PR TITLE
feat: Implemented syncing of state through rpc.

### DIFF
--- a/src/main/java/com/limechain/config/HostConfig.java
+++ b/src/main/java/com/limechain/config/HostConfig.java
@@ -52,6 +52,13 @@ public class HostConfig {
     @Value("${genesis.path.local}")
     private String localGenesisPath;
 
+    @Value("${sync.state.path.polkadot}")
+    private String polkadotNodePath;
+    @Value("${sync.state.path.kusama}")
+    private String kusamaNodePath;
+    @Value("${sync.state.path.westend}")
+    private String westendNodePath;
+
     public HostConfig(CliArguments cliArguments) {
         this.rocksDbPath = cliArguments.dbPath();
         this.dbRecreate = cliArguments.dbRecreate();
@@ -89,6 +96,20 @@ public class HostConfig {
             case KUSAMA -> kusamaGenesisPath;
             case WESTEND -> westendGenesisPath;
             case LOCAL -> localGenesisPath;
+        };
+    }
+
+    /**
+     * Gets the path to peer node based on the chain the node is configured
+     * Intended to be used when syncing state after warp sync
+     *
+     * @return genesis(chain spec) file path
+     */
+    public String getNodeSynckPath() {
+        return switch (chain) {
+            case POLKADOT, LOCAL -> polkadotNodePath;
+            case KUSAMA -> kusamaNodePath;
+            case WESTEND -> westendNodePath;
         };
     }
 }

--- a/src/main/java/com/limechain/config/HostConfig.java
+++ b/src/main/java/com/limechain/config/HostConfig.java
@@ -107,9 +107,9 @@ public class HostConfig {
      */
     public String getNodeSynckPath() {
         return switch (chain) {
-            case POLKADOT, LOCAL -> polkadotNodePath;
+            case POLKADOT -> polkadotNodePath;
             case KUSAMA -> kusamaNodePath;
-            case WESTEND -> westendNodePath;
+            case WESTEND, LOCAL -> westendNodePath;
         };
     }
 }

--- a/src/main/java/com/limechain/network/NetworkService.java
+++ b/src/main/java/com/limechain/network/NetworkService.java
@@ -150,7 +150,7 @@ public class NetworkService implements NodeService {
     }
 
     public boolean updateCurrentSelectedPeerWithNextBootnode() {
-        if (bootPeerIndex > kademliaService.getBootNodePeerIds().size())
+        if (bootPeerIndex >= kademliaService.getBootNodePeerIds().size())
             return false;
         this.currentSelectedPeer = this.kademliaService.getBootNodePeerIds().get(bootPeerIndex);
         bootPeerIndex++;

--- a/src/main/java/com/limechain/network/protocol/sync/SyncMessages.java
+++ b/src/main/java/com/limechain/network/protocol/sync/SyncMessages.java
@@ -26,7 +26,7 @@ public class SyncMessages extends StrictProtocolBinding<SyncController> {
             SyncMessage.BlockResponse response = controller
                     .sendBlockRequest(blockRequest.getFields(), blockRequest.getHash(), blockRequest.getNumber(),
                             blockRequest.getDirection(), blockRequest.getMaxBlocks())
-                    .get(7, TimeUnit.SECONDS);
+                    .get(10, TimeUnit.SECONDS);
             log.log(Level.FINE, "Received blocks: " + response.getBlocksCount());
             return response;
         } catch (ExecutionException | TimeoutException | IllegalStateException e) {

--- a/src/main/java/com/limechain/network/protocol/sync/SyncMessages.java
+++ b/src/main/java/com/limechain/network/protocol/sync/SyncMessages.java
@@ -26,7 +26,7 @@ public class SyncMessages extends StrictProtocolBinding<SyncController> {
             SyncMessage.BlockResponse response = controller
                     .sendBlockRequest(blockRequest.getFields(), blockRequest.getHash(), blockRequest.getNumber(),
                             blockRequest.getDirection(), blockRequest.getMaxBlocks())
-                    .get(2, TimeUnit.SECONDS);
+                    .get(7, TimeUnit.SECONDS);
             log.log(Level.FINE, "Received blocks: " + response.getBlocksCount());
             return response;
         } catch (ExecutionException | TimeoutException | IllegalStateException e) {

--- a/src/main/java/com/limechain/rpc/client/AbstractRpcClient.java
+++ b/src/main/java/com/limechain/rpc/client/AbstractRpcClient.java
@@ -13,6 +13,7 @@ import java.util.logging.Level;
  */
 @Log
 public abstract class AbstractRpcClient extends WebSocketClient {
+    public static final String REG_EXPRESSION_NUMBER = "-?\\d+(\\.\\d+)?";
 
     protected AbstractRpcClient(URI serverURI) {
         super(serverURI);
@@ -50,9 +51,41 @@ public abstract class AbstractRpcClient extends WebSocketClient {
      * @param params method parameters
      */
     public void send(String method, String[] params) {
-        String message =
-                "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"" + method + "\",\"params\":[" + String.join(",", params) +
-                        "]}";
-        super.send(message);
+        String payload = buildRpcRequest(method, params);
+        super.send(payload);
+    }
+
+    private String buildRpcRequest(String method, String[] params) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{")
+                .append("\"id\":1, ")
+                .append("\"jsonrpc\":\"2.0\", ")
+                .append("\"method\":\"").append(method).append("\", ")
+                .append("\"params\":[");
+
+        for (int i = 0; i < params.length; i++) {
+            builder.append(serializeParam(params[i]));
+            if (i < params.length - 1) {
+                builder.append(", ");
+            }
+        }
+
+        builder.append("]}");
+        return builder.toString();
+    }
+
+    private String serializeParam(String param) {
+        if (param == null) {
+            return "null";
+        }
+        if (isNumeric(param)) {
+            return param;
+        }
+        return "\"" + param + "\"";
+    }
+
+
+    private boolean isNumeric(String str) {
+        return str.matches(REG_EXPRESSION_NUMBER);
     }
 }

--- a/src/main/java/com/limechain/rpc/client/AbstractRpcClient.java
+++ b/src/main/java/com/limechain/rpc/client/AbstractRpcClient.java
@@ -1,6 +1,7 @@
 package com.limechain.rpc.client;
 
 import lombok.extern.java.Log;
+import org.apache.commons.lang3.StringUtils;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 
@@ -13,7 +14,6 @@ import java.util.logging.Level;
  */
 @Log
 public abstract class AbstractRpcClient extends WebSocketClient {
-    public static final String REG_EXPRESSION_NUMBER = "-?\\d+(\\.\\d+)?";
 
     protected AbstractRpcClient(URI serverURI) {
         super(serverURI);
@@ -78,14 +78,9 @@ public abstract class AbstractRpcClient extends WebSocketClient {
         if (param == null) {
             return "null";
         }
-        if (isNumeric(param)) {
+        if (StringUtils.isNumeric(param)) {
             return param;
         }
         return "\"" + param + "\"";
-    }
-
-
-    private boolean isNumeric(String str) {
-        return str.matches(REG_EXPRESSION_NUMBER);
     }
 }

--- a/src/main/java/com/limechain/rpc/client/StateSyncRpcClient.java
+++ b/src/main/java/com/limechain/rpc/client/StateSyncRpcClient.java
@@ -1,0 +1,58 @@
+package com.limechain.rpc.client;
+
+import lombok.extern.java.Log;
+import org.java_websocket.client.WebSocketClient;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Log
+public class StateSyncRpcClient extends AbstractRpcClient {
+    private final Map<WebSocketClient, CompletableFuture<String>> responseMap;
+
+    public StateSyncRpcClient(URI serverUri,
+                              Map<WebSocketClient, CompletableFuture<String>> responseMap) {
+        super(serverUri);
+        this.responseMap = responseMap;
+    }
+
+    @Override
+    public void onMessage(String message) {
+        CompletableFuture<String> future = responseMap.remove(this);
+        if (future != null && !future.isDone()) future.complete(message);
+    }
+
+    @Override
+    public void onError(Exception ex) {
+        CompletableFuture<String> future = responseMap.remove(this);
+        if (future != null && !future.isDone()) future.completeExceptionally(ex);
+    }
+
+
+    @Override
+    public void send(String method, String[] params) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{\"id\":1, \"jsonrpc\":\"2.0\", \"method\": \"")
+                .append(method)
+                .append("\", \"params\":[");
+
+        for (int i = 0; i < params.length; i++) {
+            String param = params[i];
+            if (param == null) {
+                builder.append("null");
+            } else if (param.matches("-?\\d+(\\.\\d+)?")) { // check if it's a number
+                builder.append(param);
+            } else {
+                builder.append("\"").append(param).append("\"");
+            }
+
+            if (i < params.length - 1) {
+                builder.append(", ");
+            }
+        }
+
+        builder.append("]}");
+        super.send(builder.toString());
+    }
+}

--- a/src/main/java/com/limechain/rpc/client/StateSyncRpcClient.java
+++ b/src/main/java/com/limechain/rpc/client/StateSyncRpcClient.java
@@ -28,31 +28,4 @@ public class StateSyncRpcClient extends AbstractRpcClient {
         CompletableFuture<String> future = responseMap.remove(this);
         if (future != null && !future.isDone()) future.completeExceptionally(ex);
     }
-
-
-    @Override
-    public void send(String method, String[] params) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("{\"id\":1, \"jsonrpc\":\"2.0\", \"method\": \"")
-                .append(method)
-                .append("\", \"params\":[");
-
-        for (int i = 0; i < params.length; i++) {
-            String param = params[i];
-            if (param == null) {
-                builder.append("null");
-            } else if (param.matches("-?\\d+(\\.\\d+)?")) { // check if it's a number
-                builder.append(param);
-            } else {
-                builder.append("\"").append(param).append("\"");
-            }
-
-            if (i < params.length - 1) {
-                builder.append(", ");
-            }
-        }
-
-        builder.append("]}");
-        super.send(builder.toString());
-    }
 }

--- a/src/main/java/com/limechain/rpc/client/SyncStateRpcClient.java
+++ b/src/main/java/com/limechain/rpc/client/SyncStateRpcClient.java
@@ -8,10 +8,10 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @Log
-public class StateSyncRpcClient extends AbstractRpcClient {
+public class SyncStateRpcClient extends AbstractRpcClient {
     private final Map<WebSocketClient, CompletableFuture<String>> responseMap;
 
-    public StateSyncRpcClient(URI serverUri,
+    public SyncStateRpcClient(URI serverUri,
                               Map<WebSocketClient, CompletableFuture<String>> responseMap) {
         super(serverUri);
         this.responseMap = responseMap;

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -30,6 +30,7 @@ import com.limechain.storage.trie.TrieStorage;
 import com.limechain.sync.SyncMode;
 import com.limechain.sync.fullsync.inherents.InherentData;
 import com.limechain.sync.state.SyncState;
+import com.limechain.sync.state.SyncStateRequesterRpc;
 import com.limechain.trie.DiskTrieAccessor;
 import com.limechain.trie.TrieAccessor;
 import com.limechain.trie.TrieStructureFactory;
@@ -69,6 +70,7 @@ public class FullSyncMachine {
     private final SlotCoordinator slotCoordinator = AppBean.getBean(SlotCoordinator.class);
     private final GrandpaService grandpaService = AppBean.getBean(GrandpaService.class);
     private final BeefyService beefyService = AppBean.getBean(BeefyService.class);
+    private final SyncStateRequesterRpc syncStateRequesterRpc = AppBean.getBean(SyncStateRequesterRpc.class);
     private Runtime runtime = null;
 
     public FullSyncMachine(NetworkService networkService,
@@ -154,7 +156,7 @@ public class FullSyncMachine {
 
     private TrieStructure<NodeData> loadStateAtBlockFromPeer(Hash256 lastFinalizedBlockHash) {
         log.info("Loading state at block from peer");
-        Map<ByteString, ByteString> kvps = makeStateRequest(lastFinalizedBlockHash);
+        Map<ByteString, ByteString> kvps = syncStateRequesterRpc.requestState(lastFinalizedBlockHash.toString());
 
         TrieStructure<NodeData> trieStructure = TrieStructureFactory.buildFromKVPs(kvps);
         trieStorage.insertTrieStorage(trieStructure);

--- a/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
+++ b/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.limechain.config.HostConfig;
-import com.limechain.rpc.client.StateSyncRpcClient;
+import com.limechain.rpc.client.SyncStateRpcClient;
 import com.limechain.utils.StringUtils;
 import lombok.extern.java.Log;
 import org.java_websocket.client.WebSocketClient;
@@ -72,7 +72,7 @@ public class SyncStateRequesterRpc {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final BlockingQueue<StateSyncRpcClient> clientPool = new LinkedBlockingQueue<>();
+    private final BlockingQueue<SyncStateRpcClient> clientPool = new LinkedBlockingQueue<>();
     private final Map<WebSocketClient, CompletableFuture<String>> responseMap = new ConcurrentHashMap<>();
     private String wsUrl;
 
@@ -269,7 +269,7 @@ public class SyncStateRequesterRpc {
      */
     private void initializeWebSocketPool() throws Exception {
         for (int i = 0; i < CONNECTION_POOL_SIZE; i++) {
-            StateSyncRpcClient client = new StateSyncRpcClient(new URI(wsUrl), responseMap);
+            SyncStateRpcClient client = new SyncStateRpcClient(new URI(wsUrl), responseMap);
             client.setConnectionLostTimeout(WS_TIMEOUT_SECONDS);
 
             if (!client.connectBlocking(WS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
@@ -332,7 +332,7 @@ public class SyncStateRequesterRpc {
      * Takes a WebSocket client from the pool, sends a request, waits for the response.
      */
     private String sendRequestWithPooledClient(String methodName, String[] args) throws Exception {
-        StateSyncRpcClient client = clientPool.take();
+        SyncStateRpcClient client = clientPool.take();
         CompletableFuture<String> future = new CompletableFuture<>();
         responseMap.put(client, future);
 

--- a/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
+++ b/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
@@ -81,6 +81,7 @@ public class SyncStateRequesterRpc {
                                 MAX_KEY_RETRIES));
 
                         if (retryCount >= MAX_KEY_RETRIES) {
+                            //Todo: In future we may think of requesting state for different block instead of aborting.
                             log.severe("startStateRetrieval: Aborting - too many empty key list responses");
                             System.exit(1);
                         }
@@ -105,6 +106,7 @@ public class SyncStateRequesterRpc {
                             e.getMessage()));
 
                     if (retryCount >= MAX_KEY_RETRIES) {
+                        //Todo: In future we may think of requesting state for different block instead of aborting.
                         log.severe(String.format("startStateRetrieval: Fatal - could not retrieve keys after %d attempts",
                                 MAX_VALUE_RETRIES));
 
@@ -182,6 +184,7 @@ public class SyncStateRequesterRpc {
             }
         }
         if (value == null) {
+            //Todo: In future we may think of requesting state for different block instead of aborting.
             log.severe(String.format("retrieveAndStoreValue: Fatal - could not retrieve value for key %s after %d attempts",
                     key,
                     MAX_VALUE_RETRIES)

--- a/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
+++ b/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
@@ -1,5 +1,6 @@
 package com.limechain.sync.state;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
@@ -23,7 +24,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Component
@@ -37,11 +37,7 @@ public class SyncStateRequesterRpc {
     private static final int MAX_VALUE_RETRIES = 100;
     private static final int WS_TIMEOUT_SECONDS = 30;
     private static final int CONNECTION_POOL_SIZE = 100;
-    private static final long LOG_INTERVAL = 5000;
     private static final ObjectMapper mapper = new ObjectMapper();
-
-    private final AtomicInteger processedKeys = new AtomicInteger(0);
-    private long lastLogTime = System.currentTimeMillis();
 
     private final BlockingQueue<StateSyncRpcClient> clientPool = new LinkedBlockingQueue<>();
     private final Map<WebSocketClient, CompletableFuture<String>> responseMap = new ConcurrentHashMap<>();
@@ -53,97 +49,73 @@ public class SyncStateRequesterRpc {
     }
 
     public Map<ByteString, ByteString> requestState(String blockHash) {
-        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        try {
+            initializeWebSocketPool();
+            log.info("requestState: Starting state retrieval for block: " + blockHash);
+            return startStateRetrieval(blockHash);
+        } catch (Exception e) {
+            log.severe(String.format("requestState: Error in requestState: %s", e.getMessage()));
+            return Collections.emptyMap();
+        } finally {
+            closeAllClients();
+        }
+    }
+
+    public Map<ByteString, ByteString> startStateRetrieval(String blockHash) {
         Map<String, String> stateData = new ConcurrentHashMap<>();
         String lastKey = null;
         int retryCount = 0;
-        int totalKeysProcessed = 0;
-        final AtomicInteger failedKeys = new AtomicInteger(0);
 
         try {
-            initializeWebSocketPool();
-
             List<String> keys;
-            log.info("Starting state retrieval for block: " + blockHash);
+            log.info("startStateRetrieval: Starting state retrieval for block: " + blockHash);
+
             while (true) {
                 try {
                     keys = getKeysPaged(lastKey, blockHash);
-                    totalKeysProcessed += keys.size();
-                    log.info(String.format("Retrieved %d keys in total", totalKeysProcessed));
 
                     if (keys.isEmpty()) {
                         retryCount++;
-                        log.warning(String.format("Received empty key list (attempt %d of %d)", retryCount, MAX_KEY_RETRIES));
+                        log.warning(String.format("startStateRetrieval: Received empty key list (attempt %d of %d)",
+                                retryCount,
+                                MAX_KEY_RETRIES));
+
                         if (retryCount >= MAX_KEY_RETRIES) {
-                            log.severe("Aborting: Too many empty key list responses");
+                            log.severe("startStateRetrieval: Aborting - too many empty key list responses");
                             System.exit(1);
                         }
                         Thread.sleep(1000);
                         continue;
                     }
 
-                    List<CompletableFuture<Void>> futures = new ArrayList<>();
-                    for (String key : keys) {
-                        futures.add(
-                                CompletableFuture.runAsync(() -> {
-                                    int attempts = 0;
-                                    String value = null;
-                                    while (attempts < MAX_VALUE_RETRIES) {
-                                        try {
-                                            value = getStorage(key, blockHash);
-                                            if (value != null) break;
-                                            log.warning(String.format("Attempt %d: Retrieved null for key %s", attempts + 1, key));
-                                        } catch (Exception e) {
-                                            log.warning(String.format("Attempt %d: Error retrieving key %s: %s", attempts + 1, key, e.getMessage()));
-                                        }
-                                        attempts++;
-                                        try {
-                                            Thread.sleep(500);
-                                        } catch (InterruptedException e) {
-                                            Thread.currentThread().interrupt();
-                                            log.severe("Interrupted during retry sleep");
-                                            System.exit(1);
-                                        }
-                                    }
-                                    if (value == null) {
-                                        log.severe(String.format("Fatal: Could not retrieve value for key %s after %d attempts", key, MAX_VALUE_RETRIES));
-                                        System.exit(1);
-                                    }
-                                    stateData.put(key, value);
-                                }, executor)
-                        );
-                    }
-
-                    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-                    processedKeys.addAndGet(keys.size());
-
-                    long now = System.currentTimeMillis();
-                    if (now - lastLogTime >= LOG_INTERVAL) {
-                        log.info(String.format("Progress: %d keys processed, %d valid values, %d failed.",
-                                processedKeys.get(), stateData.size(), failedKeys.get()));
-                        lastLogTime = now;
-                    }
+                    ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+                    processKeysBatch(keys, executor, stateData, blockHash);
 
                     lastKey = keys.getLast();
                     retryCount = 0;
 
                     if (keys.size() < BATCH_SIZE) {
-                        log.info("Finished: Received less than batch size");
+                        log.info("startStateRetrieval: Finished - received less than batch size");
                         break;
                     }
                 } catch (Exception e) {
                     retryCount++;
-                    log.severe(String.format("Error fetching batch (attempt %d): %s", retryCount, e.getMessage()));
+                    log.severe(String.format("startStateRetrieval: Error fetching batch (attempt %d): %s",
+                            retryCount,
+                            e.getMessage()));
+
                     if (retryCount >= MAX_KEY_RETRIES) {
-                        log.severe(String.format("Fatal: Could not retrieve keys after %d attempts", MAX_VALUE_RETRIES));
+                        log.severe(String.format("startStateRetrieval: Fatal - could not retrieve keys after %d attempts",
+                                MAX_VALUE_RETRIES));
+
                         System.exit(1);
                     }
                     Thread.sleep(5000);
                 }
             }
 
-            log.info(String.format("Completed: %d total keys, %d valid values, %d failed",
-                    totalKeysProcessed, stateData.size(), failedKeys.get()));
+            log.info(String.format("startStateRetrieval: Completed - %d total keys and their valid values.",
+                    stateData.size()));
 
             return stateData.entrySet().stream()
                     .filter(entry -> entry.getValue() != null)
@@ -152,7 +124,7 @@ public class SyncStateRequesterRpc {
                             entry -> ByteString.fromHex(StringUtils.remove0xPrefix(entry.getValue()))
                     ));
         } catch (Exception e) {
-            log.severe(String.format("Error in collectState: %s", e.getMessage()));
+            log.severe(String.format("startStateRetrieval: Error in collectState: %s", e.getMessage()));
             return Collections.emptyMap();
         } finally {
             for (WebSocketClient client : clientPool) {
@@ -164,16 +136,80 @@ public class SyncStateRequesterRpc {
         }
     }
 
+    private void processKeysBatch(List<String> keys,
+                                  ExecutorService executor,
+                                  Map<String, String> stateData,
+                                  String blockHash) {
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (String key : keys) {
+            futures.add(
+                    CompletableFuture.runAsync(() -> {
+                        retrieveAndStoreValue(key, blockHash, stateData);
+                    }, executor)
+            );
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    }
+
+    private void retrieveAndStoreValue(String key, String blockHash, Map<String, String> stateData) {
+        int attempts = 0;
+        String value = null;
+
+        while (attempts < MAX_VALUE_RETRIES) {
+            try {
+                value = getStorage(key, blockHash);
+                if (value != null) break;
+
+                log.warning(String.format("retrieveAndStoreValue: Attempt %d - retrieved null for key %s",
+                        attempts + 1,
+                        key));
+
+            } catch (Exception e) {
+                log.warning(String.format("retrieveAndStoreValue: Attempt %d - error retrieving key %s: %s",
+                        attempts + 1,
+                        key, e.getMessage()));
+            }
+            attempts++;
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.severe("retrieveAndStoreValue: Interrupted during retry sleep");
+                System.exit(1);
+            }
+        }
+        if (value == null) {
+            log.severe(String.format("retrieveAndStoreValue: Fatal - could not retrieve value for key %s after %d attempts",
+                    key,
+                    MAX_VALUE_RETRIES)
+            );
+            System.exit(1);
+        }
+        stateData.put(key, value);
+    }
+
     private void initializeWebSocketPool() throws Exception {
         for (int i = 0; i < CONNECTION_POOL_SIZE; i++) {
             StateSyncRpcClient client = new StateSyncRpcClient(new URI(wsUrl), responseMap);
             client.setConnectionLostTimeout(WS_TIMEOUT_SECONDS);
 
             if (!client.connectBlocking(WS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                throw new RuntimeException("Failed to connect WebSocket");
+                throw new RuntimeException("initializeWebSocketPool: Failed to connect WebSocket");
             }
 
             clientPool.add(client);
+        }
+    }
+
+    private void closeAllClients() {
+        for (WebSocketClient client : clientPool) {
+            try {
+                client.close();
+            } catch (Exception ignored) {
+            }
         }
     }
 
@@ -185,8 +221,7 @@ public class SyncStateRequesterRpc {
                         blockHash
                 }
         );
-        JsonNode responseNode = mapper.readTree(response);
-        JsonNode result = responseNode.get("result");
+        JsonNode result = getJsonNode(response);
 
         if (result == null) return Collections.emptyList();
 
@@ -199,10 +234,14 @@ public class SyncStateRequesterRpc {
                         blockHash
                 }
         );
-        JsonNode responseNode = mapper.readTree(response);
-        JsonNode result = responseNode.get("result");
+        JsonNode result = getJsonNode(response);
 
         return result != null && !result.isNull() ? result.asText() : null;
+    }
+
+    private static JsonNode getJsonNode(String response) throws JsonProcessingException {
+        JsonNode responseNode = mapper.readTree(response);
+        return responseNode.get("result");
     }
 
     private String sendRequestWithPooledClient(String methodName, String[] args) throws Exception {

--- a/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
+++ b/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
@@ -26,6 +26,34 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+/**
+ * SyncStateRequesterRpc is a service responsible for retrieving the full blockchain state (key-value pairs)
+ * from a node via RPC WebSocket API.
+ * <p>
+ * It ensures complete retrieval by:
+ * - Paged requests to fetch all keys.
+ * - Individual value requests for each key.
+ * - Retrying multiple times in case of temporary failures.
+ * - Aborting the program if critical failures happen.
+ * <p>
+ * This approach guarantees correctness compared to the protocol-based warp sync, which failed due to missing or malformed key/value data.
+ * <p>
+ * <p>
+ * ------------------
+ * High-Level Workflow:
+ * ------------------
+ * <p>
+ * 1. Initialize a pool of WebSocket clients.
+ * 2. Fetch all state keys using `state_getKeysPaged` in batches.
+ * 3. For each key, retrieve its corresponding value using `state_getStorage`.
+ * 4. Retry failed operations a limited number of times.
+ * 5. If critical errors occur (e.g., persistent missing keys/values), abort the program.
+ * 6. Finally, return the full validated key-value map.
+ * <p>
+ * Threads:
+ * - One thread fetches key batches sequentially.
+ * - A virtual thread pool fetches values for keys in parallel for efficiency.
+ */
 @Component
 @Log
 public class SyncStateRequesterRpc {
@@ -37,6 +65,11 @@ public class SyncStateRequesterRpc {
     private static final int MAX_VALUE_RETRIES = 100;
     private static final int WS_TIMEOUT_SECONDS = 30;
     private static final int CONNECTION_POOL_SIZE = 100;
+    private static final int SLEEP_BETWEEN_RETRIES = 5000;
+    private static final int SLEEP_AFTER_EMPTY_KEYS = 1000;
+    private static final long LOG_INTERVAL = 20000;
+    private long lastLogTime = System.currentTimeMillis();
+
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private final BlockingQueue<StateSyncRpcClient> clientPool = new LinkedBlockingQueue<>();
@@ -48,10 +81,14 @@ public class SyncStateRequesterRpc {
         this.wsUrl = hostConfig.getNodeSynckPath();
     }
 
+    /**
+     * Initializes connections and starts the retrieval process
+     *
+     * @param blockHash is the last finalized block hash for which we want the full state
+     */
     public Map<ByteString, ByteString> requestState(String blockHash) {
         try {
             initializeWebSocketPool();
-            log.info("requestState: Starting state retrieval for block: " + blockHash);
             return startStateRetrieval(blockHash);
         } catch (Exception e) {
             log.severe(String.format("requestState: Error in requestState: %s", e.getMessage()));
@@ -61,7 +98,19 @@ public class SyncStateRequesterRpc {
         }
     }
 
+    /**
+     * Main retrieval loop.
+     * <p>
+     * Repeatedly:
+     * - Fetches the next batch of keys.
+     * - Fetches values for these keys in parallel.
+     * - If we get less than BATCH_SIZE keys, we assume we are done.
+     * <p>
+     * Retry behavior:
+     * - If a batch fetch fails, we retry up to MAX_KEY_RETRIES times before aborting.
+     */
     public Map<ByteString, ByteString> startStateRetrieval(String blockHash) {
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
         Map<String, String> stateData = new ConcurrentHashMap<>();
         String lastKey = null;
         int retryCount = 0;
@@ -85,14 +134,21 @@ public class SyncStateRequesterRpc {
                             log.severe("startStateRetrieval: Aborting - too many empty key list responses");
                             System.exit(1);
                         }
-                        Thread.sleep(1000);
+                        Thread.sleep(SLEEP_AFTER_EMPTY_KEYS);
                         continue;
                     }
 
-                    ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+                    // Process the keys in parallel (each fetches its own value)
                     processKeysBatch(keys, executor, stateData, blockHash);
+                    long now = System.currentTimeMillis();
 
-                    lastKey = keys.getLast();
+                    if (now - lastLogTime >= LOG_INTERVAL) {
+                        log.info(String.format("Progress: %d keys processed with values.",
+                                stateData.size()));
+                        lastLogTime = now;
+                    }
+
+                    lastKey = keys.getLast(); // Use last key from previous batch as start for next
                     retryCount = 0;
 
                     if (keys.size() < BATCH_SIZE) {
@@ -112,13 +168,14 @@ public class SyncStateRequesterRpc {
 
                         System.exit(1);
                     }
-                    Thread.sleep(5000);
+                    Thread.sleep(SLEEP_BETWEEN_RETRIES);
                 }
             }
 
             log.info(String.format("startStateRetrieval: Completed - %d total keys and their valid values.",
                     stateData.size()));
 
+            // Final return: Hex-encoded keys and values wrapped in ByteString
             return stateData.entrySet().stream()
                     .filter(entry -> entry.getValue() != null)
                     .collect(Collectors.toMap(
@@ -128,16 +185,12 @@ public class SyncStateRequesterRpc {
         } catch (Exception e) {
             log.severe(String.format("startStateRetrieval: Error in collectState: %s", e.getMessage()));
             return Collections.emptyMap();
-        } finally {
-            for (WebSocketClient client : clientPool) {
-                try {
-                    client.close();
-                } catch (Exception ignored) {
-                }
-            }
         }
     }
 
+    /**
+     * Takes a batch of keys and retrieves their corresponding values in parallel.
+     */
     private void processKeysBatch(List<String> keys,
                                   ExecutorService executor,
                                   Map<String, String> stateData,
@@ -156,6 +209,12 @@ public class SyncStateRequesterRpc {
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
     }
 
+    /**
+     * Attempts to fetch the value for a given key.
+     * <p>
+     * Retries if null response received or any error occurs.
+     * Aborts program if retrieval fails after MAX_VALUE_RETRIES.
+     */
     private void retrieveAndStoreValue(String key, String blockHash, Map<String, String> stateData) {
         int attempts = 0;
         String value = null;
@@ -176,7 +235,7 @@ public class SyncStateRequesterRpc {
             }
             attempts++;
             try {
-                Thread.sleep(5000);
+                Thread.sleep(SLEEP_BETWEEN_RETRIES);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 log.severe("retrieveAndStoreValue: Interrupted during retry sleep");
@@ -194,6 +253,9 @@ public class SyncStateRequesterRpc {
         stateData.put(key, value);
     }
 
+    /**
+     * Initializes multiple WebSocket clients and adds them to the client pool for reuse.
+     */
     private void initializeWebSocketPool() throws Exception {
         for (int i = 0; i < CONNECTION_POOL_SIZE; i++) {
             StateSyncRpcClient client = new StateSyncRpcClient(new URI(wsUrl), responseMap);
@@ -211,42 +273,53 @@ public class SyncStateRequesterRpc {
         for (WebSocketClient client : clientPool) {
             try {
                 client.close();
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                log.warning("closeAllClients: Failed to close WebSocketClient: " + e.getMessage());
             }
         }
     }
 
+    /**
+     * RPC call to retrieve a batch of keys.
+     */
     private List<String> getKeysPaged(String startKey, String blockHash) throws Exception {
-        String response = sendRequestWithPooledClient(GET_KEYS_PAGED_METHOD_NAME, new String[]{
-                        PREFIX,
-                        String.valueOf(BATCH_SIZE),
-                        startKey,
-                        blockHash
-                }
+        String response = sendRequestWithPooledClient(
+                GET_KEYS_PAGED_METHOD_NAME,
+                new String[]{PREFIX, String.valueOf(BATCH_SIZE), startKey, blockHash}
         );
         JsonNode result = getJsonNode(response);
-
-        if (result == null) return Collections.emptyList();
 
         return mapper.convertValue(result, List.class);
     }
 
+    /**
+     * RPC call to retrieve the value of a single key.
+     */
     private String getStorage(String key, String blockHash) throws Exception {
-        String response = sendRequestWithPooledClient(GET_STORAGE_METHOD_NAME, new String[]{
-                        key,
-                        blockHash
-                }
+        String response = sendRequestWithPooledClient(
+                GET_STORAGE_METHOD_NAME,
+                new String[]{key, blockHash}
         );
         JsonNode result = getJsonNode(response);
 
-        return result != null && !result.isNull() ? result.asText() : null;
+        return result.isNull() ? null : result.asText();
     }
 
-    private static JsonNode getJsonNode(String response) throws JsonProcessingException {
-        JsonNode responseNode = mapper.readTree(response);
-        return responseNode.get("result");
+    /**
+     * Validates and extracts the 'result' part of a JSON-RPC response.
+     * Throws if missing to avoid silent failures.
+     */
+    private JsonNode getJsonNode(String response) throws JsonProcessingException {
+        JsonNode root = mapper.readTree(response);
+        if (root == null || !root.has("result")) {
+            throw new IllegalStateException("Invalid JSON response: missing result field");
+        }
+        return root.get("result");
     }
 
+    /**
+     * Takes a WebSocket client from the pool, sends a request, waits for the response.
+     */
     private String sendRequestWithPooledClient(String methodName, String[] args) throws Exception {
         StateSyncRpcClient client = clientPool.take();
         CompletableFuture<String> future = new CompletableFuture<>();

--- a/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
+++ b/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
@@ -1,0 +1,220 @@
+package com.limechain.sync.state;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+import com.limechain.config.HostConfig;
+import com.limechain.rpc.client.StateSyncRpcClient;
+import com.limechain.utils.StringUtils;
+import lombok.extern.java.Log;
+import org.java_websocket.client.WebSocketClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Component
+@Log
+public class SyncStateRequesterRpc {
+    private static final String PREFIX = "0x";
+    public static final String GET_KEYS_PAGED_METHOD_NAME = "state_getKeysPaged";
+    public static final String GET_STORAGE_METHOD_NAME = "state_getStorage";
+    private static final int BATCH_SIZE = 1000;
+    private static final int MAX_KEY_RETRIES = 100;
+    private static final int MAX_VALUE_RETRIES = 100;
+    private static final int WS_TIMEOUT_SECONDS = 30;
+    private static final int CONNECTION_POOL_SIZE = 100;
+    private static final long LOG_INTERVAL = 5000;
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final AtomicInteger processedKeys = new AtomicInteger(0);
+    private long lastLogTime = System.currentTimeMillis();
+
+    private final BlockingQueue<StateSyncRpcClient> clientPool = new LinkedBlockingQueue<>();
+    private final Map<WebSocketClient, CompletableFuture<String>> responseMap = new ConcurrentHashMap<>();
+    private String wsUrl;
+
+    @Autowired
+    public void setHostConfig(HostConfig hostConfig) {
+        this.wsUrl = hostConfig.getNodeSynckPath();
+    }
+
+    public Map<ByteString, ByteString> requestState(String blockHash) {
+        ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+        Map<String, String> stateData = new ConcurrentHashMap<>();
+        String lastKey = null;
+        int retryCount = 0;
+        int totalKeysProcessed = 0;
+        final AtomicInteger failedKeys = new AtomicInteger(0);
+
+        try {
+            initializeWebSocketPool();
+
+            List<String> keys;
+            log.info("Starting state retrieval for block: " + blockHash);
+            while (true) {
+                try {
+                    keys = getKeysPaged(lastKey, blockHash);
+                    totalKeysProcessed += keys.size();
+                    log.info(String.format("Retrieved %d keys in total", totalKeysProcessed));
+
+                    if (keys.isEmpty()) {
+                        retryCount++;
+                        log.warning(String.format("Received empty key list (attempt %d of %d)", retryCount, MAX_KEY_RETRIES));
+                        if (retryCount >= MAX_KEY_RETRIES) {
+                            log.severe("Aborting: Too many empty key list responses");
+                            System.exit(1);
+                        }
+                        Thread.sleep(1000);
+                        continue;
+                    }
+
+                    List<CompletableFuture<Void>> futures = new ArrayList<>();
+                    for (String key : keys) {
+                        futures.add(
+                                CompletableFuture.runAsync(() -> {
+                                    int attempts = 0;
+                                    String value = null;
+                                    while (attempts < MAX_VALUE_RETRIES) {
+                                        try {
+                                            value = getStorage(key, blockHash);
+                                            if (value != null) break;
+                                            log.warning(String.format("Attempt %d: Retrieved null for key %s", attempts + 1, key));
+                                        } catch (Exception e) {
+                                            log.warning(String.format("Attempt %d: Error retrieving key %s: %s", attempts + 1, key, e.getMessage()));
+                                        }
+                                        attempts++;
+                                        try {
+                                            Thread.sleep(500);
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                            log.severe("Interrupted during retry sleep");
+                                            System.exit(1);
+                                        }
+                                    }
+                                    if (value == null) {
+                                        log.severe(String.format("Fatal: Could not retrieve value for key %s after %d attempts", key, MAX_VALUE_RETRIES));
+                                        System.exit(1);
+                                    }
+                                    stateData.put(key, value);
+                                }, executor)
+                        );
+                    }
+
+                    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+                    processedKeys.addAndGet(keys.size());
+
+                    long now = System.currentTimeMillis();
+                    if (now - lastLogTime >= LOG_INTERVAL) {
+                        log.info(String.format("Progress: %d keys processed, %d valid values, %d failed.",
+                                processedKeys.get(), stateData.size(), failedKeys.get()));
+                        lastLogTime = now;
+                    }
+
+                    lastKey = keys.getLast();
+                    retryCount = 0;
+
+                    if (keys.size() < BATCH_SIZE) {
+                        log.info("Finished: Received less than batch size");
+                        break;
+                    }
+                } catch (Exception e) {
+                    retryCount++;
+                    log.severe(String.format("Error fetching batch (attempt %d): %s", retryCount, e.getMessage()));
+                    if (retryCount >= MAX_KEY_RETRIES) {
+                        log.severe(String.format("Fatal: Could not retrieve keys after %d attempts", MAX_VALUE_RETRIES));
+                        System.exit(1);
+                    }
+                    Thread.sleep(5000);
+                }
+            }
+
+            log.info(String.format("Completed: %d total keys, %d valid values, %d failed",
+                    totalKeysProcessed, stateData.size(), failedKeys.get()));
+
+            return stateData.entrySet().stream()
+                    .filter(entry -> entry.getValue() != null)
+                    .collect(Collectors.toMap(
+                            entry -> ByteString.fromHex(StringUtils.remove0xPrefix(entry.getKey())),
+                            entry -> ByteString.fromHex(StringUtils.remove0xPrefix(entry.getValue()))
+                    ));
+        } catch (Exception e) {
+            log.severe(String.format("Error in collectState: %s", e.getMessage()));
+            return Collections.emptyMap();
+        } finally {
+            for (WebSocketClient client : clientPool) {
+                try {
+                    client.close();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    private void initializeWebSocketPool() throws Exception {
+        for (int i = 0; i < CONNECTION_POOL_SIZE; i++) {
+            StateSyncRpcClient client = new StateSyncRpcClient(new URI(wsUrl), responseMap);
+            client.setConnectionLostTimeout(WS_TIMEOUT_SECONDS);
+
+            if (!client.connectBlocking(WS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Failed to connect WebSocket");
+            }
+
+            clientPool.add(client);
+        }
+    }
+
+    private List<String> getKeysPaged(String startKey, String blockHash) throws Exception {
+        String response = sendRequestWithPooledClient(GET_KEYS_PAGED_METHOD_NAME, new String[]{
+                        PREFIX,
+                        String.valueOf(BATCH_SIZE),
+                        startKey,
+                        blockHash
+                }
+        );
+        JsonNode responseNode = mapper.readTree(response);
+        JsonNode result = responseNode.get("result");
+
+        if (result == null) return Collections.emptyList();
+
+        return mapper.convertValue(result, List.class);
+    }
+
+    private String getStorage(String key, String blockHash) throws Exception {
+        String response = sendRequestWithPooledClient(GET_STORAGE_METHOD_NAME, new String[]{
+                        key,
+                        blockHash
+                }
+        );
+        JsonNode responseNode = mapper.readTree(response);
+        JsonNode result = responseNode.get("result");
+
+        return result != null && !result.isNull() ? result.asText() : null;
+    }
+
+    private String sendRequestWithPooledClient(String methodName, String[] args) throws Exception {
+        StateSyncRpcClient client = clientPool.take();
+        CompletableFuture<String> future = new CompletableFuture<>();
+        responseMap.put(client, future);
+
+        try {
+            client.send(methodName, args);
+            return future.get(WS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } finally {
+            clientPool.put(client);
+        }
+    }
+}

--- a/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
+++ b/src/main/java/com/limechain/sync/state/SyncStateRequesterRpc.java
@@ -160,6 +160,11 @@ public class SyncStateRequesterRpc {
                     log.severe(String.format("startStateRetrieval: Error fetching batch (attempt %d): %s",
                             retryCount,
                             e.getMessage()));
+                    if (e instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                        log.severe("startStateRetrieval: Interrupted during fetching batch, aborting...");
+                        System.exit(1);
+                    }
 
                     if (retryCount >= MAX_KEY_RETRIES) {
                         //Todo: In future we may think of requesting state for different block instead of aborting.
@@ -183,7 +188,13 @@ public class SyncStateRequesterRpc {
                             entry -> ByteString.fromHex(StringUtils.remove0xPrefix(entry.getValue()))
                     ));
         } catch (Exception e) {
-            log.severe(String.format("startStateRetrieval: Error in collectState: %s", e.getMessage()));
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                log.severe("startStateRetrieval: Interrupted during fetching batch, aborting...");
+                System.exit(1);
+            }
+
+            log.severe(String.format("startStateRetrieval: Error in startStateRetrieval: %s", e.getMessage()));
             return Collections.emptyMap();
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,9 @@ genesis.path.polkadot=genesis/polkadot.json
 genesis.path.kusama=genesis/ksmcc3.json
 genesis.path.westend=genesis/westend2.json
 genesis.path.local=genesis/westend-local.json
+sync.state.path.polkadot=wss://polkadot.dotters.network
+sync.state.path.kusama=wss://kusama.dotters.network
+sync.state.path.westend=wss://westend.dotters.network
 
 #logging.level.root=DEBUG
 #logging.level.com.limechain.runtime.hostapi=DEBUG


### PR DESCRIPTION
# Description

### Initial Problem
 After completing warp sync, Fruzhin's build trie structure produced a trie which calculated merkle root (state root) did not match the expected state root of the last finalized block received from the network.

### Research revealed
- Key-value pairs retrieved over protocol were corrupted — missing keys, incorrect values or wrong ordering.
- After manually providing correct key-value pairs (dumped from other node implementations) to Fruzhin's trie construction logic, the reconstructed trie successfully produced the correct state root hash, confirming that the issue was not with the trie algorithm itself, but rather with the data retrieval process.

### Solution - fetch the state via RPC not protocol.
**Initialization**
- A pool of 100 WebSocket connections is created and maintained.
- Virtual threads, using Executors.newVirtualThreadPerTaskExecutor for high concurrency with low overhead. This enables fetching many values from keys in parallel, which results into speeding up the sync process.

**Key Fetching**
- It starts from a null as starting key and requests keys in batches (up to 1000 keys) using state_getKeysPaged RPC. On each follow request starting key is the last retrieved key from last batch.
- The method keeps paging through keys until there are no more keys left.
- If an empty list is returned, program retries up to 100 times to tolerate temporary node issues before aborting.

**Value Fetching:**
- For every key retrieved, the corresponding value is fetched concurrently using the state_getStorage RPC.
- If fetching a value fails or returns null, program retries up to 100 times per key.
- If after 100 attempts the value is still missing, the program aborts - this guarantees that no corrupted or incomplete state continues being used.

## Checklist:
- [x] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.