### PR TITLE
fix: grandpa validator's workflow

### DIFF
--- a/src/main/java/com/limechain/consensus/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/consensus/grandpa/GrandpaService.java
@@ -79,8 +79,7 @@ public class GrandpaService {
 
         GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
 
-        // We can add directly the authorities from the genesis in order to have them as the first authority set
-        // TODO: This may make the authority set changes to fail -> check it
+        // On the genesis we have empty set changes collection, so we should take the authorities from the chain spec
         if (grandpaSetState.getSetChanges().isEmpty()) {
             return Optional.of(grandpaSetState.getAuthoritySet());
         }

--- a/src/main/java/com/limechain/consensus/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/consensus/grandpa/GrandpaService.java
@@ -79,9 +79,12 @@ public class GrandpaService {
 
         GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
 
-        // On the genesis we have empty set changes collection, so we should take the authorities from the chain spec
-        if (grandpaSetState.getSetChanges().isEmpty()) {
-            return Optional.of(grandpaSetState.getAuthoritySet());
+        // In the genesis set we should take the authorities from the chain spec
+        if (BigInteger.ZERO.equals(grandpaSetState.getAuthoritySet().getSetId())) {
+            grandpaSetState.getSetChanges().putIfAbsent(
+                    Pair.with(stateManager.getSyncState().getGenesisBlockHash(), BigInteger.ZERO),
+                    grandpaSetState.getAuthoritySet()
+            );
         }
 
         for (Map.Entry<Pair<Hash256, BigInteger>, GrandpaAuthoritySet> entry :

--- a/src/main/java/com/limechain/consensus/grandpa/GrandpaService.java
+++ b/src/main/java/com/limechain/consensus/grandpa/GrandpaService.java
@@ -10,6 +10,7 @@ import com.limechain.network.protocol.warp.dto.Justification;
 import com.limechain.state.AbstractState;
 import com.limechain.state.StateManager;
 import com.limechain.storage.block.state.BlockState;
+import com.limechain.utils.async.AsyncExecutor;
 import io.emeraldpay.polkaj.types.Hash256;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
@@ -31,14 +32,16 @@ public class GrandpaService {
 
     public void start() {
 
-        try {
-            tryStartFromLastFinalizedBlock();
+        AsyncExecutor.withSingleThread().executeAndForget(() -> {
+            try {
+                tryStartFromLastFinalizedBlock();
 
-            log.info(String.format("start: Grandpa service started with round #%d",
-                    stateManager.getGrandpaSetState().getCurrentGrandpaRound().getRoundNumber()));
-        } catch (RuntimeException e) {
-            log.warning(String.format("start: There was an error when starting grandpa: %s", e.getMessage()));
-        }
+                log.info(String.format("start: Grandpa service started with round #%d",
+                        stateManager.getGrandpaSetState().getCurrentGrandpaRound().getRoundNumber()));
+            } catch (RuntimeException e) {
+                log.warning(String.format("start: There was an error when starting grandpa: %s", e.getMessage()));
+            }
+        });
     }
 
     public void tryStartFromPreviousRound(GrandpaRound prevRound) {
@@ -64,15 +67,23 @@ public class GrandpaService {
         GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
         GrandpaAuthoritySet authoritySet = roundState.getAuthoritySet();
 
-        return new GrandpaRound(roundState,
+        return new GrandpaRound(
+                roundState,
                 grandpaSetState.getThreshold(authoritySet.getAuthorities()),
-                isPrimary(roundState.getRoundNumber(), authoritySet));
+                isPrimary(roundState.getRoundNumber(), authoritySet)
+        );
     }
 
     public Optional<GrandpaAuthoritySet> getAuthoritiesForBlock(BigInteger blockNumber) {
         GrandpaAuthoritySet authorities = null;
 
         GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();
+
+        // We can add directly the authorities from the genesis in order to have them as the first authority set
+        // TODO: This may make the authority set changes to fail -> check it
+        if (grandpaSetState.getSetChanges().isEmpty()) {
+            return Optional.of(grandpaSetState.getAuthoritySet());
+        }
 
         for (Map.Entry<Pair<Hash256, BigInteger>, GrandpaAuthoritySet> entry :
                 grandpaSetState.getSetChanges().entrySet()) {

--- a/src/main/java/com/limechain/consensus/grandpa/GrandpaSetState.java
+++ b/src/main/java/com/limechain/consensus/grandpa/GrandpaSetState.java
@@ -68,7 +68,9 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
 
     @Override
     public void populateDataFromRuntime(Runtime runtime) {
+        this.authoritySet.setSetId(BigInteger.ZERO);
         this.authoritySet.setAuthorities(runtime.getGrandpaApiAuthorities());
+        updateAuthorityStatus();
     }
 
     @Override
@@ -335,6 +337,8 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
     private void loadPersistedState() {
         authoritySet.setSetId(repository.fetchAuthoritiesSetId());
         authoritySet.setAuthorities(Arrays.asList(repository.fetchGrandpaAuthorities(authoritySet)));
+        updateAuthorityStatus();
+
         BigInteger latestRoundNumber = repository.fetchLatestRoundNumber();
         Vote primaryVote = repository.fetchPrimaryVote(authoritySet, latestRoundNumber);
         boolean isPrimaryVoter = repository.fetchIsPrimaryVoter(authoritySet, latestRoundNumber) != null;

--- a/src/main/java/com/limechain/consensus/grandpa/GrandpaSetState.java
+++ b/src/main/java/com/limechain/consensus/grandpa/GrandpaSetState.java
@@ -274,6 +274,11 @@ public class GrandpaSetState extends AbstractState implements ServiceConsensusSt
             return true;
         }
 
+        // Check if there are any pending authority set changes in the fork tree
+        if (authoritySetChangeHandler.getPendingScheduledChanges().getAll().isEmpty()) {
+            return false;
+        }
+
         Optional<PendingChange> scheduledChange = Optional.empty();
         try {
             scheduledChange =

--- a/src/main/java/com/limechain/consensus/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/consensus/grandpa/round/GrandpaRound.java
@@ -478,11 +478,10 @@ public class GrandpaRound {
 
             try {
                 blockState.finalizeBlock(finalizedBlock, createJustification(), authoritySet.getSetId());
+                syncState.finalizeBlock(finalizedBlock);
             } catch (BlockStorageGenericException e) {
                 log.warning("Block cannot be finalized: " + e.getMessage());
             }
-
-            syncState.finalizeBlock(finalizedBlock);
 
             // Persisting round data into the database when a block is finalized
             GrandpaSetState grandpaSetState = stateManager.getGrandpaSetState();

--- a/src/main/java/com/limechain/consensus/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/consensus/grandpa/round/GrandpaRound.java
@@ -213,11 +213,9 @@ public class GrandpaRound {
         if (shouldUpdateGhost) {
             shouldUpdateEstimate = updateGrandpaGhost();
 
-            if (grandpaGhost != null) {
+            if (grandpaGhost != null && stage instanceof PreCommitStage) {
                 ASYNC_EXECUTOR.executeAndForget(() -> {
-                    if (stage instanceof PreCommitStage) {
-                        stage.end(this);
-                    }
+                    stage.end(this);
                 });
             }
         }
@@ -232,6 +230,9 @@ public class GrandpaRound {
 
         if (previous != null) {
             shouldStartNextRound = previous.finalizedBlock != null;
+        } else {
+            // at the genesis -> round number is equal to one
+            shouldStartNextRound = roundNumber.equals(BigInteger.ONE);
         }
 
         shouldStartNextRound = shouldStartNextRound && isCompletable;
@@ -280,7 +281,7 @@ public class GrandpaRound {
      */
     public Vote findBestPreVoteCandidate() {
 
-        BlockHeader choiceHeader = getGrandpaGhost();
+        BlockHeader choiceHeader = getSafeBlockBetweenFinalizedAndBest();
 
         if (primaryVote != null) {
             BigInteger primaryBlockNumber = primaryVote.getBlockNumber();
@@ -296,6 +297,39 @@ public class GrandpaRound {
         preVoteChoice = choiceVote;
 
         return choiceVote;
+    }
+
+    /**
+     * Returns a 'safe block' between the last finalized and best block, based on a 3/4 rounded-up rule:
+     * lastFinalized + ceil(3/4 * (best - lastFinalized)). This helps avoid voting for the tip of the chain.
+     * When the block gap is greater than 3, the tip is deliberately avoided to reduce fork risk.
+     * For gaps of 3 or less, selecting the tip is acceptable to avoid delaying progress.
+     *
+     * @return BlockHeader of the safe block
+     */
+    public BlockHeader getSafeBlockBetweenFinalizedAndBest() {
+
+        BlockState blockState = stateManager.getBlockState();
+        BlockHeader bestBlock = blockState.bestBlockHeader();
+
+        BigInteger finalizedNumber = lastFinalizedBlock.getBlockNumber();
+        BigInteger bestNumber = bestBlock.getBlockNumber();
+
+        BigInteger diff = bestNumber.subtract(finalizedNumber);
+
+        // (x * 3 + 3) / 4 is common round up (ceil) operation when using integer division.
+        BigInteger threeFourths = diff.multiply(BigInteger.valueOf(3))
+                .add(BigInteger.valueOf(3))
+                .divide(BigInteger.valueOf(4));
+
+        BigInteger safeNumber = finalizedNumber.add(threeFourths);
+
+        BlockHeader current = bestBlock;
+        while (current != null && current.getBlockNumber().compareTo(safeNumber) > 0) {
+            current = blockState.getHeader(current.getParentHash());
+        }
+
+        return current;
     }
 
     /**
@@ -442,7 +476,12 @@ public class GrandpaRound {
                 blockHeaders.removeFirst();
             }
 
-            blockState.finalizeBlock(finalizedBlock, createJustification(), authoritySet.getSetId());
+            try {
+                blockState.finalizeBlock(finalizedBlock, createJustification(), authoritySet.getSetId());
+            } catch (BlockStorageGenericException e) {
+                log.warning("Block cannot be finalized: " + e.getMessage());
+            }
+
             syncState.finalizeBlock(finalizedBlock);
 
             // Persisting round data into the database when a block is finalized

--- a/src/main/java/com/limechain/consensus/grandpa/round/GrandpaRound.java
+++ b/src/main/java/com/limechain/consensus/grandpa/round/GrandpaRound.java
@@ -231,8 +231,8 @@ public class GrandpaRound {
         if (previous != null) {
             shouldStartNextRound = previous.finalizedBlock != null;
         } else {
-            // at the genesis -> round number is equal to one
-            shouldStartNextRound = roundNumber.equals(BigInteger.ONE);
+            // If this is the genesis round, allow starting the next round
+            shouldStartNextRound = isGenesisRound();
         }
 
         shouldStartNextRound = shouldStartNextRound && isCompletable;
@@ -480,7 +480,8 @@ public class GrandpaRound {
                 blockState.finalizeBlock(finalizedBlock, createJustification(), authoritySet.getSetId());
                 syncState.finalizeBlock(finalizedBlock);
             } catch (BlockStorageGenericException e) {
-                log.warning("Block cannot be finalized: " + e.getMessage());
+                log.warning(String.format("Block cannot be finalized: %s", e.getMessage()));
+                return;
             }
 
             // Persisting round data into the database when a block is finalized
@@ -942,5 +943,11 @@ public class GrandpaRound {
         if (nextRound != null) {
             nextRound.update(true, false, false);
         }
+    }
+
+    private boolean isGenesisRound() {
+        return previous == null &&
+                BigInteger.ZERO.equals(authoritySet.getSetId()) &&
+                BigInteger.ONE.equals(roundNumber);
     }
 }

--- a/src/main/java/com/limechain/consensus/grandpa/round/PreCommitStage.java
+++ b/src/main/java/com/limechain/consensus/grandpa/round/PreCommitStage.java
@@ -47,8 +47,8 @@ public class PreCommitStage implements StageState {
             Vote grandpaGhost = Vote.fromBlockHeader(round.getGrandpaGhost());
             log.fine(String.format("Round %d ended pre-commit stage.", round.getRoundNumber()));
 
-            round.broadcastVoteMessage(grandpaGhost, SubRound.PRE_COMMIT);
             round.setOnFinalizeHandler(null);
+            round.broadcastVoteMessage(grandpaGhost, SubRound.PRE_COMMIT);
             round.switchStage();
 
         } catch (GrandpaGenericException e) {

--- a/src/main/java/com/limechain/consensus/grandpa/round/PreVoteStage.java
+++ b/src/main/java/com/limechain/consensus/grandpa/round/PreVoteStage.java
@@ -29,12 +29,12 @@ public class PreVoteStage implements StageState {
             }
         });
 
-        log.info(String.format("Round #%d: Start prevote stage", round.getRoundNumber()));
+        log.info(String.format("Round %d Start prevote stage", round.getRoundNumber()));
         long delay = (DURATION * 2) - (System.currentTimeMillis() - round.getStartTime().toEpochMilli());
 
         round.setOnStageTimerHandler(Executors.newScheduledThreadPool(1));
         round.getOnStageTimerHandler().schedule(() -> {
-            log.info(String.format("Round #%d: Time of prevote stage is out", round.getRoundNumber()));
+            log.info(String.format("Round %d Time of prevote stage is out", round.getRoundNumber()));
             end(round);
         }, delay, TimeUnit.MILLISECONDS);
     }

--- a/src/main/java/com/limechain/consensus/grandpa/round/StartStage.java
+++ b/src/main/java/com/limechain/consensus/grandpa/round/StartStage.java
@@ -19,12 +19,15 @@ public class StartStage implements StageState {
         round.getPeerMessageCoordinator().sendNeighborMessageToPeers();
 
         GrandpaRound previous = round.getPrevious();
-        if (round.isPrimaryVoter() && previous != null) {
+        if (round.isPrimaryVoter()) {
             log.fine("We are a primary voter for round " + round.getRoundNumber());
-            round.getPrevious().broadcastCommitMessage();
 
-            if (previous.getBestFinalCandidate().getBlockNumber()
-                    .compareTo(round.getLastFinalizedBlock().getBlockNumber()) > 0) {
+            if (previous != null) {
+                round.getPrevious().broadcastCommitMessage();
+            }
+
+            if (round.getBestFinalCandidate().getBlockNumber()
+                    .compareTo(round.getLastFinalizedBlock().getBlockNumber()) >= 0) {
                 doProposal(round);
             }
         }
@@ -46,10 +49,8 @@ public class StartStage implements StageState {
             return;
         }
 
-        Vote primaryVote = Vote.fromBlockHeader(round.getPrevious().getBestFinalCandidate());
+        Vote primaryVote = Vote.fromBlockHeader(round.getBestFinalCandidate());
         round.setPrimaryVote(primaryVote);
-
-        //TODO onProposal method
         round.broadcastVoteMessage(primaryVote, SubRound.PRIMARY_PROPOSAL);
     }
 }

--- a/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
+++ b/src/main/java/com/limechain/network/protocol/grandpa/GrandpaMessageHandler.java
@@ -139,7 +139,11 @@ public class GrandpaMessageHandler {
                 grandpaRound.getPreCommits().put(authorityPublicKey, receivedSignedVote);
                 grandpaRound.update(false, false, true);
             }
-            case SubRound.PRIMARY_PROPOSAL -> grandpaRound.setPrimaryVote(receivedSignedVote.getVote());
+            case SubRound.PRIMARY_PROPOSAL -> {
+                grandpaRound.setPrimaryVote(receivedSignedVote.getVote());
+                grandpaRound.getPreVotes().put(authorityPublicKey, receivedSignedVote);
+                grandpaRound.update(false, true, false);
+            }
             default -> throw new GrandpaGenericException("Unknown subround: " + subround);
         }
     }

--- a/src/main/java/com/limechain/storage/crypto/KeyStore.java
+++ b/src/main/java/com/limechain/storage/crypto/KeyStore.java
@@ -100,6 +100,6 @@ public class KeyStore {
      * @return The constructed key string.
      */
     private String getKey(KeyType keyType, byte[] key) {
-        return new String(keyType.getBytes()).concat(StringUtils.toHexWithPrefix(key));
+        return new String(keyType.getBytes()).concat(new String(key));
     }
 }

--- a/src/main/java/com/limechain/storage/crypto/KeyStore.java
+++ b/src/main/java/com/limechain/storage/crypto/KeyStore.java
@@ -1,6 +1,7 @@
 package com.limechain.storage.crypto;
 
 import com.limechain.storage.KVRepository;
+import com.limechain.utils.StringUtils;
 import io.emeraldpay.polkaj.schnorrkel.Schnorrkel;
 import lombok.extern.java.Log;
 import org.javatuples.Pair;
@@ -99,6 +100,6 @@ public class KeyStore {
      * @return The constructed key string.
      */
     private String getKey(KeyType keyType, byte[] key) {
-        return new String(keyType.getBytes()).concat(new String(key));
+        return new String(keyType.getBytes()).concat(StringUtils.toHexWithPrefix(key));
     }
 }

--- a/src/main/java/com/limechain/storage/crypto/KeyStore.java
+++ b/src/main/java/com/limechain/storage/crypto/KeyStore.java
@@ -1,7 +1,6 @@
 package com.limechain.storage.crypto;
 
 import com.limechain.storage.KVRepository;
-import com.limechain.utils.StringUtils;
 import io.emeraldpay.polkaj.schnorrkel.Schnorrkel;
 import lombok.extern.java.Log;
 import org.javatuples.Pair;

--- a/src/main/java/com/limechain/storage/forktree/ForkTree.java
+++ b/src/main/java/com/limechain/storage/forktree/ForkTree.java
@@ -128,7 +128,7 @@ public class ForkTree<T> {
     private void validateNumberExceedsFinalizedNumber(BigInteger nodeNumber) throws ForkTreeException {
         if (Objects.nonNull(bestFinalizedNumber) && nodeNumber.compareTo(bestFinalizedNumber) <= 0) {
             throw new ForkTreeException("Cannot import or finalize a node " + nodeNumber +
-                    "that is ancestor of the current finalized block " + bestFinalizedNumber);
+                    " that is ancestor of the current finalized block " + bestFinalizedNumber);
         }
     }
 

--- a/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
+++ b/src/main/java/com/limechain/sync/fullsync/FullSyncMachine.java
@@ -67,6 +67,7 @@ public class FullSyncMachine {
     private final TrieStorage trieStorage = AppBean.getBean(TrieStorage.class);
     private final RuntimeBuilder runtimeBuilder = AppBean.getBean(RuntimeBuilder.class);
     private final SlotCoordinator slotCoordinator = AppBean.getBean(SlotCoordinator.class);
+    private final BabeService babeService = AppBean.getBean(BabeService.class);
     private final GrandpaService grandpaService = AppBean.getBean(GrandpaService.class);
     private final BeefyService beefyService = AppBean.getBean(BeefyService.class);
     private Runtime runtime = null;
@@ -142,9 +143,7 @@ public class FullSyncMachine {
         stateManager.getBeefyState().populateDataFromRuntime(runtime);
 
         if (NodeRole.AUTHORING.equals(hostConfig.getNodeRole())) {
-            slotCoordinator.start(List.of(
-                    AppBean.getBean(BabeService.class)
-            ));
+            slotCoordinator.start(List.of(babeService));
         }
         grandpaService.start();
         beefyService.start();


### PR DESCRIPTION
# Description

This PR refactors the Grandpa validator logic to enable starting a local network from the genesis, ensuring proper processing of grandpa rounds. The changes are backward-compatible and apply seamlessly when acting as a validator on other networks.

Partially fixes: https://github.com/LimeChain/Fruzhin/issues/422

## Checklist:
- [x] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.