### PR TITLE
fix: Handled case when recovering public key from signature removed leading 0.

### DIFF
--- a/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
+++ b/src/main/java/com/limechain/runtime/hostapi/CryptoHostFunctions.java
@@ -41,6 +41,8 @@ import java.util.Set;
 import java.util.logging.Level;
 
 import static com.limechain.runtime.hostapi.PartialHostApi.newImportObjectPair;
+import static com.limechain.utils.EcdsaUtils.PRIVATE_KEY_LEN;
+import static com.limechain.utils.EcdsaUtils.PUBLIC_KEY_COMPRESSED_LEN;
 
 /**
  * Implementations of the Crypto HostAPI functions
@@ -515,7 +517,13 @@ public class CryptoHostFunctions implements PartialHostApi {
             keyPair = EcdsaUtils.generateKeyPair();
         }
 
-        keyStore.put(pair.getKeyType(), keyPair.getSecond().raw(), keyPair.getFirst().raw());
+        byte[] publicKey = keyPair.getSecond().raw();
+        byte[] privateKey = keyPair.getFirst().raw();
+
+        publicKey = EcdsaUtils.normalizeKeyLength(publicKey, PUBLIC_KEY_COMPRESSED_LEN);
+        privateKey = EcdsaUtils.normalizeKeyLength(privateKey, PRIVATE_KEY_LEN);
+
+        keyStore.put(pair.getKeyType(), publicKey, privateKey);
         return sharedMemory.writeData(keyPair.getSecond().raw()).pointer();
     }
 

--- a/src/main/java/com/limechain/utils/EcdsaUtils.java
+++ b/src/main/java/com/limechain/utils/EcdsaUtils.java
@@ -46,7 +46,8 @@ public class EcdsaUtils {
         byte[] seed = MnemonicUtils.generateSeed(mnemonic, "");
         Bip32ECKeyPair keyPair = Bip32ECKeyPair.generateKeyPair(seed);
 
-        PrivKey privKey = Secp256k1Kt.unmarshalSecp256k1PrivateKey(keyPair.getPrivateKey().toByteArray());
+        byte[] normalizedPrivateKey = normalizeKeyLength(keyPair.getPrivateKey().toByteArray(), PRIVATE_KEY_LEN);
+        PrivKey privKey = Secp256k1Kt.unmarshalSecp256k1PrivateKey(normalizedPrivateKey);
         PubKey pubKey = privKey.publicKey();
 
         return new Pair<>(privKey, pubKey);

--- a/src/main/java/com/limechain/utils/EcdsaUtils.java
+++ b/src/main/java/com/limechain/utils/EcdsaUtils.java
@@ -24,6 +24,7 @@ public class EcdsaUtils {
     public static final int PUBLIC_KEY_TRIM_LEN = 64;
     public static final int PUBLIC_KEY_COMPRESSED_LEN = 33;
     public static final int HASHED_MESSAGE_LEN = 32;
+    public static final int PRIVATE_KEY_LEN = 32;
 
     /**
      * Generates Secp256k1 key pair using the Secp256k1 library from libp2p
@@ -108,24 +109,53 @@ public class EcdsaUtils {
                 new ECDSASignature(new BigInteger(1, r), new BigInteger(1, s));
 
         byte[] fullPubKey = Sign.recoverFromSignature(recId, sig, messageData).toByteArray();
-
-        // If the recovered public key length is less than 64 bytes, it means one or more leading 0x00 bytes
-        // were stripped during BigInteger.toByteArray(), which minimizes size by dropping unnecessary leading zeros.
-        if (fullPubKey.length < PUBLIC_KEY_TRIM_LEN) {
-            byte[] paddedKey = new byte[PUBLIC_KEY_TRIM_LEN];
-            int destPos = PUBLIC_KEY_TRIM_LEN - fullPubKey.length;
-            System.arraycopy(fullPubKey, 0, paddedKey, destPos, fullPubKey.length);
-            fullPubKey = paddedKey;
-        }
+        fullPubKey = normalizeKeyLength(fullPubKey, PUBLIC_KEY_TRIM_LEN);
 
         if (compressed) {
             return compressPublicKey(fullPubKey);
         } else {
-            if (fullPubKey.length == PUBLIC_KEY_PURE_LEN) {
-                return Arrays.copyOfRange(fullPubKey, 1, fullPubKey.length);
-            }
             return fullPubKey;
         }
+    }
+
+    /**
+     * Normalizes a byte array to a fixed length.
+     * <p>
+     * If the input is longer, it means leading bytes are stripped.
+     * If shorter, it is left-padded with 0x00, toByteArray() minimizes size by dropping unnecessary leading zeros
+     *
+     * @param key            The input byte array.
+     * @param expectedLength The desired fixed length.
+     * @return A new byte array of exactly {@code expectedLength} bytes.
+     */
+    public static byte[] normalizeKeyLength(byte[] key, int expectedLength) {
+        if (key.length == expectedLength) {
+            return key;
+        }
+
+        byte[] normalized = new byte[expectedLength];
+
+        if (key.length > expectedLength) {
+            // Strip leading bytes (e.g. BigInteger sign byte)
+            System.arraycopy(
+                    key,
+                    key.length - expectedLength,
+                    normalized,
+                    0,
+                    expectedLength
+            );
+        } else {
+            // Pad with leading zeros
+            System.arraycopy(
+                    key,
+                    0,
+                    normalized,
+                    expectedLength - key.length,
+                    key.length
+            );
+        }
+
+        return normalized;
     }
 
     /**
@@ -136,12 +166,7 @@ public class EcdsaUtils {
      * @return 33 bytes Secp256k1 public key
      */
     private static byte[] compressPublicKey(byte[] publicKey) {
-        byte[] key = new byte[PUBLIC_KEY_PURE_LEN];
-        if (publicKey.length == PUBLIC_KEY_TRIM_LEN) {
-            System.arraycopy(publicKey, 0, key, 1, 64);
-        } else {
-            key = publicKey;
-        }
+        byte[] key = normalizeKeyLength(publicKey, PUBLIC_KEY_PURE_LEN);
         key[0] = 4;
         ECPoint point = Sign.CURVE_PARAMS.getCurve().decodePoint(key);
 

--- a/src/main/java/com/limechain/utils/EcdsaUtils.java
+++ b/src/main/java/com/limechain/utils/EcdsaUtils.java
@@ -22,11 +22,13 @@ public class EcdsaUtils {
     public static final int SIGNATURE_LEN = 65;
     public static final int PUBLIC_KEY_PURE_LEN = 65;
     public static final int PUBLIC_KEY_TRIM_LEN = 64;
+    public static final int PUBLIC_KEY_MISSING_LEADING_ZERO_LENGTH = 63;
     public static final int PUBLIC_KEY_COMPRESSED_LEN = 33;
     public static final int HASHED_MESSAGE_LEN = 32;
 
     /**
      * Generates Secp256k1 key pair using the Secp256k1 library from libp2p
+     *
      * @return Secp256k1 Private key (32 bytes) and Public key (33 or 65 bytes)
      */
     public static Pair<PrivKey, PubKey> generateKeyPair() {
@@ -36,6 +38,7 @@ public class EcdsaUtils {
     /**
      * Generates Secp256k1 key pair from mnemonic phrase using the Bip32ECKeyPair library from web3j and then
      * converting it to Secp256k1 key pair using the Secp256k1 library from libp2p to get the KeyPair
+     *
      * @param mnemonic BIP-39 12 or 24 word mnemonic phrase
      * @return Secp256k1 Private key (32 bytes) and Public key (33 or 65 bytes)
      */
@@ -52,8 +55,9 @@ public class EcdsaUtils {
     /**
      * Signs message with Secp256k1 private key using the Bip32ECKeyPair library from web3j and splitting the signature
      * data to R S and V
+     *
      * @param privateKey 32 bytes Secp256k1 private key
-     * @param message message to be signed
+     * @param message    message to be signed
      * @return 65 bytes Secp256k1 signature {R (32 bytes), S (32 bytes), V (1 byte)}
      */
     public static byte[] signMessage(final byte[] privateKey, final byte[] message) {
@@ -73,6 +77,7 @@ public class EcdsaUtils {
     /**
      * Verifies Secp256k1 signature using the Bip32ECKeyPair library from web3j to recover public key from signature
      * and then comparing it to the public key from the verify signature object
+     *
      * @param sig signature to be verified
      * @return true if the signature is valid, false otherwise
      */
@@ -85,9 +90,10 @@ public class EcdsaUtils {
 
     /**
      * Recovers public key from signature
+     *
      * @param signatureData 65 bytes Secp256k1 signature {R (32 bytes), S (32 bytes), V (1 byte)}
-     * @param messageData signed message
-     * @param compressed true if the public key should be compressed, false otherwise
+     * @param messageData   signed message
+     * @param compressed    true if the public key should be compressed, false otherwise
      * @return 33 or 65 bytes Secp256k1 public key
      */
     public static byte[] recoverPublicKeyFromSignature(byte[] signatureData, byte[] messageData, boolean compressed) {
@@ -104,10 +110,18 @@ public class EcdsaUtils {
 
         byte[] fullPubKey = Sign.recoverFromSignature(recId, sig, messageData).toByteArray();
 
+        // If the recovered public key is only 63 bytes, it means a leading 0x00 byte was omitted
+        // when BigInteger was serialized via toByteArray(), which minimizes size by dropping unnecessary leading zeros.
+        if (fullPubKey.length == PUBLIC_KEY_MISSING_LEADING_ZERO_LENGTH) {
+            byte[] paddedKey = new byte[PUBLIC_KEY_TRIM_LEN];
+            System.arraycopy(fullPubKey, 0, paddedKey, 1, fullPubKey.length);
+            fullPubKey = paddedKey;
+        }
+
         if (compressed) {
             return compressPublicKey(fullPubKey);
         } else {
-            if(fullPubKey.length == PUBLIC_KEY_PURE_LEN){
+            if (fullPubKey.length == PUBLIC_KEY_PURE_LEN) {
                 return Arrays.copyOfRange(fullPubKey, 1, fullPubKey.length);
             }
             return fullPubKey;
@@ -116,6 +130,7 @@ public class EcdsaUtils {
 
     /**
      * Compresses public key
+     *
      * @param publicKey 64 or 65 bytes Secp256k1 public key (web3j generates 64 public key because it is always 4 and
      *                  not needed, but Secp256k1 requires 65 bytes public key to be able to compress it)
      * @return 33 bytes Secp256k1 public key

--- a/src/main/java/com/limechain/utils/EcdsaUtils.java
+++ b/src/main/java/com/limechain/utils/EcdsaUtils.java
@@ -22,7 +22,6 @@ public class EcdsaUtils {
     public static final int SIGNATURE_LEN = 65;
     public static final int PUBLIC_KEY_PURE_LEN = 65;
     public static final int PUBLIC_KEY_TRIM_LEN = 64;
-    public static final int PUBLIC_KEY_MISSING_LEADING_ZERO_LENGTH = 63;
     public static final int PUBLIC_KEY_COMPRESSED_LEN = 33;
     public static final int HASHED_MESSAGE_LEN = 32;
 
@@ -110,11 +109,12 @@ public class EcdsaUtils {
 
         byte[] fullPubKey = Sign.recoverFromSignature(recId, sig, messageData).toByteArray();
 
-        // If the recovered public key is only 63 bytes, it means a leading 0x00 byte was omitted
-        // when BigInteger was serialized via toByteArray(), which minimizes size by dropping unnecessary leading zeros.
-        if (fullPubKey.length == PUBLIC_KEY_MISSING_LEADING_ZERO_LENGTH) {
+        // If the recovered public key length is less than 64 bytes, it means one or more leading 0x00 bytes
+        // were stripped during BigInteger.toByteArray(), which minimizes size by dropping unnecessary leading zeros.
+        if (fullPubKey.length < PUBLIC_KEY_TRIM_LEN) {
             byte[] paddedKey = new byte[PUBLIC_KEY_TRIM_LEN];
-            System.arraycopy(fullPubKey, 0, paddedKey, 1, fullPubKey.length);
+            int destPos = PUBLIC_KEY_TRIM_LEN - fullPubKey.length;
+            System.arraycopy(fullPubKey, 0, paddedKey, destPos, fullPubKey.length);
             fullPubKey = paddedKey;
         }
 

--- a/src/main/java/com/limechain/utils/EcdsaUtils.java
+++ b/src/main/java/com/limechain/utils/EcdsaUtils.java
@@ -136,7 +136,7 @@ public class EcdsaUtils {
         byte[] normalized = new byte[expectedLength];
 
         if (key.length > expectedLength) {
-            // Strip leading bytes (e.g. BigInteger sign byte)
+            // Strip leading bytes
             System.arraycopy(
                     key,
                     key.length - expectedLength,


### PR DESCRIPTION
# Description

This PR improves the handling of recovered public keys by correctly interpreting the behavior of BigInteger serialization with toByteArray(), based on the state of the second byte after construction.

First byte is not part of the public key, so it is always trimmed.

1. If the second byte after BigInteger creation is positive:
  - No extra leading 0 byte is needed during serialization.
  - Resulting byte array length = 64.
2. If the second byte after BigInteger creation is negative:
  - A leading 0 byte is appended during serialization to enforce positive two's complement encoding.
  - Resulting byte array length = 65.
3. If the first non-zero byte after leading 0 byte is positive:
  - All leading 0x00 bytes are stripped after toByteArray().
  - The resulting byte array length will be shorter than 64 bytes, depending on how many leading zeros were removed.
  
  
###   P.S.

An additional issue was identified in the EcdsaUtils.generateKeyPair(...) method.
The root cause is the same as described above. 
- The returned private key must be exactly 32 bytes
- The returned public key must be exactly 33 bytes (compressed format).

However, due to missing normalization, there were cases where the keys were either too short (with trimmed 0x00 bytes) or too long (with added 0x00 byte). 
  
Fixes #899 >

## Checklist:
- [x] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [x] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.